### PR TITLE
Retira SessionAuthentication

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -313,7 +313,7 @@ STATICFILES_FINDERS += ["compressor.finders.CompressorFinder"]
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_jwt.authentication.JSONWebTokenAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
+        #"rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
     ),
     # "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),


### PR DESCRIPTION
Esse PR contém:

- Retira SessionAuthentication

O objetivo é parar com o seguinte erro: {"detail":"CSRF Failed: CSRF token missing or incorrect."}

link para ideia da solução: https://stackoverflow.com/questions/39315443/using-django-with-postman-detailcsrf-failed-csrf-token-missing-or-incorrec/52347668
