### PR TITLE
fix(api): Corrige efeito de cache devido ao get_querysets de views da api

### DIFF
--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -25,9 +25,6 @@ class DespesasViewSet(mixins.CreateModelMixin,
     queryset = Despesa.objects.all()
     serializer_class = DespesaSerializer
 
-    def get_queryset(self):
-        return self.queryset
-
     def get_serializer_class(self):
         if self.action in ['retrieve', 'list']:
             return DespesaSerializer

--- a/sme_ptrf_apps/despesas/api/views/especificacoes_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/especificacoes_viewset.py
@@ -17,8 +17,5 @@ class EspecificacaoMaterialServicoViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ('uuid', 'id', 'descricao')
     filter_fields = ('aplicacao_recurso', 'tipo_custeio')
 
-    def get_queryset(self):
-        return self.queryset
-
     def get_serializer_class(self):
         return EspecificacaoMaterialServicoLookUpSerializer

--- a/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
@@ -24,8 +24,5 @@ class RateiosDespesasViewSet(viewsets.ReadOnlyModelViewSet):
 
     # pagination_class = StandardResultsSetPagination
 
-    # def get_queryset(self):
-    #     return self.queryset
-
     def get_serializer_class(self):
         return RateioDespesaListaSerializer


### PR DESCRIPTION
Removido o get_querysets de views que retornavam o queryset sem
modificação.

Isso provocava um efeito de cache nos resultados da API.