### PR TITLE
fix(despesas): Corrige calculo status rateios tipo capital

### DIFF
--- a/sme_ptrf_apps/despesas/models/rateio_despesa.py
+++ b/sme_ptrf_apps/despesas/models/rateio_despesa.py
@@ -54,9 +54,11 @@ class RateioDespesa(ModeloBase):
         completo = self.conta_associacao and \
                    self.acao_associacao and \
                    self.aplicacao_recurso and \
-                   self.tipo_custeio and \
                    self.especificacao_material_servico and \
                    self.valor_rateio
+
+        if self.aplicacao_recurso == APLICACAO_CUSTEIO:
+            completo = completo and self.tipo_custeio
 
         if self.aplicacao_recurso == APLICACAO_CAPITAL:
             completo = completo and \

--- a/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_calculo_status.py
+++ b/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_calculo_status.py
@@ -42,6 +42,25 @@ def rateio_despesa_custeio_incompleto(associacao, despesa, conta_associacao, aca
 
 
 @pytest.fixture
+def rateio_despesa_capital_completo(associacao, despesa, conta_associacao, acao, tipo_aplicacao_recurso_capital,
+                                    especificacao_material_servico, acao_associacao):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso_capital,
+        tipo_custeio=None,
+        especificacao_material_servico=especificacao_material_servico,
+        valor_rateio=10.00,  # Falta o valor
+        quantidade_itens_capital=1,
+        valor_item_capital=10.00,
+        numero_processo_incorporacao_capital='teste123456'
+    )
+
+
+@pytest.fixture
 def rateio_despesa_capital_incompleto(associacao, despesa, conta_associacao, acao, tipo_aplicacao_recurso_capital,
                                       especificacao_material_servico, acao_associacao):
     return baker.make(
@@ -53,9 +72,10 @@ def rateio_despesa_capital_incompleto(associacao, despesa, conta_associacao, aca
         aplicacao_recurso=tipo_aplicacao_recurso_capital,
         tipo_custeio=None,
         especificacao_material_servico=especificacao_material_servico,
-        valor_rateio=10.00,  # Falta o valor
-        # Faltam os campos especificos para Capital
-
+        valor_rateio=0.00,
+        quantidade_itens_capital=0,
+        valor_item_capital=0,
+        numero_processo_incorporacao_capital=''
     )
 
 
@@ -98,3 +118,9 @@ def test_rateio_despesa_capital_incompleto(rateio_despesa_capital_incompleto):
     assert rateio_despesa_capital_incompleto.status == STATUS_INCOMPLETO
     despesa = Despesa.objects.get(uuid=rateio_despesa_capital_incompleto.despesa.uuid)
     assert despesa.status == STATUS_INCOMPLETO
+
+
+def test_rateio_despesa_capital_completo(rateio_despesa_capital_completo):
+    assert rateio_despesa_capital_completo.status == STATUS_COMPLETO
+    despesa = Despesa.objects.get(uuid=rateio_despesa_capital_completo.despesa.uuid)
+    assert despesa.status == STATUS_COMPLETO


### PR DESCRIPTION
Esse PR:
- Corrige o calculo do status dos rateios de despesa do tipo Capital.

O  método que calcula o status dos rateios de despesa do tipo capital estavam considerando
obrigatória a existência do campo tipo de custeio.