### PR TITLE
fix(15450): Erro 500 ao consultar um período não cadastrado

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -61,12 +61,18 @@ class AssociacoesViewSet(mixins.RetrieveModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         periodo = Periodo.da_data(data)
-        periodo_status = status_periodo_associacao(periodo_uuid=periodo.uuid, associacao_uuid=uuid)
-        aceita_alteracoes = status_aceita_alteracoes_em_transacoes(periodo_status)
+        if periodo:
+            periodo_referencia = periodo.referencia
+            periodo_status = status_periodo_associacao(periodo_uuid=periodo.uuid, associacao_uuid=uuid)
+            aceita_alteracoes = status_aceita_alteracoes_em_transacoes(periodo_status)
+        else:
+            periodo_referencia = ''
+            periodo_status = 'PERIODO_NAO_ENCONTRADO'
+            aceita_alteracoes = True
 
         result = {
             'associacao': f'{uuid}',
-            'periodo_referencia': periodo.referencia,
+            'periodo_referencia': periodo_referencia,
             'periodo_status': periodo_status,
             'aceita_alteracoes': aceita_alteracoes,
         }

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -61,3 +61,34 @@ def test_status_periodo_conciliado(client, associacao, periodo_2020_1, prestacao
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
+
+
+def test_chamada_sem_passar_data(client, associacao, periodo_2020_1, prestacao_conta_2020_1_conciliada):
+    response = client.get(f'/api/associacoes/{associacao.uuid}/status-periodo/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = {
+                'erro': 'parametros_requerido',
+                'mensagem': 'É necessário enviar a data que você quer consultar o status.'
+            }
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == esperado
+
+
+def test_chamada_data_sem_periodo(client, associacao, periodo_2020_1):
+    response = client.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2000-01-10',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = {
+        'associacao': f'{associacao.uuid}',
+        'periodo_referencia': '',
+        'periodo_status': 'PERIODO_NAO_ENCONTRADO',
+        'aceita_alteracoes': True,
+
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado


### PR DESCRIPTION
Esse PR:
- Corrige erro 500 quando se consultava uma data que não correspondia a nenhum período cadastrado.

Agora nesses casos a API retornará uma mensagem dizendo que o
período não foi encontrado.