### PR TITLE
fix(15110): Revisar prestacao não apagava os fechamentos

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -356,6 +356,26 @@ def prestacao_conta_2020_1_conciliada(periodo_2020_1, associacao, conta_associac
         motivo_reabertura=''
     )
 
+@pytest.fixture
+def fechamento_2020_1(periodo_2020_1, associacao, conta_associacao, acao_associacao, prestacao_conta_2020_1_conciliada):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=None,
+        total_receitas_capital=1000,
+        total_repasses_capital=900,
+        total_despesas_capital=800,
+        total_receitas_custeio=2000,
+        total_repasses_custeio=1800,
+        total_despesas_custeio=1600,
+        status=STATUS_FECHADO,
+        prestacao_conta=prestacao_conta_2020_1_conciliada
+    )
+
+
 
 @pytest.fixture
 def fechamento_periodo_com_saldo(periodo, associacao, conta_associacao, acao_associacao, ):

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -8,7 +8,8 @@ from rest_framework.viewsets import GenericViewSet
 
 from ..serializers.prestacao_conta_serializer import PrestacaoContaLookUpSerializer
 from ...models import PrestacaoConta, AcaoAssociacao
-from ...services import iniciar_prestacao_de_contas, concluir_prestacao_de_contas, salvar_prestacao_de_contas
+from ...services import (iniciar_prestacao_de_contas, concluir_prestacao_de_contas, salvar_prestacao_de_contas,
+                         revisar_prestacao_de_contas)
 from ....despesas.api.serializers.rateio_despesa_serializer import RateioDespesaListaSerializer
 from ....despesas.models import RateioDespesa
 from ....receitas.api.serializers.receita_serializer import ReceitaListaSerializer
@@ -66,7 +67,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             }
             return Response(result_error, status=status.HTTP_400_BAD_REQUEST)
 
-        prestacao_de_conta_revista = PrestacaoConta.revisar(uuid=uuid, motivo=motivo)
+        prestacao_de_conta_revista = revisar_prestacao_de_contas(prestacao_contas_uuid=uuid, motivo=motivo)
         return Response(PrestacaoContaLookUpSerializer(prestacao_de_conta_revista, many=False).data,
                         status=status.HTTP_200_OK)
 

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -59,6 +59,10 @@ class PrestacaoConta(ModeloBase):
             associacao=conta_associacao.associacao,
         )
 
+    def apaga_fechamentos(self):
+        for fechamento in self.fechamentos_da_prestacao.all():
+            fechamento.delete()
+
     @classmethod
     def revisar(cls, uuid, motivo):
         prestacao_de_conta = cls.by_uuid(uuid=uuid)
@@ -66,6 +70,7 @@ class PrestacaoConta(ModeloBase):
         prestacao_de_conta.conciliado_em = None
         prestacao_de_conta.conciliado = False
         prestacao_de_conta.save()
+        prestacao_de_conta.apaga_fechamentos()
         return prestacao_de_conta
 
     @classmethod

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -3,5 +3,5 @@ from .info_por_acao_services import (info_acao_associacao_no_periodo, info_acoes
 from .periodo_associacao_services import status_periodo_associacao, status_aceita_alteracoes_em_transacoes
 from .prestacao_contas_services import concluir_prestacao_de_contas
 from .prestacao_contas_services import iniciar_prestacao_de_contas
+from .prestacao_contas_services import revisar_prestacao_de_contas
 from .prestacao_contas_services import salvar_prestacao_de_contas
-

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -35,3 +35,10 @@ def concluir_prestacao_de_contas(prestacao_contas_uuid, observacoes):
 
 def salvar_prestacao_de_contas(prestacao_contas_uuid, observacoes):
     return PrestacaoConta.salvar(uuid=prestacao_contas_uuid, observacoes=observacoes)
+
+
+def revisar_prestacao_de_contas(prestacao_contas_uuid, motivo):
+
+    prestacao = PrestacaoConta.revisar(uuid=prestacao_contas_uuid, motivo=motivo)
+
+    return prestacao

--- a/sme_ptrf_apps/core/tests/tests_services/test_revisar_prestacao_de_contas_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/test_revisar_prestacao_de_contas_service.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ...models.prestacao_conta import STATUS_ABERTO
+from ...services import revisar_prestacao_de_contas
+
+pytestmark = pytest.mark.django_db
+
+
+def test_prestacao_de_contas_deve_ser_atualizada(prestacao_conta_2020_1_conciliada):
+    motivo = "Teste"
+    prestacao = revisar_prestacao_de_contas(prestacao_contas_uuid=prestacao_conta_2020_1_conciliada.uuid, motivo=motivo)
+
+    assert prestacao.status == STATUS_ABERTO, "O status deveria ser aberto."
+    assert not prestacao.conciliado, "Deveria ter passado para não conciliado."
+    assert prestacao.conciliado_em is None, "Deveria ter apagado a data e hora da última conciliação."
+
+
+def test_fechamentos_devem_ser_apagados(prestacao_conta_2020_1_conciliada, fechamento_2020_1):
+    motivo = "Teste"
+    prestacao = revisar_prestacao_de_contas(prestacao_contas_uuid=prestacao_conta_2020_1_conciliada.uuid, motivo=motivo)
+
+    assert prestacao.fechamentos_da_prestacao.count() == 0, "Os fechamentos da prestação deveriam ter sido apagados."


### PR DESCRIPTION
Ao revisar uma prestação os fechamentos não eram apagados e com nova conclusão da prestação eles eram duplicados.

Agora os fechamentos de uma prestação são apagados quando ela é revisada.