### PR TITLE
Feature/19332 livre aplicacao painel acoes ajustes

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -427,6 +427,24 @@ def fechamento_periodo_anterior(periodo_anterior, associacao, conta_associacao, 
 
 
 @pytest.fixture
+def fechamento_periodo_anterior_capital_1000_livre_2000(periodo_anterior, associacao, conta_associacao,
+                                                        acao_associacao, ):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_anterior,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=None,
+        total_receitas_capital=1000,
+        total_repasses_capital=1000,
+        total_receitas_livre=2000,
+        total_repasses_livre=2000,
+        status=STATUS_IMPLANTACAO
+    )
+
+
+@pytest.fixture
 def prestacao_conta_2020_1_conciliada(periodo_2020_1, associacao, conta_associacao):
     return baker.make(
         'PrestacaoConta',
@@ -707,6 +725,7 @@ def receita_100_no_periodo(associacao, conta_associacao, acao_associacao, tipo_r
         tipo_receita=tipo_receita,
     )
 
+
 @pytest.fixture
 def receita_1000_no_periodo_livre_aplicacao(associacao, conta_associacao, acao_associacao, tipo_receita, periodo):
     return baker.make(
@@ -720,6 +739,19 @@ def receita_1000_no_periodo_livre_aplicacao(associacao, conta_associacao, acao_a
         categoria_receita='LIVRE'
     )
 
+
+@pytest.fixture
+def receita_100_no_periodo_capital(associacao, conta_associacao, acao_associacao, tipo_receita, periodo):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=periodo.data_inicio_realizacao_despesas + timedelta(days=3),
+        valor=100.00,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        tipo_receita=tipo_receita,
+        categoria_receita='CAPITAL'
+    )
 
 
 @pytest.fixture
@@ -962,6 +994,29 @@ def rateio_no_periodo_200_capital(associacao, despesa_no_periodo, conta_associac
         valor_rateio=200.00,
         quantidade_itens_capital=1,
         valor_item_capital=200.00,
+        numero_processo_incorporacao_capital='Teste123456'
+
+    )
+
+
+# rateio_200_capital
+@pytest.fixture
+def rateio_no_periodo_1500_capital(associacao, despesa_no_periodo, conta_associacao, acao,
+                                   tipo_aplicacao_recurso_capital,
+                                   tipo_custeio,
+                                   especificacao_ar_condicionado, acao_associacao):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_no_periodo,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso_capital,
+        tipo_custeio=None,
+        especificacao_material_servico=especificacao_ar_condicionado,
+        valor_rateio=1500.00,
+        quantidade_itens_capital=1,
+        valor_item_capital=1500.00,
         numero_processo_incorporacao_capital='Teste123456'
 
     )

--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -235,6 +235,16 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
         info = sumariza_despesas_do_periodo_e_acao(periodo=periodo, acao_associacao=acao_associacao, info=info,
                                                    conta=conta)
 
+        if info['saldo_atual_custeio'] < 0:
+            logger.debug(f'Usado saldo de livre aplicação para cobertura de custeio')
+            info['saldo_atual_livre'] += info['saldo_atual_custeio']
+            info['saldo_atual_custeio'] = 0
+
+        if info['saldo_atual_capital'] < 0:
+            logger.debug(f'Usado saldo de livre aplicação para cobertura de capital')
+            info['saldo_atual_livre'] += info['saldo_atual_capital']
+            info['saldo_atual_capital'] = 0
+
         return info
 
     fechamentos_periodo = FechamentoPeriodo.fechamentos_da_acao_no_periodo(acao_associacao=acao_associacao,

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
@@ -63,8 +63,8 @@ def test_action_painel_acoes(
                 'despesas_no_periodo_custeio': 100.0,
 
                 'saldo_atual_custeio': 300.0,
-                'saldo_atual_capital': -200.0,
-                'saldo_atual_livre': 0,
+                'saldo_atual_capital': 0.0,
+                'saldo_atual_livre': -200,
                 'saldo_atual_total': 100.0,
 
                 'despesas_nao_conciliadas': 300.0,

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
@@ -128,9 +128,9 @@ def test_action_painel_acoes_por_periodo(
                 'saldo_reprogramado_custeio': 0,
                 'saldo_reprogramado_livre': 0,
 
-                'receitas_no_periodo': 1500.0,
+                'receitas_no_periodo': 3500.0,
 
-                'repasses_no_periodo': 1350.0,
+                'repasses_no_periodo': 3350.0,
                 'repasses_no_periodo_capital': 450.0,
                 'repasses_no_periodo_custeio': 900.0,
                 'repasses_no_periodo_livre': 2000,

--- a/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_acao_associacao_no_periodo_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_acao_associacao_no_periodo_service.py
@@ -133,14 +133,14 @@ def test_resultado_periodo_aberto_com_despesas_sem_receitas(
         'receitas_no_periodo_capital': 0,
         'repasses_no_periodo_capital': 0,
         'despesas_no_periodo_capital': 200,
-        'saldo_atual_capital': -100,
+        'saldo_atual_capital': -0,
         'despesas_nao_conciliadas_capital': 200.0,
         'receitas_nao_conciliadas_capital': 0.0,
 
         'saldo_anterior_livre': 2000,
         'receitas_no_periodo_livre': 0,
         'repasses_no_periodo_livre': 0,
-        'saldo_atual_livre': 2000,
+        'saldo_atual_livre': 1900,
         'receitas_nao_conciliadas_livre': 0.0,
 
     }
@@ -177,14 +177,51 @@ def test_resultado_periodo_aberto_com_despesas_e_receitas(
         'receitas_no_periodo_capital': 0,
         'repasses_no_periodo_capital': 0,
         'despesas_no_periodo_capital': 200,
-        'saldo_atual_capital': -100,
+        'saldo_atual_capital': 0,
         'despesas_nao_conciliadas_capital': 200.0,
         'receitas_nao_conciliadas_capital': 0.0,
 
         'saldo_anterior_livre': 2000,
         'receitas_no_periodo_livre': 0,
         'repasses_no_periodo_livre': 0,
-        'saldo_atual_livre': 2000,
+        'saldo_atual_livre': 1900,
+        'receitas_nao_conciliadas_livre': 0.0,
+
+    }
+    resultado = info_acao_associacao_no_periodo(acao_associacao, periodo)
+
+    assert resultado == resultado_esperado
+
+
+def test_resultado_periodo_aberto_consumo_do_saldo_livre_aplicacao(
+    periodo,
+    acao_associacao,
+    fechamento_periodo_anterior_capital_1000_livre_2000,
+    despesa_no_periodo,
+    rateio_no_periodo_1500_capital,
+    receita_100_no_periodo_capital
+):
+    resultado_esperado = {
+        'saldo_anterior_custeio': 0,
+        'receitas_no_periodo_custeio': 0,
+        'repasses_no_periodo_custeio': 0,
+        'despesas_no_periodo_custeio': 0,
+        'saldo_atual_custeio': 0,
+        'despesas_nao_conciliadas_custeio': 0.0,
+        'receitas_nao_conciliadas_custeio': 0.0,
+
+        'saldo_anterior_capital': 1000,
+        'receitas_no_periodo_capital': 100,
+        'repasses_no_periodo_capital': 0,
+        'despesas_no_periodo_capital': 1500,
+        'saldo_atual_capital': 0,
+        'despesas_nao_conciliadas_capital': 1500.0,
+        'receitas_nao_conciliadas_capital': 100.0,
+
+        'saldo_anterior_livre': 2000,
+        'receitas_no_periodo_livre': 0,
+        'repasses_no_periodo_livre': 0,
+        'saldo_atual_livre': 1600,
         'receitas_nao_conciliadas_livre': 0.0,
 
     }


### PR DESCRIPTION
Esse PR:
- Corrige o serviço que retorna informações para o painel de ações que não estava usando os saldos de livre aplicação para compensar saldos negativos de capital ou custeio.
