### PR TITLE
feat(19957): Prestação de contas apenas até o próximo período pendente

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -307,3 +307,9 @@ class AssociacoesViewSet(mixins.ListModelMixin,
         response['Content-Disposition'] = 'attachment; filename=%s' % filename
 
         return response
+
+    @action(detail=True, url_path='periodos-para-prestacao-de-contas', methods=['get'])
+    def periodos_para_prestacao_de_contas(self, request, uuid=None):
+        associacao = self.get_object()
+        periodos = associacao.periodos_para_prestacoes_de_conta()
+        return Response(PeriodoLookUpSerializer(periodos, many=True).data)

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -76,6 +76,27 @@ class Associacao(ModeloIdNome):
                 'cargo_educacao': ''
             }
 
+    def periodos_com_prestacao_de_contas(self):
+        periodos = set()
+        for prestacao in self.prestacoes_de_conta_da_associacao.all():
+            periodos.add(prestacao.periodo)
+        return periodos
+
+    def proximo_periodo_de_prestacao_de_contas(self):
+        ultima_prestacao_feita = self.prestacoes_de_conta_da_associacao.last()
+        ultimo_periodo_com_prestacao = ultima_prestacao_feita.periodo if ultima_prestacao_feita else None
+        if ultimo_periodo_com_prestacao:
+            return ultimo_periodo_com_prestacao.periodo_seguinte.first()
+        else:
+            return self.periodo_inicial.periodo_seguinte.first() if self.periodo_inicial else None
+
+    def periodos_para_prestacoes_de_conta(self):
+        periodos = list(self.periodos_com_prestacao_de_contas())
+        proximo_periodo = self.proximo_periodo_de_prestacao_de_contas()
+        if proximo_periodo:
+            periodos.append(proximo_periodo)
+        return periodos
+
     @classmethod
     def acoes_da_associacao(cls, associacao_uuid):
         associacao = cls.objects.filter(uuid=associacao_uuid).first()


### PR DESCRIPTION
Esse PR:
- Cria novo endpoint que retorna os períodos para os cais dado associação pode editar ou criar uma prestação de contas.
