### PR TITLE
feat(22328): Remove opção de ata aprovada com ressalvas

### DIFF
--- a/sme_ptrf_apps/core/models/ata.py
+++ b/sme_ptrf_apps/core/models/ata.py
@@ -53,18 +53,15 @@ class Ata(ModeloBase):
     # Parecer Choice
     PARECER_APROVADA = 'APROVADA'
     PARECER_REJEITADA = 'REJEITADA'
-    PARECER_RESSALVAS = 'RESSALVAS'
 
     PARECER_NOMES = {
         PARECER_APROVADA: 'Aprovada',
         PARECER_REJEITADA: 'Rejeitada',
-        PARECER_RESSALVAS: 'Aprovada com ressalvas'
     }
 
     PARECER_CHOICES = (
         (PARECER_APROVADA, PARECER_NOMES[PARECER_APROVADA]),
         (PARECER_REJEITADA, PARECER_NOMES[PARECER_REJEITADA]),
-        (PARECER_RESSALVAS, PARECER_NOMES[PARECER_RESSALVAS]),
     )
 
     prestacao_conta = models.ForeignKey('PrestacaoConta', on_delete=models.CASCADE, related_name='atas_da_prestacao')

--- a/sme_ptrf_apps/core/tests/tests_api_atas_associacao/test_get_tabelas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_atas_associacao/test_get_tabelas.py
@@ -54,10 +54,6 @@ def test_api_get_atas_tabelas(client, ata_2020_1_cheque_aprovada):
             {
                 'id': Ata.PARECER_REJEITADA,
                 'nome': Ata.PARECER_NOMES[Ata.PARECER_REJEITADA]
-            },
-            {
-                'id': Ata.PARECER_RESSALVAS,
-                'nome': Ata.PARECER_NOMES[Ata.PARECER_RESSALVAS]
             }
         ]
     }


### PR DESCRIPTION
Esse PR:
-Atualiza modelo e API para não ter mais opção de Ata provada com ressalvas.