### PR TITLE
feat(22699): Adiciona uuid da PC na consulta de status do período

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -9,6 +9,7 @@ from sme_ptrf_apps.users.models import User
 from sme_ptrf_apps.users.tests.factories import UserFactory
 from .core.choices import MembroEnum, RepresentacaoCargo, StatusTag
 from .core.models import AcaoAssociacao, ContaAssociacao, STATUS_FECHADO, STATUS_ABERTO, STATUS_IMPLANTACAO
+from .core.models.prestacao_conta import PrestacaoConta
 from .despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CUSTEIO
 
 
@@ -452,7 +453,7 @@ def prestacao_conta_2020_1_conciliada(periodo_2020_1, associacao):
         'PrestacaoConta',
         periodo=periodo_2020_1,
         associacao=associacao,
-        status=STATUS_ABERTO,
+        status=PrestacaoConta.STATUS_NAO_RECEBIDA
     )
 
 

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -23,7 +23,7 @@ from ..serializers.conta_associacao_serializer import (
 )
 from ..serializers.periodo_serializer import PeriodoLookUpSerializer
 from ..serializers.processo_associacao_serializer import ProcessoAssociacaoRetrieveSerializer
-from ...models import Associacao, ContaAssociacao, Periodo, Unidade
+from ...models import Associacao, ContaAssociacao, Periodo, Unidade, PrestacaoConta
 from ...services import (
     implanta_saldos_da_associacao,
     implantacoes_de_saldo_da_associacao,
@@ -92,6 +92,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
 
     @action(detail=True, url_path='status-periodo')
     def status_periodo(self, request, uuid=None):
+        associacao = self.get_object()
 
         data = request.query_params.get('data')
 
@@ -103,10 +104,12 @@ class AssociacoesViewSet(mixins.ListModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         periodo = Periodo.da_data(data)
+        prestacao_conta = None
         if periodo:
             periodo_referencia = periodo.referencia
             prestacao_conta_status = status_prestacao_conta_associacao(periodo_uuid=periodo.uuid, associacao_uuid=uuid)
             aceita_alteracoes = not prestacao_conta_status['periodo_bloqueado'] if prestacao_conta_status else True
+            prestacao_conta = PrestacaoConta.by_periodo(associacao=associacao, periodo=periodo)
         else:
             periodo_referencia = ''
             aceita_alteracoes = True
@@ -117,6 +120,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
             'periodo_referencia': periodo_referencia,
             'aceita_alteracoes': aceita_alteracoes,
             'prestacao_contas_status': prestacao_conta_status,
+            'prestacao_conta': prestacao_conta.uuid if prestacao_conta else '',
         }
 
         return Response(result)

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -23,8 +23,9 @@ def test_status_periodo_em_andamento(client, associacao, periodo_fim_em_aberto):
             'periodo_bloqueado': False,
             'periodo_encerrado': None,
             'status_prestacao': 'DOCS_PENDENTES',
-            'texto_status': 'Período em andamento. '
-        }
+            'texto_status': 'Período em andamento. ',
+        },
+        'prestacao_conta': '',
 
     }
 
@@ -48,8 +49,9 @@ def test_status_periodo_pendente(client, associacao, periodo_fim_em_2020_06_30):
             'periodo_bloqueado': False,
             'periodo_encerrado': True,
             'status_prestacao': 'DOCS_PENDENTES',
-            'texto_status': 'Período finalizado. Documentos pendentes de geração.'
-        }
+            'texto_status': 'Período finalizado. Documentos pendentes de geração.',
+        },
+        'prestacao_conta': '',
 
     }
 
@@ -80,8 +82,38 @@ def test_chamada_data_sem_periodo(client, associacao, periodo_2020_1):
         'associacao': f'{associacao.uuid}',
         'periodo_referencia': '',
         'aceita_alteracoes': True,
-        'prestacao_contas_status': {}
+        'prestacao_contas_status': {},
+        'prestacao_conta': '',
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
+
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_finalizado(client, associacao, prestacao_conta_2020_1_conciliada):
+    periodo = prestacao_conta_2020_1_conciliada.periodo
+
+    response = client.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = {
+        'associacao': f'{associacao.uuid}',
+        'periodo_referencia': periodo.referencia,
+        'aceita_alteracoes': False,
+        'prestacao_contas_status': {
+            'documentos_gerados': True,
+            'legenda_cor': 2,
+            'periodo_bloqueado': True,
+            'periodo_encerrado': True,
+            'status_prestacao': 'NAO_RECEBIDA',
+            'texto_status': 'Período finalizado. Prestação de contas ainda não recebida pela DRE.',
+        },
+        'prestacao_conta': f'{prestacao_conta_2020_1_conciliada.uuid}',
+
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado
+


### PR DESCRIPTION
Esse PR:
- Inclui no resultado da consulta de status do período o uuid da prestação de contas, caso ela já tenha sido gerada.