### PR TITLE
Feature/22197 lista pcs get status

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -22,6 +22,7 @@ class PrestacaoContaListSerializer(serializers.ModelSerializer):
     periodo_uuid = serializers.SerializerMethodField('get_periodo_uuid')
     associacao_uuid = serializers.SerializerMethodField('get_associacao_uuid')
     tecnico_responsavel = serializers.SerializerMethodField('get_tecnico_responsavel')
+    devolucao_ao_tesouro = serializers.SerializerMethodField('get_devolucao_ao_tesouro')
 
     def get_unidade_eol(self, obj):
         return obj.associacao.unidade.codigo_eol if obj.associacao and obj.associacao.unidade else ''
@@ -41,9 +42,13 @@ class PrestacaoContaListSerializer(serializers.ModelSerializer):
     def get_tecnico_responsavel(self, obj):
         return obj.tecnico_responsavel.nome if obj.tecnico_responsavel else ''
 
+    # TODO Rever método ao implementar devolução ao tesouro
+    def get_devolucao_ao_tesouro(self, obj):
+        return '999,99' if obj.devolucao_tesouro else 'Não'
+
 
     class Meta:
         model = PrestacaoConta
         fields = (
         'uuid', 'unidade_eol', 'unidade_nome', 'status', 'tecnico_responsavel', 'processo_sei', 'data_recebimento',
-        'data_ultima_analise', 'periodo_uuid', 'associacao_uuid')
+        'data_ultima_analise', 'periodo_uuid', 'associacao_uuid', 'devolucao_ao_tesouro')

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -28,10 +28,18 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
     queryset = PrestacaoConta.objects.all()
     serializer_class = PrestacaoContaLookUpSerializer
     filter_backends = (filters.DjangoFilterBackend, SearchFilter,)
-    filter_fields = ('associacao__unidade__dre__uuid', 'periodo__uuid', 'status', 'associacao__unidade__tipo_unidade')
+    filter_fields = ('associacao__unidade__dre__uuid', 'periodo__uuid', 'associacao__unidade__tipo_unidade')
 
     def get_queryset(self):
         qs = PrestacaoConta.objects.all()
+
+        status = self.request.query_params.get('status')
+        if status is not None:
+            if status in ['APROVADA', 'APROVADA_RESSALVA']:
+                qs = qs.filter(Q(status='APROVADA') | Q(status='APROVADA_RESSALVA'))
+            else:
+                 qs = qs.filter(status=status)
+
 
         nome = self.request.query_params.get('nome')
         if nome is not None:

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -223,3 +223,10 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
         }
 
         return Response(dashboard)
+
+    @action(detail=False, url_path='tabelas')
+    def tabelas(self, _):
+        result = {
+            'status': PrestacaoConta.status_to_json(),
+        }
+        return Response(result)

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -136,6 +136,17 @@ class PrestacaoConta(ModeloBase):
 
         return cards
 
+    @classmethod
+    def status_to_json(cls):
+        result = []
+        for choice in cls.STATUS_CHOICES:
+            status = {
+                'id': choice[0],
+                'nome': choice[1]
+            }
+            result.append(status)
+        return result
+
     class Meta:
         verbose_name = "Prestação de conta"
         verbose_name_plural = "Prestações de contas"

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_get_prestacoes_contas_tabelas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_get_prestacoes_contas_tabelas.py
@@ -1,0 +1,20 @@
+import json
+
+import pytest
+from rest_framework import status
+
+from ...models import PrestacaoConta
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_get_prestacoes_contas_tabelas(client):
+    response = client.get('/api/prestacoes-contas/tabelas/', content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = {
+        'status': PrestacaoConta.status_to_json(),
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
@@ -106,7 +106,8 @@ def _prestacao_conta_2020_1_unidade_a_dre1(periodo_2020_1, _unidade_a_dre_1, _as
         periodo=periodo_2020_1,
         associacao=_associacao_a_dre_1,
         data_recebimento=date(2020, 1, 1),
-        devolucao_tesouro=True
+        devolucao_tesouro=True,
+        status='APROVADA'
     )
 
 
@@ -116,7 +117,8 @@ def _prestacao_conta_2020_1_unidade_c_dre1(periodo_2020_1, _unidade_c_dre_1_ceu,
         'PrestacaoConta',
         periodo=periodo_2020_1,
         associacao=_associacao_c_dre_1,
-        data_recebimento=date(2020, 1, 3)
+        data_recebimento=date(2020, 1, 3),
+        status='RECEBIDA'
     )
 
 
@@ -127,6 +129,7 @@ def _prestacao_conta_2019_2_unidade_a_dre1(periodo_2019_2, _unidade_a_dre_1, _as
         periodo=periodo_2019_2,
         associacao=_associacao_a_dre_1,
         data_recebimento=date(2019, 1, 1),
+        status='APROVADA_RESSALVA'
     )
 
 
@@ -161,7 +164,7 @@ def test_api_list_prestacoes_conta_por_periodo_e_dre(client,
             'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA',
             'tecnico_responsavel': '',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -195,7 +198,7 @@ def test_api_list_prestacoes_conta_por_nome_unidade(client,
             'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA',
             'tecnico_responsavel': '',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -208,7 +211,7 @@ def test_api_list_prestacoes_conta_por_nome_unidade(client,
             'data_recebimento': '2019-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA_RESSALVA',
             'tecnico_responsavel': '',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -244,7 +247,7 @@ def test_api_list_prestacoes_conta_por_nome_associacao(client,
             'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA',
             'tecnico_responsavel': '',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -257,7 +260,7 @@ def test_api_list_prestacoes_conta_por_nome_associacao(client,
             'data_recebimento': '2019-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA_RESSALVA',
             'tecnico_responsavel': '',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -292,7 +295,7 @@ def test_api_list_prestacoes_conta_por_tipo_unidade(client,
             'data_recebimento': '2020-01-03',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'RECEBIDA',
             'tecnico_responsavel': '',
             'unidade_eol': '000102',
             'unidade_nome': 'Codorna',
@@ -374,7 +377,7 @@ def test_api_list_prestacoes_conta_por_tecnico(client,
             'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
-            'status': 'DOCS_PENDENTES',
+            'status': 'APROVADA',
             'tecnico_responsavel': 'José Testando',
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
@@ -415,6 +418,98 @@ def test_api_list_prestacoes_conta_por_data_recebimento(client,
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_b_dre2.associacao.uuid}',
             'devolucao_ao_tesouro': 'Não'
         }
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_por_status_aprovada_e_aprovada_ressalva(client,
+                                                                           _prestacao_conta_2020_1_unidade_a_dre1,
+                                                                           # Entra
+                                                                           _prestacao_conta_2020_1_unidade_c_dre1,
+                                                                           # Não entra
+                                                                           _prestacao_conta_2019_2_unidade_a_dre1,
+                                                                           # Entra
+                                                                           _prestacao_conta_2020_1_unidade_b_dre2,
+                                                                           # Não entra
+                                                                           _dre_01,
+                                                                           periodo_2020_1,
+                                                                           periodo_2019_2):
+    url = f'/api/prestacoes-contas/?status=APROVADA'
+
+    response = client.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': '2020-01-01',
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'APROVADA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '999,99'
+        },
+        {
+            'periodo_uuid': f'{periodo_2019_2.uuid}',
+            'data_recebimento': '2019-01-01',
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'APROVADA_RESSALVA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
+
+        },
+
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_por_status_recebida(client,
+                                                       _prestacao_conta_2020_1_unidade_a_dre1,
+                                                       # Não entra
+                                                       _prestacao_conta_2020_1_unidade_c_dre1,
+                                                       # Entra
+                                                       _prestacao_conta_2019_2_unidade_a_dre1,
+                                                       # Não entra
+                                                       _prestacao_conta_2020_1_unidade_b_dre2,
+                                                       # Não entra
+                                                       _dre_01,
+                                                       periodo_2020_1,
+                                                       periodo_2019_2):
+    url = f'/api/prestacoes-contas/?status=RECEBIDA'
+
+    response = client.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': '2020-01-03',
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'RECEBIDA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000102',
+            'unidade_nome': 'Codorna',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_c_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_c_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
+        },
+
     ]
 
     assert response.status_code == status.HTTP_200_OK

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
@@ -105,7 +105,8 @@ def _prestacao_conta_2020_1_unidade_a_dre1(periodo_2020_1, _unidade_a_dre_1, _as
         'PrestacaoConta',
         periodo=periodo_2020_1,
         associacao=_associacao_a_dre_1,
-        data_recebimento=date(2020, 1, 1)
+        data_recebimento=date(2020, 1, 1),
+        devolucao_tesouro=True
     )
 
 
@@ -125,7 +126,7 @@ def _prestacao_conta_2019_2_unidade_a_dre1(periodo_2019_2, _unidade_a_dre_1, _as
         'PrestacaoConta',
         periodo=periodo_2019_2,
         associacao=_associacao_a_dre_1,
-        data_recebimento=date(2019, 1, 1)
+        data_recebimento=date(2019, 1, 1),
     )
 
 
@@ -165,7 +166,8 @@ def test_api_list_prestacoes_conta_por_periodo_e_dre(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '999,99'
         },
     ]
 
@@ -198,7 +200,8 @@ def test_api_list_prestacoes_conta_por_nome_unidade(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '999,99'
         },
         {
             'periodo_uuid': f'{periodo_2019_2.uuid}',
@@ -210,7 +213,9 @@ def test_api_list_prestacoes_conta_por_nome_unidade(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
+
         },
 
     ]
@@ -244,7 +249,8 @@ def test_api_list_prestacoes_conta_por_nome_associacao(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '999,99'
         },
         {
             'periodo_uuid': f'{periodo_2019_2.uuid}',
@@ -256,7 +262,8 @@ def test_api_list_prestacoes_conta_por_nome_associacao(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
         },
 
     ]
@@ -290,7 +297,8 @@ def test_api_list_prestacoes_conta_por_tipo_unidade(client,
             'unidade_eol': '000102',
             'unidade_nome': 'Codorna',
             'uuid': f'{_prestacao_conta_2020_1_unidade_c_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_c_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_c_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
         },
 
     ]
@@ -371,7 +379,8 @@ def test_api_list_prestacoes_conta_por_tecnico(client,
             'unidade_eol': '000101',
             'unidade_nome': 'Andorinha',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '999,99'
         },
     ]
 
@@ -386,7 +395,6 @@ def test_api_list_prestacoes_conta_por_data_recebimento(client,
                                                         _prestacao_conta_2020_1_unidade_b_dre2,  # Entra
                                                         _dre_01,
                                                         periodo_2020_1):
-
     url = f'/api/prestacoes-contas/?data_inicio=2020-01-02&data_fim=2020-01-02'
 
     response = client.get(url, content_type='application/json')
@@ -404,7 +412,8 @@ def test_api_list_prestacoes_conta_por_data_recebimento(client,
             'unidade_eol': '000201',
             'unidade_nome': 'Bentivi',
             'uuid': f'{_prestacao_conta_2020_1_unidade_b_dre2.uuid}',
-            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_b_dre2.associacao.uuid}'
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_b_dre2.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
         }
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_serializer.py
@@ -55,3 +55,4 @@ def test_list_serializer(prestacao_conta, atribuicao, processo_associacao_2019):
     assert serializer.data['processo_sei'] == processo_associacao_2019.numero_processo
     assert serializer.data['data_recebimento']
     assert serializer.data['data_ultima_analise']
+    assert serializer.data['devolucao_ao_tesouro']


### PR DESCRIPTION
Esse PR:
-  Cria endpoint para retornar valores possíveis do status de Prestações de Contas;
-  Inclui coluna Devolução ao tesouro na lista de Prestações de conta
-  Altera o filtro por status das prestações de compra para que no caso de APROVADA e APROVADA_RESSALVA retorne ambos os status