### PR TITLE
Features/22960 permitir cadastro unico de membros da associacao

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -1274,12 +1274,12 @@ def membro_associacao(associacao):
 def membro_associacao_presidente_conselho(associacao):
     return baker.make(
         'MembroAssociacao',
-        nome='Arthur Nobrega',
+        nome='Arthur Nobrega Junior',
         associacao=associacao,
         cargo_associacao=MembroEnum.PRESIDENTE_CONSELHO_FISCAL.value,
         cargo_educacao='Coordenador',
         representacao=RepresentacaoCargo.SERVIDOR.value,
-        codigo_identificacao='567432',
+        codigo_identificacao='967499',
         email='ollyverottoboni@gmail.com'
     )
 
@@ -1288,12 +1288,12 @@ def membro_associacao_presidente_conselho(associacao):
 def membro_associacao_presidente_associacao(associacao):
     return baker.make(
         'MembroAssociacao',
-        nome='Arthur Nobrega',
+        nome='Arthur Nobrega Silva',
         associacao=associacao,
         cargo_associacao=MembroEnum.PRESIDENTE_DIRETORIA_EXECUTIVA.value,
         cargo_educacao='Coordenador',
         representacao=RepresentacaoCargo.SERVIDOR.value,
-        codigo_identificacao='567432',
+        codigo_identificacao='567411',
         email='ollyverottoboni@gmail.com'
     )
 

--- a/sme_ptrf_apps/core/models/membro_associacao.py
+++ b/sme_ptrf_apps/core/models/membro_associacao.py
@@ -1,4 +1,7 @@
 from django.db import models
+from django.db.models import Q
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 from sme_ptrf_apps.core.choices import MembroEnum, RepresentacaoCargo
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
@@ -38,3 +41,14 @@ class MembroAssociacao(ModeloBase):
 
     def __str__(self):
         return f"<Nome: {self.nome}, Representacao: {self.representacao}>"
+
+
+@receiver(pre_save, sender=MembroAssociacao)
+def membro_pre_save(instance, **kwargs):
+    """Deve garantir que um membro da associação NÃO seja cadastrado mais de uma vez."""
+
+    membro = MembroAssociacao.objects.filter(Q(nome__iexact=(instance.nome or None)) | Q(
+        codigo_identificacao__exact=(instance.codigo_identificacao or None))).first()
+
+    if membro and membro.id != instance.id:
+        raise ValueError("Membro já cadastrado")

--- a/sme_ptrf_apps/core/tests/tests_membro_associacao/test_membro_associacao_codigo_identificacao_nome_api.py
+++ b/sme_ptrf_apps/core/tests/tests_membro_associacao/test_membro_associacao_codigo_identificacao_nome_api.py
@@ -62,6 +62,44 @@ def test_consulta_codigo_identificacao_rf(jwt_authenticated_client):
         assert result == data
 
 
+def test_consulta_nome_responsavel(jwt_authenticated_client):
+    nome = 'Eren Jeager'
+    response = jwt_authenticated_client.get(f'/api/membros-associacao/nome-responsavel/?nome={nome}')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == {'detail': 'Pode ser cadastrado.'}
+
+
+def test_consulta_codigo_identificacao_rf_com_membro_ja_cadastrado(jwt_authenticated_client, membro_associacao):
+    rf = membro_associacao.codigo_identificacao
+    response = jwt_authenticated_client.get(f'/api/membros-associacao/codigo-identificacao/?rf={rf}')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == {"detail": "Membro já cadastrado."}
+
+
+def test_consulta_codigo_eol_com_membro_ja_cadastrado(jwt_authenticated_client, membro_associacao):
+
+    cod_eol = membro_associacao.codigo_identificacao
+    response = jwt_authenticated_client.get(f'/api/membros-associacao/codigo-identificacao/?codigo-eol={cod_eol}')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == {"detail": "Membro já cadastrado."}
+
+
+def test_consulta_nome_responsavel_com_membro_ja_cadastrado(jwt_authenticated_client, membro_associacao):
+
+    nome = membro_associacao.nome
+    response = jwt_authenticated_client.get(f'/api/membros-associacao/nome-responsavel/?nome={nome}')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == {"detail": "Membro já cadastrado."}
+
+
 def test_consulta_codigo_identificacao_sem_rf(jwt_authenticated_client):
     response = jwt_authenticated_client.get(f'/api/membros-associacao/codigo-identificacao/?rf=')
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/sme_ptrf_apps/core/tests/tests_membro_associacao/test_membro_associacao_model.py
+++ b/sme_ptrf_apps/core/tests/tests_membro_associacao/test_membro_associacao_model.py
@@ -18,6 +18,16 @@ def test_instance_model(membro_associacao):
     assert model.email
 
 
+def test_nao_criar_novo_membro_caso_exista_pelo_nome(membro_associacao):
+    with pytest.raises(ValueError):
+        MembroAssociacao.objects.create(nome=membro_associacao.nome)
+
+
+def test_nao_criar_novo_membro_caso_exista_pelo_codigo_identificaca0(membro_associacao):
+    with pytest.raises(ValueError):
+        MembroAssociacao.objects.create(codigo_identificacao=membro_associacao.codigo_identificacao)
+
+
 def test_admin():
     from django.contrib import admin
     assert admin.site._registry[MembroAssociacao]


### PR DESCRIPTION
Esse PR contém:

* Cria consistência no modelo para não permitir cadastro de servidor duplicado (rf).
* Cria consistência no modelo para não permitir cadastro de aluno duplicado (eol).
* Cria consistência no modelo para não permitir cadastro do responsável duplicado (nome).
* API. Alterar consulta que checa o RF para ver se membro já existe.
* API. Alterar consulta que checa o eol para ver se membro já existe.
* API. Cria consulta que checa o nome do responsável para ver se membro já existe.