### PR TITLE
Feature(23678) Detalhe pc devolvidas cobrancas

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/devolucao_prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/devolucao_prestacao_conta_serializer.py
@@ -15,4 +15,5 @@ class DevolucaoPrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DevolucaoPrestacaoConta
+        order_by = 'id'
         fields = ('uuid', 'prestacao_conta', 'data', 'data_limite_ue', 'cobrancas_da_devolucao')

--- a/sme_ptrf_apps/core/models/cobranca_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/cobranca_prestacao_conta.py
@@ -46,5 +46,5 @@ class CobrancaPrestacaoConta(ModeloBase):
 @receiver(pre_save, sender=CobrancaPrestacaoConta)
 def cobranca_pre_save(instance, **kwargs):
     if instance.tipo == TIPO_DEVOLUCAO and instance.prestacao_conta:
-        ultima_devolucao = instance.prestacao_conta.devolucoes_da_prestacao.order_by('-data').first()
+        ultima_devolucao = instance.prestacao_conta.devolucoes_da_prestacao.order_by('-id').first()
         instance.devolucao_prestacao = ultima_devolucao


### PR DESCRIPTION
Esse PR:
- Altera a regra de negócio para determinar a última devolução da PC para usar o id em vez da data da devolução.