### PR TITLE
feat(23815): Add uuid tipo devolução no json de PC

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/tipo_devolucao_ao_tesouro_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/tipo_devolucao_ao_tesouro_serializer.py
@@ -6,4 +6,4 @@ from ...models import TipoDevolucaoAoTesouro
 class TipoDevolucaoAoTesouroSerializer(serializers.ModelSerializer):
     class Meta:
         model = TipoDevolucaoAoTesouro
-        fields = ('id', 'nome')
+        fields = ('id', 'nome', 'uuid')

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -259,7 +259,9 @@ def test_api_retrieve_prestacao_conta_por_uuid(jwt_authenticated_client, prestac
                 'motivo': 'teste',
                 'prestacao_conta': f'{prestacao_conta.uuid}',
                 'tipo': {
-                    'id': devolucao_ao_tesouro.tipo.id, 'nome': 'Teste'
+                    'id': devolucao_ao_tesouro.tipo.id,
+                    'nome': 'Teste',
+                    'uuid': f'{devolucao_ao_tesouro.tipo.uuid}',
                 },
                 'uuid': f'{devolucao_ao_tesouro.uuid}',
                 'valor': '100.00'

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_devolucao_ao_tesouro/test_tipos_devolucao_ao_tesouro_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_devolucao_ao_tesouro/test_tipos_devolucao_ao_tesouro_list.py
@@ -19,7 +19,8 @@ def test_api_list_devolucoes_ao_tesouro(jwt_authenticated_client, tipo_devolucao
     resultado_esperado = [
         {
             'id': tipo_devolucao_ao_tesouro.id,
-            'nome': 'Teste'
+            'nome': 'Teste',
+            'uuid': f'{tipo_devolucao_ao_tesouro.uuid}'
         }
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_tipo_devolucao_ao_tesouro/test_tipo_devolucao_ao_tesouro_serializer.py
+++ b/sme_ptrf_apps/core/tests/tests_tipo_devolucao_ao_tesouro/test_tipo_devolucao_ao_tesouro_serializer.py
@@ -17,3 +17,4 @@ def test_serializer(tipo_devolucao_ao_tesouro):
     assert serializer.data is not None
     assert serializer.data['id']
     assert serializer.data['nome']
+    assert serializer.data['uuid']


### PR DESCRIPTION
Esse PR:
- Altera o serializer de prestação de contas para incluir o uuid do tipo de devolução ao tesouro.