### PR TITLE
feat(25499):Devoluções ao tesouro pela data do crédito

### DIFF
--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -248,8 +248,14 @@ def informacoes_devolucoes_a_conta_ptrf(dre, periodo, tipo_conta):
         status__in=['APROVADA', 'APROVADA_RESSALVA', 'REPROVADA']
     ).values_list('associacao__uuid')
 
-    devolucoes = Receita.objects.filter(
-        referencia_devolucao=periodo,
+    if periodo.data_fim_realizacao_despesas:
+        receitas_periodo = Receita.objects.filter(
+            data__range=(periodo.data_inicio_realizacao_despesas, periodo.data_fim_realizacao_despesas))
+    else:
+        receitas_periodo = Receita.objects.filter(
+            data__gte=periodo.data_inicio_realizacao_despesas)
+
+    devolucoes = receitas_periodo.filter(
         tipo_receita__e_devolucao=True,
         conta_associacao__tipo_conta=tipo_conta,
         associacao__uuid__in=associacoes_com_pc_concluidas,

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_conta_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_conta_relatorio_consolidado_dre.py
@@ -64,7 +64,7 @@ def receita_devolucao_1(associacao, conta_associacao, acao_associacao, tipo_rece
     return baker.make(
         'Receita',
         associacao=associacao,
-        data=date(2019, 3, 26),
+        data=date(2019, 9, 26),
         valor=100.00,
         conta_associacao=conta_associacao,
         acao_associacao=acao_associacao,
@@ -73,7 +73,6 @@ def receita_devolucao_1(associacao, conta_associacao, acao_associacao, tipo_rece
         conferido=True,
         categoria_receita='CUSTEIO',
         detalhe_tipo_receita=detalhe_tipo_receita,
-        referencia_devolucao=periodo,
     )
 
 
@@ -83,7 +82,7 @@ def receita_devolucao_2(associacao, conta_associacao, acao_associacao, tipo_rece
     return baker.make(
         'Receita',
         associacao=associacao,
-        data=date(2019, 3, 26),
+        data=date(2019, 9, 26),
         valor=100.00,
         conta_associacao=conta_associacao,
         acao_associacao=acao_associacao,
@@ -92,7 +91,6 @@ def receita_devolucao_2(associacao, conta_associacao, acao_associacao, tipo_rece
         conferido=True,
         categoria_receita='CUSTEIO',
         detalhe_tipo_receita=detalhe_tipo_receita,
-        referencia_devolucao=periodo,
     )
 
 


### PR DESCRIPTION
Esse PR:

Altera a regra de negócios para a consulta de devoluções
à conta do PTRF. Agora considera a data do crédito, antes
considerava o período de referência da devolução.