### PR TITLE
feat(26292): Filtro por data em consulta de totais de rateio

### DIFF
--- a/sme_ptrf_apps/core/services/periodo_inicial.py
+++ b/sme_ptrf_apps/core/services/periodo_inicial.py
@@ -74,7 +74,7 @@ def carrega_periodo_inicial(arquivo):
     logger.info("Executando Carga de Período inicial para associações.")
     arquivo.ultima_execucao = datetime.datetime.now()
 
-    with open(arquivo.conteudo.path, 'r') as f:
+    with open(arquivo.conteudo.path, 'r', encoding="utf-8") as f:
         sniffer = csv.Sniffer().sniff(f.read(1024))
         f.seek(0)
         if  __DELIMITADORES[sniffer.delimiter] != arquivo.tipo_delimitador:

--- a/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
@@ -160,6 +160,12 @@ class RateiosDespesasViewSet(mixins.CreateModelMixin,
             if filter_value:
                 filtered_queryset = filtered_queryset.filter(**{field: filter_value})
 
+
+        data_inicio = self.request.query_params.get('data_inicio')
+        data_fim = self.request.query_params.get('data_fim')
+        if data_inicio is not None and data_fim is not None:
+            filtered_queryset  = filtered_queryset .filter(despesa__data_documento__range=[data_inicio, data_fim])
+
         total_despesas_com_filtro = filtered_queryset.aggregate(Sum('valor_rateio'))['valor_rateio__sum']
         total_despesas_sem_filtro = queryset.aggregate(Sum('valor_rateio'))['valor_rateio__sum']
 

--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas_totais.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas_totais.py
@@ -1,6 +1,9 @@
 import json
-
 import pytest
+
+from datetime import date
+
+from model_bakery import baker
 from rest_framework import status
 
 pytestmark = pytest.mark.django_db
@@ -124,6 +127,75 @@ def test_api_get_despesas_totais_search_despesas_por_especificacao(jwt_authentic
                                 rateio_despesa_instalacao_eletrica_ptrf.valor_rateio
 
     total_despesas_com_filtro = rateio_despesa_material_eletrico_role_cultural.valor_rateio
+
+    results = {
+        "associacao_uuid": f'{associacao.uuid}',
+        "total_despesas_sem_filtro": total_despesas_sem_filtro,
+        "total_despesas_com_filtro": total_despesas_com_filtro
+    }
+
+    esperado = results
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado
+
+
+@pytest.fixture
+def despesa_11_03_2020(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='9999999',
+        data_documento=date(2020, 3, 11),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=date(2020, 3, 10),
+        valor_total=100.00,
+    )
+
+
+@pytest.fixture
+def rateio_despesa_11_03_2020(associacao, despesa_11_03_2020, conta_associacao, acao,
+                              tipo_aplicacao_recurso_custeio,
+                              tipo_custeio_material,
+                              especificacao_material_eletrico, acao_associacao_role_cultural):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_11_03_2020,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_material,
+        especificacao_material_servico=especificacao_material_eletrico,
+        valor_rateio=999.00,
+
+    )
+
+
+def test_api_get_despesas_totais_por_periodo(jwt_authenticated_client_d, associacao, despesa,
+                                             conta_associacao, acao,
+                                             tipo_aplicacao_recurso_custeio,
+                                             tipo_custeio_servico,
+                                             especificacao_instalacao_eletrica, acao_associacao,
+                                             especificacao_material_eletrico,
+                                             rateio_despesa_material_eletrico_role_cultural,
+                                             rateio_despesa_instalacao_eletrica_ptrf,
+                                             despesa_11_03_2020,
+                                             rateio_despesa_11_03_2020
+                                             ):
+    response = jwt_authenticated_client_d.get(
+        f'/api/rateios-despesas/totais/?associacao__uuid={associacao.uuid}&data_inicio=2020-03-11&data_fim=2020-03-11',
+        content_type='application/json')
+    result = json.loads(response.content)
+
+    total_despesas_sem_filtro = rateio_despesa_material_eletrico_role_cultural.valor_rateio + \
+                                rateio_despesa_instalacao_eletrica_ptrf.valor_rateio + \
+                                rateio_despesa_11_03_2020.valor_rateio
+
+    total_despesas_com_filtro = rateio_despesa_11_03_2020.valor_rateio
 
     results = {
         "associacao_uuid": f'{associacao.uuid}',


### PR DESCRIPTION
Esse PR:
- Corrige a consulta de totais de despesas que não aplicava o filtro por range de datas.