### PR TITLE
feat(27047): Limpa devoluções tesouro ao salvar vazio

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -322,14 +322,6 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
         prestacao_conta = self.get_object()
 
         devolucoes_ao_tesouro_da_prestacao = request.data.get('devolucoes_ao_tesouro_da_prestacao', [])
-        if not devolucoes_ao_tesouro_da_prestacao:
-            response = {
-                'uuid': f'{uuid}',
-                'erro': 'falta_de_informacoes',
-                'operacao': 'salvar-devolucoes-ao-tesouro',
-                'mensagem': 'Faltou informar o campo devolucoes_ao_tesouro_da_prestacao.'
-            }
-            return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
         if prestacao_conta.status not in [PrestacaoConta.STATUS_EM_ANALISE, PrestacaoConta.STATUS_DEVOLVIDA]:
             response = {

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_devolucoes_ao_tesouro.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_devolucoes_ao_tesouro.py
@@ -46,7 +46,7 @@ def tipo_devolucao_ao_tesouro():
 
 @freeze_time('2020-09-01')
 def test_api_salva_devolucoes_ao_tesouro(jwt_authenticated_client, prestacao_conta_em_analise, conta_associacao,
-                                           tipo_devolucao_ao_tesouro, despesa):
+                                         tipo_devolucao_ao_tesouro, despesa):
     payload = {
         'devolucoes_ao_tesouro_da_prestacao': [
             {
@@ -71,20 +71,33 @@ def test_api_salva_devolucoes_ao_tesouro(jwt_authenticated_client, prestacao_con
     assert prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.exists(), 'Não gravou as devoluções ao tesouro'
     assert prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.first().visao_criacao == 'UE'
 
-def test_api_salvar_devolucoes_ao_tesouro_exige_devolucao_tesouro(jwt_authenticated_client, prestacao_conta_em_analise):
+
+@pytest.fixture
+def tipo_devolucao_ao_tesouro():
+    return baker.make('TipoDevolucaoAoTesouro', nome='Teste')
+
+
+@pytest.fixture
+def devolucao_ao_tesouro(prestacao_conta_em_analise, tipo_devolucao_ao_tesouro, despesa):
+    return baker.make(
+        'DevolucaoAoTesouro',
+        prestacao_conta=prestacao_conta_em_analise,
+        tipo=tipo_devolucao_ao_tesouro,
+        data=date(2020, 7, 1),
+        despesa=despesa,
+        devolucao_total=True,
+        valor=100.00,
+        motivo='teste'
+    )
+
+
+def test_api_salvar_devolucoes_ao_tesouro_sem_devolucao_tesouro(jwt_authenticated_client, prestacao_conta_em_analise,
+                                                                  devolucao_ao_tesouro):
     url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/salvar-devolucoes-ao-tesouro/'
 
     response = jwt_authenticated_client.patch(url, content_type='application/json')
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_200_OK
 
-    result = json.loads(response.content)
-
-    result_esperado = {
-        'uuid': f'{prestacao_conta_em_analise.uuid}',
-        'erro': 'falta_de_informacoes',
-        'operacao': 'salvar-devolucoes-ao-tesouro',
-        'mensagem': 'Faltou informar o campo devolucoes_ao_tesouro_da_prestacao.'
-    }
-
-    assert result == result_esperado, "Deveria ter retornado erro falta_de_informacoes."
+    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_em_analise.uuid)
+    assert not prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.exists(), 'Não apagou as devoluções ao tesouro'


### PR DESCRIPTION
Esse PR:
-Alterar o endpoint de salvamento de devoluções ao tesouro de modo que ao passar uma lista de devoluções vazia o sistema apaga as devoluções existentes.