### PR TITLE
feat(26461): Dashboard card não recebido em primeiro

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -312,6 +312,7 @@ class PrestacaoConta(ModeloBase):
             }
             cards.append(card)
 
+
         quantidade_unidades_dre = Associacao.objects.filter(unidade__dre__uuid=dre_uuid).exclude(cnpj__exact='').count()
         quantidade_pcs_nao_apresentadas = quantidade_unidades_dre - quantidade_pcs_apresentadas
         card_nao_recebidas = {
@@ -319,8 +320,7 @@ class PrestacaoConta(ModeloBase):
             "quantidade_prestacoes": quantidade_pcs_nao_apresentadas,
             "status": 'NAO_RECEBIDA'
         }
-        cards.append(card_nao_recebidas)
-
+        cards.insert(0, card_nao_recebidas)
         return cards
 
     @classmethod

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_dashboard.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_dashboard.py
@@ -122,6 +122,10 @@ def test_dashboard(
         'total_associacoes_dre': 5,
         'cards': [
             {
+                'titulo': 'Prestações de contas não recebidas',
+                'quantidade_prestacoes': 2,  # Uma PC não recebida + Uma Associação sem PC.
+                'status': 'NAO_RECEBIDA'},
+            {
                 'titulo': 'Prestações de contas recebidas aguardando análise',
                 'quantidade_prestacoes': 0,
                 'status': 'RECEBIDA'},
@@ -140,12 +144,7 @@ def test_dashboard(
             {
                 'titulo': 'Prestações de contas reprovadas',
                 'quantidade_prestacoes': 0,
-                'status': 'REPROVADA'},
-
-            {
-                'titulo': 'Prestações de contas não recebidas',
-                'quantidade_prestacoes': 2,  # Uma PC não recebida + Uma Associação sem PC.
-                'status': 'NAO_RECEBIDA'}
+                'status': 'REPROVADA'}
         ]
     }
 
@@ -171,6 +170,10 @@ def test_dashboard_add_aprovada_ressalva(
         'total_associacoes_dre': 5,
         'cards': [
             {
+                'titulo': 'Prestações de contas não recebidas',
+                'quantidade_prestacoes': 2,
+                'status': 'NAO_RECEBIDA'},
+            {
                 'titulo': 'Prestações de contas recebidas aguardando análise',
                 'quantidade_prestacoes': 0,
                 'status': 'RECEBIDA'},
@@ -193,11 +196,7 @@ def test_dashboard_add_aprovada_ressalva(
             {
                 'titulo': 'Prestações de contas aprovadas com ressalvas',
                 'quantidade_prestacoes': 1,
-                'status': 'APROVADA_RESSALVA'},
-            {
-                'titulo': 'Prestações de contas não recebidas',
-                'quantidade_prestacoes': 2,
-                'status': 'NAO_RECEBIDA'}
+                'status': 'APROVADA_RESSALVA'}
         ]
     }
 
@@ -228,6 +227,10 @@ def test_dashboard_outro_periodo(jwt_authenticated_client_a, prestacao_conta_apr
         'total_associacoes_dre': 2,
         'cards': [
             {
+                'titulo': 'Prestações de contas não recebidas',
+                'quantidade_prestacoes': 2,
+                'status': 'NAO_RECEBIDA'},
+            {
                 'titulo': 'Prestações de contas recebidas aguardando análise',
                 'quantidade_prestacoes': 0,
                 'status': 'RECEBIDA'},
@@ -246,11 +249,7 @@ def test_dashboard_outro_periodo(jwt_authenticated_client_a, prestacao_conta_apr
             {
                 'titulo': 'Prestações de contas reprovadas',
                 'quantidade_prestacoes': 0,
-                'status': 'REPROVADA'},
-            {
-                'titulo': 'Prestações de contas não recebidas',
-                'quantidade_prestacoes': 2,
-                'status': 'NAO_RECEBIDA'}
+                'status': 'REPROVADA'}
         ]
     }
 

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
@@ -55,6 +55,10 @@ def prestacao_conta2(periodo, outra_associacao):
 def test_dash_board(prestacao_conta1, prestacao_conta2, periodo, dre):
     esperado = [
         {
+            'titulo': 'Prestações de contas não recebidas',
+            'quantidade_prestacoes': 0,
+            'status': 'NAO_RECEBIDA'},
+        {
             'titulo': 'Prestações de contas recebidas aguardando análise',
             'quantidade_prestacoes': 0,
             'status': 'RECEBIDA'},
@@ -73,11 +77,7 @@ def test_dash_board(prestacao_conta1, prestacao_conta2, periodo, dre):
         {
             'titulo': 'Prestações de contas reprovadas',
             'quantidade_prestacoes': 0,
-            'status': 'REPROVADA'},
-        {
-            'titulo': 'Prestações de contas não recebidas',
-            'quantidade_prestacoes': 0,
-            'status': 'NAO_RECEBIDA'}
+            'status': 'REPROVADA'}
     ]
 
     assert esperado == prestacao_conta1.dashboard(periodo.uuid, dre.uuid)


### PR DESCRIPTION
Esse PR:
- Ajusta o retorno para o dashboard da DRE de modo que o card Não Recebidas fique em primeiro.