### PR TITLE
Features/25460 permissoes associacoes dre

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -13,7 +13,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from sme_ptrf_apps.users.permissoes import PermissaoAssociacao, PermissaoAssociacaoDre, PermissaoExportarDadosAssociacao
+from sme_ptrf_apps.users.permissoes import (
+    PermissaoAssociacao,
+    PermissaoAssociacaoDre,
+    PermissaoDadosUnidadeDre,
+    PermissaoExportarDadosAssociacao,
+)
 
 from ....dre.services import (
     desmarca_item_verificacao_associacao,
@@ -53,7 +58,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
                          mixins.UpdateModelMixin,
                          GenericViewSet, ):
-    permission_classes = [IsAuthenticated & (PermissaoAssociacao | PermissaoAssociacaoDre)]
+    permission_classes = [IsAuthenticated & (PermissaoAssociacao | PermissaoAssociacaoDre | PermissaoDadosUnidadeDre)]
     lookup_field = 'uuid'
     queryset = Associacao.objects.all()
     serializer_class = AssociacaoSerializer

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -19,6 +19,7 @@ from sme_ptrf_apps.users.permissoes import (
     PermissaoDadosUnidadeDre,
     PermissaoExportarDadosAssociacao,
     PermissaoRegularidadeDre,
+    PermissaoSituacaoFinanceira
 )
 
 from ....dre.services import (
@@ -59,7 +60,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
                          mixins.UpdateModelMixin,
                          GenericViewSet, ):
-    permission_classes = [IsAuthenticated & (PermissaoAssociacao | PermissaoAssociacaoDre | PermissaoDadosUnidadeDre)]
+    permission_classes = [IsAuthenticated & (PermissaoAssociacao | PermissaoAssociacaoDre | PermissaoDadosUnidadeDre | PermissaoSituacaoFinanceira)]
     lookup_field = 'uuid'
     queryset = Associacao.objects.all()
     serializer_class = AssociacaoSerializer

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -18,6 +18,7 @@ from sme_ptrf_apps.users.permissoes import (
     PermissaoAssociacaoDre,
     PermissaoDadosUnidadeDre,
     PermissaoExportarDadosAssociacao,
+    PermissaoRegularidadeDre,
 )
 
 from ....dre.services import (
@@ -329,12 +330,12 @@ class AssociacoesViewSet(mixins.ListModelMixin,
         processos = associacao.processos.all()
         return Response(ProcessoAssociacaoRetrieveSerializer(processos, many=True).data)
 
-    @action(detail=True, url_path='verificacao-regularidade', methods=['get'])
+    @action(detail=True, url_path='verificacao-regularidade', methods=['get'], permission_classes=[IsAuthenticated & ((PermissaoAssociacaoDre & PermissaoRegularidadeDre))])
     def verificacao_regularidade(self, request, uuid=None):
         verificacao = verifica_regularidade_associacao(uuid)
         return Response(verificacao)
 
-    @action(detail=True, url_path='marca-item-verificacao', methods=['get'])
+    @action(detail=True, url_path='marca-item-verificacao', methods=['get'], permission_classes=[IsAuthenticated & ((PermissaoAssociacaoDre & PermissaoRegularidadeDre))])
     def marca_item_verificacao(self, request, uuid=None):
         item = request.query_params.get('item')
 
@@ -362,7 +363,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
 
         return Response(result, status=status_code)
 
-    @action(detail=True, url_path='desmarca-item-verificacao', methods=['get'])
+    @action(detail=True, url_path='desmarca-item-verificacao', methods=['get'], permission_classes=[IsAuthenticated & ((PermissaoAssociacaoDre & PermissaoRegularidadeDre))])
     def desmarca_item_verificacao(self, request, uuid=None):
         item = request.query_params.get('item')
 
@@ -390,7 +391,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
 
         return Response(result, status=status_code)
 
-    @action(detail=True, url_path='marca-lista-verificacao', methods=['get'])
+    @action(detail=True, url_path='marca-lista-verificacao', methods=['get'], permission_classes=[IsAuthenticated & ((PermissaoAssociacaoDre & PermissaoRegularidadeDre))])
     def marca_lista_verificacao(self, request, uuid=None):
         lista = request.query_params.get('lista')
 
@@ -418,7 +419,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
 
         return Response(result, status=status_code)
 
-    @action(detail=True, url_path='desmarca-lista-verificacao', methods=['get'])
+    @action(detail=True, url_path='desmarca-lista-verificacao', methods=['get'], permission_classes=[IsAuthenticated & ((PermissaoAssociacaoDre & PermissaoRegularidadeDre))])
     def desmarca_lista_verificacao(self, request, uuid=None):
         lista = request.query_params.get('lista')
 
@@ -446,7 +447,7 @@ class AssociacoesViewSet(mixins.ListModelMixin,
 
         return Response(result, status=status_code)
 
-    @action(detail=True, url_path='atualiza-itens-verificacao', methods=['post'])
+    @action(detail=True, url_path='atualiza-itens-verificacao', methods=['post'], permission_classes=[IsAuthenticated & (PermissaoAssociacaoDre & PermissaoRegularidadeDre)])
     def atualiza_itens_verificacao(self, request, uuid=None):
         itens = request.data
 

--- a/sme_ptrf_apps/core/tests/conftest.py
+++ b/sme_ptrf_apps/core/tests/conftest.py
@@ -109,6 +109,19 @@ def permissoes_dadosdiretoria_dre():
 
 
 @pytest.fixture
+def permissoes_regularidade_dre():
+    permissoes = [
+        Permission.objects.create(
+            name="visualizar regularidade dre", 
+            codename='view_regularidade_dre', 
+            content_type=ContentType.objects.filter(app_label="auth").first()
+        ),
+    ]
+
+    return permissoes
+
+
+@pytest.fixture
 def grupo_associacao(permissoes_associacao):
     g = Grupo.objects.create(name="associacao")
     g.permissions.add(*permissoes_associacao)
@@ -179,6 +192,13 @@ def grupo_dadosdiretoria_dre(permissoes_dadosdiretoria_dre):
 
 
 @pytest.fixture
+def grupo_regularidade_dre(permissoes_regularidade_dre):
+    g = Grupo.objects.create(name="gruporegulariade_dre")
+    g.permissions.add(*permissoes_regularidade_dre)
+    return g
+
+
+@pytest.fixture
 def usuario_permissao_associacao(
         unidade,
         grupo_associacao,
@@ -190,7 +210,8 @@ def usuario_permissao_associacao(
         grupo_unidades,
         grupo_dashboard_dre,
         grupo_associacao_dre,
-        grupo_dadosdiretoria_dre):
+        grupo_dadosdiretoria_dre,
+        grupo_regularidade_dre):
 
     from django.contrib.auth import get_user_model
     senha = 'Sgp0418'
@@ -209,7 +230,8 @@ def usuario_permissao_associacao(
         grupo_unidades,
         grupo_dashboard_dre,
         grupo_associacao_dre,
-        grupo_dadosdiretoria_dre)
+        grupo_dadosdiretoria_dre,
+        grupo_regularidade_dre)
     user.save()
     return user
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_retrieve_associacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_retrieve_associacao.py
@@ -1,8 +1,12 @@
 import json
 
 import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from model_bakery import baker
 from rest_framework import status
+
+from sme_ptrf_apps.users.models import Grupo
 
 from ....core.choices import MembroEnum, RepresentacaoCargo
 
@@ -104,3 +108,170 @@ def test_api_retrieve_associacao(jwt_authenticated_client_a, associacao, preside
 
         assert response.status_code == status.HTTP_200_OK
         assert result == result_esperado
+
+
+@pytest.fixture
+def permissoes_ver_dados_unidade_dre():
+    permissoes = [
+        Permission.objects.create(
+            name="Ver Dados Unidade", 
+            codename='view_dados_unidade_dre', 
+            content_type=ContentType.objects.filter(app_label="auth").first()
+        ),
+    ]
+
+    return permissoes
+
+
+@pytest.fixture
+def grupo_permissoes_unidades_dre(permissoes_ver_dados_unidade_dre):
+    g = Grupo.objects.create(name="VerDadosUnidade")
+    g.permissions.add(*permissoes_ver_dados_unidade_dre)
+    return g
+
+
+@pytest.fixture
+def usuario_permissao_unidades_dre(unidade, grupo_permissoes_unidades_dre):
+
+    from django.contrib.auth import get_user_model
+    senha = 'Sgp0418'
+    login = '7210418'
+    email = 'sme@amcom.com.br'
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email)
+    user.unidades.add(unidade)
+    user.groups.add(grupo_permissoes_unidades_dre)
+    user.save()
+    return user
+
+
+@pytest.fixture
+def usuario_sem_permissao_unidades_dre(unidade):
+    from django.contrib.auth import get_user_model
+    senha = 'Sgp0419'
+    login = '7210419'
+    email = 'sme@amcom.com.br'
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email)
+    user.unidades.add(unidade)
+    user.save()
+    return user
+
+
+@pytest.fixture
+def jwt_authenticated_client_com_permissao(client, usuario_permissao_unidades_dre):
+    from unittest.mock import patch
+
+    from rest_framework.test import APIClient
+    api_client = APIClient()
+    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
+        data = {
+            "nome": "LUCIA HELENA",
+            "cpf": "62085077072",
+            "email": "luh@gmail.com",
+            "login": "7210418"
+        }
+        mock_post.return_value.ok = True
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = data
+        resp = api_client.post('/api/login', {'login': usuario_permissao_unidades_dre.username,
+                                              'senha': usuario_permissao_unidades_dre.password}, format='json')
+        resp_data = resp.json()
+        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    return api_client
+
+
+@pytest.fixture
+def jwt_authenticated_client_sem_permissao(client, usuario_sem_permissao_unidades_dre):
+    from unittest.mock import patch
+
+    from rest_framework.test import APIClient
+    api_client = APIClient()
+    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
+        data = {
+            "nome": "LUCIA HELENA",
+            "cpf": "62085077072",
+            "email": "luh@gmail.com",
+            "login": "7210419"
+        }
+        mock_post.return_value.ok = True
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = data
+        resp = api_client.post('/api/login', {'login': usuario_sem_permissao_unidades_dre.username,
+                                              'senha': usuario_sem_permissao_unidades_dre.password}, format='json')
+        resp_data = resp.json()
+        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    return api_client
+
+
+def test_api_retrieve_associacao_apenas_com_permissao_ver_dados_unidade_dre(jwt_authenticated_client_com_permissao, associacao, presidente_associacao, presidente_conselho_fiscal, censo):
+    from unittest.mock import patch
+    with patch('sme_ptrf_apps.core.api.views.associacoes_viewset.atualiza_dados_unidade') as mock_patch:
+        response = jwt_authenticated_client_com_permissao.get(f'/api/associacoes/{associacao.uuid}/', content_type='application/json')
+        result = json.loads(response.content)
+
+        mock_patch.return_value = None
+
+        result_esperado = {
+            'uuid': f'{associacao.uuid}',
+            'ccm': f'{associacao.ccm}',
+            'cnpj': f'{associacao.cnpj}',
+            'email': f'{associacao.email}',
+            'nome': f'{associacao.nome}',
+            'status_regularidade': f'{associacao.status_regularidade}',
+            'presidente_associacao': {
+                'nome': presidente_associacao.nome,
+                'email': presidente_associacao.email,
+                'cargo_educacao': presidente_associacao.cargo_educacao
+            },
+            'presidente_conselho_fiscal': {
+                'nome': presidente_conselho_fiscal.nome,
+                'email': presidente_conselho_fiscal.email,
+                'cargo_educacao': presidente_conselho_fiscal.cargo_educacao
+            },
+            'processo_regularidade': '123456',
+            'unidade': {
+                'codigo_eol': f'{associacao.unidade.codigo_eol}',
+                'dre': {
+                    'codigo_eol': f'{associacao.unidade.dre.codigo_eol}',
+                    'nome': f'{associacao.unidade.dre.nome}',
+                    'sigla': f'{associacao.unidade.dre.sigla}',
+                    'tipo_unidade': 'DRE',
+                    'uuid': f'{associacao.unidade.dre.uuid}'
+                },
+                'dre_cnpj': f'{associacao.unidade.dre_cnpj}',
+                'dre_designacao_ano': f'{associacao.unidade.dre_designacao_ano}',
+                'dre_designacao_portaria': f'{associacao.unidade.dre_designacao_portaria}',
+                'dre_diretor_regional_nome': f'{associacao.unidade.dre_diretor_regional_nome}',
+                'dre_diretor_regional_rf': f'{associacao.unidade.dre_diretor_regional_rf}',
+                'nome': f'{associacao.unidade.nome}',
+                'sigla': f'{associacao.unidade.sigla}',
+                'tipo_unidade': f'{associacao.unidade.tipo_unidade}',
+                'uuid': f'{associacao.unidade.uuid}',
+                'email': f'{associacao.unidade.email}',
+                'qtd_alunos': associacao.unidade.qtd_alunos,
+                'tipo_logradouro': f'{associacao.unidade.tipo_logradouro}',
+                'logradouro': f'{associacao.unidade.logradouro}',
+                'numero': f'{associacao.unidade.numero}',
+                'complemento': f'{associacao.unidade.complemento}',
+                'bairro': f'{associacao.unidade.bairro}',
+                'cep': f'{associacao.unidade.cep}',
+                'telefone': f'{associacao.unidade.telefone}',
+                'diretor_nome': f'{associacao.unidade.diretor_nome}',
+            },
+        }
+
+        assert response.status_code == status.HTTP_200_OK
+        assert result == result_esperado
+
+
+def test_api_retrieve_associacao_apenas_sem_permissao_ver_dados_unidade_dre(jwt_authenticated_client_sem_permissao, associacao, presidente_associacao, presidente_conselho_fiscal, censo):
+    from unittest.mock import patch
+    with patch('sme_ptrf_apps.core.api.views.associacoes_viewset.atualiza_dados_unidade') as mock_patch:
+        response = jwt_authenticated_client_sem_permissao.get(f'/api/associacoes/{associacao.uuid}/', content_type='application/json')
+        result = json.loads(response.content)
+
+        mock_patch.return_value = None
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+

--- a/sme_ptrf_apps/users/permissoes.py
+++ b/sme_ptrf_apps/users/permissoes.py
@@ -212,6 +212,28 @@ class PermissaoDadosUnidadeDre(PermissaoCRUD):
         return self.has_perms(perms, request.user)
 
 
+class PermissaoRegularidadeDre(PermissaoCRUD):
+    perms_map = {
+        'GET': ['view_regularidade_dre'],
+        'OPTIONS': ['view_regularidade_dre'],
+        'HEAD': ['view_regularidade_dre'],
+        'POST': ['view_regularidade_dre'],
+        'PUT': ['view_regularidade_dre'],
+        'PATCH': ['view_regularidade_dre'],
+        'DELETE': ['view_regularidade_dre'],
+    }
+
+    def get_required_permissions(self, method):
+        if method not in self.perms_map:
+            raise exceptions.MethodNotAllowed(method)
+
+        return [perm for perm in self.perms_map[method]]
+
+    def has_permission(self, request, view):
+        perms = self.get_required_permissions(request.method)
+        return self.has_perms(perms, request.user)
+
+
 class PermissaoDadosDiretoriaDre(PermissaoCRUD):
     perms_map = {
         'GET': ['view_dadosdiretoria_dre'],

--- a/sme_ptrf_apps/users/permissoes.py
+++ b/sme_ptrf_apps/users/permissoes.py
@@ -234,6 +234,28 @@ class PermissaoRegularidadeDre(PermissaoCRUD):
         return self.has_perms(perms, request.user)
 
 
+class PermissaoSituacaoFinanceira(PermissaoCRUD):
+    perms_map = {
+        'GET': ['view_situacao_financeira_dre'],
+        'OPTIONS': ['view_situacao_financeira_dre'],
+        'HEAD': ['view_situacao_financeira_dre'],
+        'POST': ['view_situacao_financeira_dre'],
+        'PUT': ['view_situacao_financeira_dre'],
+        'PATCH': ['view_situacao_financeira_dre'],
+        'DELETE': ['view_situacao_financeira_dre'],
+    }
+
+    def get_required_permissions(self, method):
+        if method not in self.perms_map:
+            raise exceptions.MethodNotAllowed(method)
+
+        return [perm for perm in self.perms_map[method]]
+
+    def has_permission(self, request, view):
+        perms = self.get_required_permissions(request.method)
+        return self.has_perms(perms, request.user)
+
+
 class PermissaoDadosDiretoriaDre(PermissaoCRUD):
     perms_map = {
         'GET': ['view_dadosdiretoria_dre'],

--- a/sme_ptrf_apps/users/permissoes.py
+++ b/sme_ptrf_apps/users/permissoes.py
@@ -190,6 +190,28 @@ class PermissaoAssociacaoDre(PermissaoCRUD):
         return self.has_perms(perms, request.user)
 
 
+class PermissaoDadosUnidadeDre(PermissaoCRUD):
+    perms_map = {
+        'GET': ['view_dados_unidade_dre'],
+        'OPTIONS': ['view_dados_unidade_dre'],
+        'HEAD': ['view_dados_unidade_dre'],
+        'POST': ['view_dados_unidade_dre'],
+        'PUT': ['view_dados_unidade_dre'],
+        'PATCH': ['view_dados_unidade_dre'],
+        'DELETE': ['view_dados_unidade_dre'],
+    }
+
+    def get_required_permissions(self, method):
+        if method not in self.perms_map:
+            raise exceptions.MethodNotAllowed(method)
+
+        return [perm for perm in self.perms_map[method]]
+
+    def has_permission(self, request, view):
+        perms = self.get_required_permissions(request.method)
+        return self.has_perms(perms, request.user)
+
+
 class PermissaoDadosDiretoriaDre(PermissaoCRUD):
     perms_map = {
         'GET': ['view_dadosdiretoria_dre'],


### PR DESCRIPTION
Esse PR contém:

* Ao acessar a funcionalidade DRE-Associações:

* Exibir o item de sub-menu "Ver dados Unidade" apenas se o usuário tiver a permissão de ver dados unidade;

* Exibir o item de sub-menu "Ver regularidade" apenas se o usuário tiver a permissão de ver regularidade;

* Exibir o item de sub-menu "Ver situação financeira" apenas se o usuário tiver a permissão de ver situação financeira;