### PR TITLE
feat(29917): Valida exclusão de ações

### DIFF
--- a/sme_ptrf_apps/core/api/views/acoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/acoes_viewset.py
@@ -1,8 +1,9 @@
-from rest_framework import mixins
+from rest_framework import mixins, status
 
 from rest_framework.permissions import IsAuthenticated
 
 from rest_framework.viewsets import GenericViewSet
+from rest_framework.response import Response
 
 from ..serializers.acao_serializer import AcaoSerializer
 from ...models import Acao
@@ -27,3 +28,19 @@ class AcoesViewSet(mixins.ListModelMixin,
             qs = qs.filter(nome__unaccent__icontains=nome)
 
         return qs.order_by('nome')
+
+    def destroy(self, request, *args, **kwargs):
+        from django.db.models.deletion import ProtectedError
+
+        obj = self.get_object()
+
+        try:
+            self.perform_destroy(obj)
+        except ProtectedError:
+            content = {
+                'erro': 'ProtectedError',
+                'mensagem': 'Essa ação não pode ser excluida porque está sendo usada.'
+            }
+            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/sme_ptrf_apps/core/tests/tests_api_acoes/test_acao_delete.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/test_acao_delete.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from rest_framework import status
 
@@ -18,3 +19,24 @@ def test_delete_acao(
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
     assert not Acao.objects.filter(uuid=acao_x.uuid).exists()
+
+
+def test_delete_acao_ja_usada(
+    jwt_authenticated_client_a,
+    acao_x,
+    acao_associacao_eco_delta_000087_x
+):
+    assert Acao.objects.filter(uuid=acao_x.uuid).exists()
+
+    response = jwt_authenticated_client_a.delete(
+        f'/api/acoes/{acao_x.uuid}/', content_type='application/json')
+
+    result = json.loads(response.content)
+
+    esperado = {
+        "erro": 'ProtectedError',
+        "mensagem": "Essa ação não pode ser excluida porque está sendo usada.",
+    }
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == esperado


### PR DESCRIPTION
Esse PR altera na API a exclusão de ações para retornar uma mensagem de erro ao tentar excluir ação
já usada.