### PR TITLE
Feat(29908) Parametrização de Períodos (ajustes 2)

### DIFF
--- a/sme_ptrf_apps/core/api/views/periodos_viewset.py
+++ b/sme_ptrf_apps/core/api/views/periodos_viewset.py
@@ -35,7 +35,7 @@ class PeriodosViewSet(mixins.ListModelMixin,
     def get_serializer_class(self):
         if self.action == 'retrieve':
             return PeriodoRetrieveSerializer
-        elif self.action == 'create':
+        elif self.action in ['create', 'update', 'partial_update']:
             return PeriodoCreateSerializer
         else:
             return PeriodoSerializer

--- a/sme_ptrf_apps/core/api/views/periodos_viewset.py
+++ b/sme_ptrf_apps/core/api/views/periodos_viewset.py
@@ -40,6 +40,22 @@ class PeriodosViewSet(mixins.ListModelMixin,
         else:
             return PeriodoSerializer
 
+    def destroy(self, request, *args, **kwargs):
+        from django.db.models.deletion import ProtectedError
+
+        obj = self.get_object()
+
+        try:
+            self.perform_destroy(obj)
+        except ProtectedError:
+            content = {
+                'erro': 'ProtectedError',
+                'mensagem': 'Esse período não pode ser excluido porque está sendo usado na aplicação.'
+            }
+            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
     @action(detail=False)
     def lookup(self, _):
         return Response(PeriodoLookUpSerializer(self.queryset.order_by('-referencia'), many=True).data)

--- a/sme_ptrf_apps/core/models/periodo.py
+++ b/sme_ptrf_apps/core/models/periodo.py
@@ -42,7 +42,7 @@ class Periodo(ModeloBase):
     @property
     def editavel(self):
         # O período não pode ser editado pelo usuário se houver um período que o referencia como período anterior
-        return self.periodo_seguinte.exists()
+        return not self.periodo_seguinte.exists()
 
     @classmethod
     def periodo_atual(cls):

--- a/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_delete.py
+++ b/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_delete.py
@@ -1,4 +1,6 @@
 import pytest
+import json
+
 from rest_framework import status
 
 from sme_ptrf_apps.core.models import Periodo
@@ -18,3 +20,23 @@ def test_delete_periodo(
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
     assert not Periodo.objects.filter(uuid=periodo_2021_2.uuid).exists()
+
+
+def test_delete_periodo_ja_usado(
+    jwt_authenticated_client_a,
+    periodo_2021_1,
+    periodo_2021_2
+):
+
+    response = jwt_authenticated_client_a.delete(
+        f'/api/periodos/{periodo_2021_1.uuid}/', content_type='application/json')
+
+    result = json.loads(response.content)
+
+    esperado = {
+        "erro": 'ProtectedError',
+        "mensagem": "Esse período não pode ser excluido porque está sendo usado na aplicação.",
+    }
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == esperado

--- a/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_update.py
+++ b/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_update.py
@@ -10,9 +10,10 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def payload_update_periodo(periodo_2021_2):
+def payload_update_periodo(periodo_2021_2, periodo_2021_1):
     payload = {
         'data_prevista_repasse': '2021-07-01',
+        'periodo_anterior': f'{periodo_2021_1.uuid}'
     }
     return payload
 


### PR DESCRIPTION
Esse PR faz ajustes na API necessários para resolver problemas encontrados no desenvolvimento do front:
- Atualização do campo período anterior
- Cálculo do campo ' editável'
- Tratamento de deleção de períodos referenciados na aplicação
