### PR TITLE
Finalizando Feature 29886 - ajuste no texto do teste teste test_delete_periodo_ja_usado

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_delete.py
+++ b/sme_ptrf_apps/core/tests/tests_api_periodos/test_periodo_delete.py
@@ -35,7 +35,7 @@ def test_delete_periodo_ja_usado(
 
     esperado = {
         "erro": 'ProtectedError',
-        "mensagem": "Esse período não pode ser excluido porque está sendo usado na aplicação.",
+        "mensagem": "Esse período não pode ser excluído porque está sendo usado na aplicação.",
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Ajustando texto de exclusão de associacao não permitida no teste test_delete_periodo_ja_usado