### PR TITLE
feat(34030): Altera api resumo conciliação

### DIFF
--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -6,7 +6,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from sme_ptrf_apps.users.permissoes import PermissaoPrestacaoConta, PermissaoVerConciliacaoBancaria, PermissaoEditarConciliacaoBancaria
+from sme_ptrf_apps.users.permissoes import (PermissaoPrestacaoConta, PermissaoVerConciliacaoBancaria,
+                                            PermissaoEditarConciliacaoBancaria)
 
 from ....despesas.api.serializers.rateio_despesa_serializer import RateioDespesaListaSerializer
 from ....receitas.api.serializers.receita_serializer import ReceitaListaSerializer
@@ -14,16 +15,17 @@ from ...models import AcaoAssociacao, ContaAssociacao, ObservacaoConciliacao, Pe
 from ...services import (
     despesas_conciliadas_por_conta_e_acao_na_conciliacao,
     despesas_nao_conciliadas_por_conta_e_acao_no_periodo,
-    info_conciliacao_pendente,
     receitas_conciliadas_por_conta_e_acao_na_conciliacao,
     receitas_nao_conciliadas_por_conta_e_acao_no_periodo,
+    info_resumo_conciliacao,
 )
 
 logger = logging.getLogger(__name__)
 
 
 class ConciliacoesViewSet(GenericViewSet):
-    permission_classes = [IsAuthenticated & (PermissaoPrestacaoConta | PermissaoVerConciliacaoBancaria | PermissaoEditarConciliacaoBancaria)]
+    permission_classes = [IsAuthenticated & (
+        PermissaoPrestacaoConta | PermissaoVerConciliacaoBancaria | PermissaoEditarConciliacaoBancaria)]
     queryset = ObservacaoConciliacao.objects.all()
 
     @action(detail=False, methods=['get'], url_path='tabela-valores-pendentes')
@@ -58,7 +60,7 @@ class ConciliacoesViewSet(GenericViewSet):
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        result = info_conciliacao_pendente(periodo=periodo, conta_associacao=conta_associacao)
+        result = info_resumo_conciliacao(periodo=periodo, conta_associacao=conta_associacao)
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=['get'])

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -4,6 +4,7 @@ from .conciliacao_services import (
     info_conciliacao_pendente,
     receitas_conciliadas_por_conta_e_acao_na_conciliacao,
     receitas_nao_conciliadas_por_conta_e_acao_no_periodo,
+    info_resumo_conciliacao,
 )
 from .exporta_associacao import gerar_planilha
 from .implantacao_saldos_services import implanta_saldos_da_associacao, implantacoes_de_saldo_da_associacao

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -1,4 +1,4 @@
-from sme_ptrf_apps.core.models import Associacao
+from sme_ptrf_apps.core.models import Associacao, FechamentoPeriodo
 from sme_ptrf_apps.despesas.models import RateioDespesa
 from sme_ptrf_apps.receitas.models import Receita
 
@@ -141,4 +141,179 @@ def receitas_conciliadas_por_conta_e_acao_no_periodo(conta_associacao, acao_asso
 
     return dataset.all()
 
+
+def info_resumo_conciliacao(periodo, conta_associacao):
+    info_conta = info_conciliacao_conta_associacao_no_periodo(periodo=periodo,
+                                                              conta_associacao=conta_associacao)
+
+    saldo_anterior = saldo_anterior_total_conta_associacao_no_periodo(conta_associacao=conta_associacao,
+                                                                      periodo=periodo)
+
+    saldo_posterior_total = (
+        saldo_anterior +
+        info_conta['receitas_no_periodo'] -
+        info_conta['despesas_no_periodo']
+    )
+
+    saldo_posterior_conciliado = (
+        saldo_anterior +
+        info_conta['receitas_conciliadas'] -
+        info_conta['despesas_conciliadas']
+    )
+
+    saldo_posterior_nao_conciliado = (
+        saldo_anterior +
+        info_conta['receitas_nao_conciliadas'] -
+        info_conta['despesas_nao_conciliadas']
+    )
+
+    info = {
+        'saldo_anterior': saldo_anterior,
+
+        'receitas_total': info_conta['receitas_no_periodo'],
+        'receitas_conciliadas': info_conta['receitas_conciliadas'],
+        'receitas_nao_conciliadas': info_conta['receitas_nao_conciliadas'],
+
+        'despesas_total': info_conta['despesas_no_periodo'],
+        'despesas_conciliadas': info_conta['despesas_conciliadas'],
+        'despesas_nao_conciliadas': info_conta['despesas_nao_conciliadas'],
+
+        'saldo_posterior_total': saldo_posterior_total,
+        'saldo_posterior_conciliado': saldo_posterior_conciliado,
+        'saldo_posterior_nao_conciliado': saldo_posterior_nao_conciliado,
+    }
+
+    return info
+
+
+def info_conciliacao_conta_associacao_no_periodo(periodo, conta_associacao):
+    def resultado_vazio():
+        return {
+            'receitas_no_periodo': 0,
+            'despesas_no_periodo': 0,
+            'receitas_nao_conciliadas': 0,
+            'despesas_nao_conciliadas': 0,
+            'receitas_conciliadas': 0,
+            'despesas_conciliadas': 0,
+        }
+
+    def sumariza_conciliacao_receitas_do_periodo_e_conta(periodo, conta_associacao, info):
+
+        receitas_conciliadas = receitas_conciliadas_por_conta_na_conciliacao(
+            conta_associacao=conta_associacao,
+            periodo=periodo)
+
+        for receita_conciliada in receitas_conciliadas:
+            info['receitas_no_periodo'] += receita_conciliada.valor
+            info['receitas_conciliadas'] += receita_conciliada.valor
+
+        receitas_nao_conciliadas = receitas_nao_conciliadas_por_conta_no_periodo(
+            conta_associacao=conta_associacao,
+            periodo=periodo)
+
+        for receita_nao_conciliada in receitas_nao_conciliadas:
+            info['receitas_no_periodo'] += receita_nao_conciliada.valor
+            info['receitas_nao_conciliadas'] += receita_nao_conciliada.valor
+
+        return info
+
+    def sumariza_conciliacao_despesas_do_periodo_e_conta(periodo, conta_associacao, info, ):
+        rateios_conciliados = despesas_conciliadas_por_conta_na_conciliacao(
+            conta_associacao=conta_associacao,
+            periodo=periodo)
+
+        for rateio_conciliado in rateios_conciliados:
+            info['despesas_no_periodo'] += rateio_conciliado.valor_rateio
+            info['despesas_conciliadas'] += rateio_conciliado.valor_rateio
+
+        rateios_nao_conciliados = despesas_nao_conciliadas_por_conta_no_periodo(
+            conta_associacao=conta_associacao,
+            periodo=periodo)
+
+        for rateio_nao_conciliado in rateios_nao_conciliados:
+            info['despesas_no_periodo'] += rateio_nao_conciliado.valor_rateio
+            info['despesas_nao_conciliadas'] += rateio_nao_conciliado.valor_rateio
+
+        return info
+
+    info = resultado_vazio()
+
+    info = sumariza_conciliacao_receitas_do_periodo_e_conta(periodo=periodo,
+                                                            conta_associacao=conta_associacao,
+                                                            info=info)
+
+    info = sumariza_conciliacao_despesas_do_periodo_e_conta(periodo=periodo,
+                                                            conta_associacao=conta_associacao,
+                                                            info=info)
+
+    return info
+
+
+def receitas_conciliadas_por_conta_na_conciliacao(conta_associacao, periodo):
+    dataset = periodo.receitas_conciliadas_no_periodo.filter(conta_associacao=conta_associacao)
+
+    return dataset.all()
+
+
+def receitas_nao_conciliadas_por_conta_no_periodo(conta_associacao, periodo):
+    dataset = Receita.objects.filter(conta_associacao=conta_associacao).filter(
+        conferido=False)
+
+    # No caso de despesas não conciliadas todas devem ser exibidas até a data limite do período
+    if periodo.data_fim_realizacao_despesas:
+        dataset = dataset.filter(data__lte=periodo.data_fim_realizacao_despesas)
+
+    return dataset.all()
+
+
+def despesas_conciliadas_por_conta_na_conciliacao(conta_associacao, periodo):
+    dataset = periodo.despesas_conciliadas_no_periodo.filter(conta_associacao=conta_associacao)
+
+    return dataset.all()
+
+
+def despesas_nao_conciliadas_por_conta_no_periodo(conta_associacao, periodo):
+    dataset = RateioDespesa.objects.filter(conta_associacao=conta_associacao).filter(conferido=False)
+
+    # No caso de despesas não conciliadas todas devem ser exibidas até a data limite do período
+    if periodo.data_fim_realizacao_despesas:
+        dataset = dataset.filter(despesa__data_documento__lte=periodo.data_fim_realizacao_despesas)
+
+    return dataset.all()
+
+
+def saldo_anterior_total_conta_associacao_no_periodo(conta_associacao, periodo):
+
+    def saldo_anterior_periodo_fechado_sumarizado(fechamentos_periodo):
+        saldo_anterior_total = 0
+
+        for fechamento_periodo in fechamentos_periodo:
+            saldo_anterior_total += fechamento_periodo.saldo_anterior
+        return saldo_anterior_total
+
+    def saldo_posterior_periodo_fechado_sumarizado(fechamentos_periodo):
+        saldo_posterior_total = 0
+        for fechamento_periodo in fechamentos_periodo:
+            saldo_posterior_total += fechamento_periodo.saldo_reprogramado
+        return saldo_posterior_total
+
+    def saldo_periodo_aberto_sumarizado(periodo, conta_associacao):
+
+        if not periodo or not periodo.periodo_anterior:
+            return 0.00
+
+        fechamentos_periodo_anterior = FechamentoPeriodo.fechamentos_da_conta_no_periodo(
+            conta_associacao=conta_associacao,
+            periodo=periodo.periodo_anterior)
+
+        saldo = saldo_posterior_periodo_fechado_sumarizado(fechamentos_periodo_anterior)
+
+        return saldo
+
+    fechamentos_periodo = FechamentoPeriodo.fechamentos_da_conta_no_periodo(conta_associacao=conta_associacao,
+                                                                            periodo=periodo)
+    if fechamentos_periodo:
+        return saldo_anterior_periodo_fechado_sumarizado(fechamentos_periodo)
+    else:
+        return saldo_periodo_aberto_sumarizado(periodo, conta_associacao)
 

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
@@ -5,8 +5,35 @@ from model_bakery import baker
 
 
 @pytest.fixture
+def periodo_2019_2():
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=datetime.date(2019, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2019, 12, 31),
+        periodo_anterior=None
+    )
+
+
+@pytest.fixture
+def periodo_2020_1(periodo_2019_2):
+    return baker.make(
+        'Periodo',
+        referencia='2020.1',
+        data_inicio_realizacao_despesas=datetime.date(2020, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 6, 30),
+        periodo_anterior=periodo_2019_2
+    )
+
+
+@pytest.fixture
 def tipo_receita_repasse():
     return baker.make('TipoReceita', nome='Repasse', e_repasse=True)
+
+
+@pytest.fixture
+def tipo_receita_outras():
+    return baker.make('TipoReceita', nome='Outras')
 
 
 @pytest.fixture
@@ -44,6 +71,23 @@ def receita_2020_1_role_repasse_cheque_conferida(associacao, conta_associacao_ch
 
 
 @pytest.fixture
+def receita_2020_1_role_outras_conferida(associacao, conta_associacao_cartao, acao_associacao_role_cultural,
+                                         tipo_receita_outras, periodo_2020_1):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        tipo_receita=tipo_receita_outras,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=periodo_2020_1,
+    )
+
+
+@pytest.fixture
 def receita_2020_1_role_repasse_nao_conferida(associacao, conta_associacao_cartao, acao_associacao_role_cultural,
                                               tipo_receita_repasse):
     return baker.make(
@@ -54,6 +98,22 @@ def receita_2020_1_role_repasse_nao_conferida(associacao, conta_associacao_carta
         conta_associacao=conta_associacao_cartao,
         acao_associacao=acao_associacao_role_cultural,
         tipo_receita=tipo_receita_repasse,
+        conferido=False,
+        periodo_conciliacao=None,
+    )
+
+
+@pytest.fixture
+def receita_2020_1_role_outras_nao_conferida(associacao, conta_associacao_cartao, acao_associacao_role_cultural,
+                                             tipo_receita_outras):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        tipo_receita=tipo_receita_outras,
         conferido=False,
         periodo_conciliacao=None,
     )
@@ -413,4 +473,33 @@ def repasse_2020_1_realizado(associacao, conta_associacao, acao_associacao, peri
         status='REALIZADO',
         realizado_capital=True,
         realizado_custeio=True
+    )
+
+
+@pytest.fixture
+def fechamento_periodo_2019_2_1000(periodo_2019_2, associacao, conta_associacao_cartao, acao_associacao, ):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_2019_2,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=None,
+        total_receitas_capital=1000,
+        status='FECHADO'
+    )
+
+
+@pytest.fixture
+def fechamento_periodo_2019_2_role_1000(periodo_2019_2, associacao, conta_associacao_cartao,
+                                        acao_associacao_role_cultural):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_2019_2,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        fechamento_anterior=None,
+        total_receitas_capital=1000,
+        status='FECHADO'
     )

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_tabela_valores_pendentes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_tabela_valores_pendentes.py
@@ -15,9 +15,11 @@ def test_tabela_valores_pendentes(
     receita_2019_2_role_repasse_conferida,
     receita_2019_2_role_repasse_conferida_no_periodo,
     receita_2020_1_role_repasse_conferida,
-    receita_2020_1_role_repasse_nao_conferida,
     receita_2020_1_ptrf_repasse_conferida,
     receita_2020_1_role_repasse_cheque_conferida,
+    receita_2020_1_role_outras_conferida,
+    receita_2020_1_role_repasse_nao_conferida,
+    receita_2020_1_role_outras_nao_conferida,
     despesa_2019_2,
     rateio_despesa_2019_role_conferido,
     rateio_despesa_2019_role_conferido_no_periodo,
@@ -26,29 +28,26 @@ def test_tabela_valores_pendentes(
     rateio_despesa_2020_role_nao_conferido,
     rateio_despesa_2020_ptrf_conferido,
     rateio_despesa_2020_role_cheque_conferido,
+    fechamento_periodo_2019_2_1000,
+    fechamento_periodo_2019_2_role_1000
 
 ):
     response = jwt_authenticated_client_a.get(
-        f'/api/conciliacoes/tabela-valores-pendentes/?periodo={periodo_2020_1.uuid}&conta_associacao={conta_associacao_cartao.uuid}', content_type='application/json')
+        f'/api/conciliacoes/tabela-valores-pendentes/?periodo={periodo_2020_1.uuid}&conta_associacao={conta_associacao_cartao.uuid}',
+        content_type='application/json')
     result = json.loads(response.content)
 
-    esperado = [
-        {
-            'acao_associacao_uuid': str(acao_associacao_role_cultural.uuid),
-            'acao_associacao_nome': 'Rolê Cultural',
-            'receitas_no_periodo': Decimal('300.00'),
-            'despesas_no_periodo': Decimal('300.00'),
-            'despesas_nao_conciliadas': Decimal('100.00'),
-            'receitas_nao_conciliadas': Decimal('100.00')
-        },
-        {
-            'acao_associacao_uuid': str(acao_associacao_ptrf.uuid),
-            'acao_associacao_nome': 'PTRF',
-            'receitas_no_periodo': Decimal('100.00'),
-            'despesas_no_periodo': Decimal('100.00'),
-            'despesas_nao_conciliadas': 0,
-            'receitas_nao_conciliadas': 0
-        },
-    ]
+    esperado = {
+        'saldo_anterior': Decimal('2000.00'),
+        'receitas_conciliadas': Decimal('400.00'),
+        'despesas_conciliadas': Decimal('300.00'),
+        'despesas_nao_conciliadas': Decimal('100.00'),
+        'receitas_nao_conciliadas': Decimal('200.00'),
+        'despesas_total': Decimal('400.00'),
+        'receitas_total': Decimal('600.00'),
+        'saldo_posterior_conciliado': Decimal('2100.00'),
+        'saldo_posterior_nao_conciliado': Decimal('2100.00'),
+        'saldo_posterior_total': Decimal('2200.00'),
+    }
 
     assert result == esperado


### PR DESCRIPTION
Esse PR:

Altera o r resumo de conciliação que passa a ser por conta e a incluir informações de saldo anterior e posterior.

História [AB#34030](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/34030)