### PR TITLE
feat(34020): Ajusta calculos do bloco 3 do demonstrativo financeiro PDF

### DIFF
--- a/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
@@ -1,20 +1,11 @@
 import logging
-import os
-
-import re
-from copy import copy
-from tempfile import NamedTemporaryFile
 
 from datetime import date
 
 from django.db.models import Sum
-from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.files import File
 
 from sme_ptrf_apps.core.choices import MembroEnum
-
-from sme_ptrf_apps.core.models import (FechamentoPeriodo, MembroAssociacao, ObservacaoConciliacao,
-                                       DemonstrativoFinanceiro)
+from sme_ptrf_apps.core.models import (FechamentoPeriodo, MembroAssociacao, ObservacaoConciliacao)
 from sme_ptrf_apps.despesas.models import RateioDespesa
 from sme_ptrf_apps.receitas.models import Receita
 from sme_ptrf_apps.receitas.tipos_aplicacao_recurso_receitas import (APLICACAO_CAPITAL, APLICACAO_CUSTEIO,
@@ -38,13 +29,10 @@ def gerar_dados_demonstrativo_financeiro(usuario, acoes, periodo, conta_associac
         receitas_demonstradas = Receita.receitas_da_conta_associacao_no_periodo(
             conta_associacao=conta_associacao, periodo=periodo, conferido=True)
 
-        fechamento_periodo = FechamentoPeriodo.objects.filter(
-            conta_associacao=conta_associacao, periodo__uuid=periodo.uuid).first()
-
         cabecalho = cria_cabecalho(periodo, conta_associacao, previa)
         identificacao_apm = cria_identificacao_apm(acoes)
         identificacao_conta = cria_identificacao_conta(conta_associacao)
-        resumo_por_acao = cria_resumo_por_acao(acoes, conta_associacao, periodo, fechamento_periodo)
+        resumo_por_acao = cria_resumo_por_acao(acoes, conta_associacao, periodo)
         creditos_demonstrados = cria_creditos_demonstrados(receitas_demonstradas)
         despesas_demonstradas = cria_despesas(rateios_conferidos)
         despesas_nao_demonstradas = cria_despesas(rateios_nao_conferidos)
@@ -128,7 +116,7 @@ def cria_identificacao_conta(conta_associacao):
     return identificacao_conta
 
 
-def cria_resumo_por_acao(acoes, conta_associacao, periodo, fechamento_periodo):
+def cria_resumo_por_acao(acoes, conta_associacao, periodo):
     total_valores = 0
     total_conciliacao = 0
 
@@ -139,7 +127,7 @@ def cria_resumo_por_acao(acoes, conta_associacao, periodo, fechamento_periodo):
         "despesa_nao_realizada": {'C': 0, 'K': 0, 'L': 0},
         "saldo_reprogramado_proximo": {'C': 0, 'K': 0, 'L': 0},
         "despesa_nao_demostrada_outros_periodos": {'C': 0, 'K': 0, 'L': 0},
-        "saldo_bancario": {'C': 0, 'K': 0, 'L': 0},
+        "saldo_bancario": 0,
         "valor_saldo_reprogramado_proximo_periodo": {'C': 0, 'K': 0, 'L': 0},
         "valor_saldo_bancario": {'C': 0, 'K': 0, 'L': 0},
         "credito_nao_demonstrado": {'C': 0, 'K': 0, 'L': 0},
@@ -148,13 +136,16 @@ def cria_resumo_por_acao(acoes, conta_associacao, periodo, fechamento_periodo):
 
     resumo_acoes = []
     for _, acao_associacao in enumerate(acoes):
+        fechamento_periodo = FechamentoPeriodo.fechamentos_da_acao_no_periodo(acao_associacao=acao_associacao,
+                                                                              periodo=periodo,
+                                                                              conta_associacao=conta_associacao).first()
+
         resumo_acao, totalizador = sintese_receita_despesa(acao_associacao, conta_associacao, periodo,
                                                            fechamento_periodo, totalizador)
         total_valores += resumo_acao['total_valores']
         total_conciliacao += resumo_acao['total_conciliacao']
         resumo_acoes.append(resumo_acao)
 
-    # total_valores = formata_valor(total_valores)
     total_conciliacao = formata_valor(total_conciliacao)
 
     resumo = {
@@ -169,9 +160,10 @@ def cria_resumo_por_acao(acoes, conta_associacao, periodo, fechamento_periodo):
 def sintese_receita_despesa(acao_associacao, conta_associacao, periodo, fechamento_periodo, totalizador):
     linha_custeio, totalizador = sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_periodo,
                                                  totalizador)
-    linha_capital, totalizador = sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_periodo, totalizador)
+    linha_capital, totalizador = sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_periodo,
+                                                 totalizador)
     linha_livre, totalizador = sintese_livre(linha_capital, linha_custeio, acao_associacao, conta_associacao, periodo,
-                                fechamento_periodo,totalizador)
+                                             fechamento_periodo, totalizador)
 
     valor_saldo_reprogramado_proximo_periodo_custeio = linha_custeio['valor_saldo_reprogramado_proximo_periodo_custeio']
     valor_saldo_bancario_custeio = linha_custeio['valor_saldo_bancario_custeio']
@@ -184,33 +176,60 @@ def sintese_receita_despesa(acao_associacao, conta_associacao, periodo, fechamen
                                        valor_saldo_reprogramado_proximo_periodo_capital if valor_saldo_reprogramado_proximo_periodo_capital > 0 else valor_total_reprogramado_proximo
     valor_total_reprogramado_proximo = valor_total_reprogramado_proximo + \
                                        valor_saldo_reprogramado_proximo_periodo_custeio if valor_saldo_reprogramado_proximo_periodo_custeio > 0 else valor_total_reprogramado_proximo
-    saldo_bancario = f'{formata_valor(valor_saldo_reprogramado_proximo_periodo_livre)}' if valor_saldo_reprogramado_proximo_periodo_livre != 0 else ''
+
+
+    subtotal_saldo_bancario = linha_custeio['valor_saldo_bancario_custeio'] + linha_capital[
+        'valor_saldo_bancario_capital'] + linha_livre['valor_saldo_reprogramado_proximo_periodo_livre']
 
     total_valores = valor_total_reprogramado_proximo
     total_conciliacao = \
         valor_saldo_bancario_capital + valor_saldo_bancario_custeio + valor_saldo_reprogramado_proximo_periodo_livre
 
     totalizador['total_valores'] += total_valores
-
-
+    totalizador['saldo_bancario'] += subtotal_saldo_bancario
 
     sintese = {
         "acao_associacao": acao_associacao.acao.nome,
         "linha_custeio": linha_custeio,
         "linha_capital": linha_capital,
         "linha_livre": linha_livre,
-        "saldo_bancario": saldo_bancario,
+        "saldo_bancario": subtotal_saldo_bancario,
         "total_valores": total_valores,
         "total_conciliacao": total_conciliacao
     }
     return sintese, totalizador
 
 
+def get_fechamento_anterior(conta_associacao, acao_associacao, periodo, fechamento_periodo):
+    """ Obtem o fechamento anterior de uma conta e ação com base no período ou fechamento_periodo
+
+    :param conta_associacao:
+    :param acao_associacao:
+    :param periodo:
+    :param fechamento_periodo:
+    :return: fechamento_anterior
+    """
+    if not fechamento_periodo:
+        # Se não há um fechamento_periodo (caso de prévias), define o fechamento anterior pelo periodo
+        if periodo and periodo.periodo_anterior:
+            fechamentos_acao_periodo_anterior = FechamentoPeriodo.fechamentos_da_acao_no_periodo(
+                acao_associacao=acao_associacao,
+                periodo=periodo.periodo_anterior,
+                conta_associacao=conta_associacao)
+            fechamento_anterior = fechamentos_acao_periodo_anterior.first() if fechamentos_acao_periodo_anterior else None
+        else:
+            fechamento_anterior = None
+    else:
+        # Se há um fechamento_periodo o fechamento anterior é obtido atravez dele
+        fechamento_anterior = fechamento_periodo.fechamento_anterior
+
+    return fechamento_anterior
+
+
 def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_periodo, totalizador):
-    saldo_reprogramado_anterior_custeio = \
-        fechamento_periodo \
-            .fechamento_anterior \
-            .saldo_reprogramado_custeio if fechamento_periodo and fechamento_periodo.fechamento_anterior else 0
+    fechamento_anterior = get_fechamento_anterior(conta_associacao=conta_associacao, acao_associacao=acao_associacao,
+                                                  periodo=periodo, fechamento_periodo=fechamento_periodo)
+    saldo_reprogramado_anterior_custeio = fechamento_anterior.saldo_reprogramado_custeio if fechamento_anterior else 0
 
     # Custeio
     receitas_demonstradas_custeio = Receita.receitas_da_acao_associacao_no_periodo(
@@ -256,12 +275,15 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
         despesa_realizada = f'{formata_valor(valor_custeio_rateios_demonstrados)}'
         despesa_nao_realizada = f'{formata_valor(valor_custeio_rateios_nao_demonstrados)}'
 
+
         valor_saldo_reprogramado_proximo_periodo_custeio = saldo_reprogramado_anterior_custeio + \
                                                            valor_custeio_receitas_demonstradas - \
                                                            valor_custeio_rateios_demonstrados - \
                                                            valor_custeio_rateios_nao_demonstrados
 
         saldo_reprogramado_proximo = f'{formata_valor(valor_saldo_reprogramado_proximo_periodo_custeio if valor_saldo_reprogramado_proximo_periodo_custeio > 0 else 0)}'
+
+
         despesa_nao_demostrada_outros_periodos = f'{formata_valor(valor_custeio_rateios_nao_demonstrados_periodos_anteriores)}'
         valor_saldo_bancario_custeio = valor_saldo_reprogramado_proximo_periodo_custeio + valor_custeio_rateios_nao_demonstrados + valor_custeio_rateios_nao_demonstrados_periodos_anteriores
         valor_saldo_bancario_custeio = valor_saldo_bancario_custeio if valor_saldo_bancario_custeio > 0 else 0
@@ -274,6 +296,7 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
         "despesa_nao_realizada": despesa_nao_realizada,
         "despesa_nao_demostrada_outros_periodos": despesa_nao_demostrada_outros_periodos,
         "saldo_reprogramado_proximo": saldo_reprogramado_proximo,
+        "saldo_reprogramado_proximo_vr": valor_saldo_reprogramado_proximo_periodo_custeio,
         "saldo_bancario": saldo_bancario,
         "valor_saldo_reprogramado_proximo_periodo_custeio": valor_saldo_reprogramado_proximo_periodo_custeio,
         "valor_saldo_bancario_custeio": valor_saldo_bancario_custeio,
@@ -284,9 +307,10 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
     totalizador['credito']['C'] += valor_custeio_receitas_demonstradas
     totalizador['despesa_realizada']['C'] += valor_custeio_rateios_demonstrados
     totalizador['despesa_nao_realizada']['C'] += valor_custeio_rateios_nao_demonstrados
-    totalizador['despesa_nao_demostrada_outros_periodos']['C'] += valor_custeio_rateios_nao_demonstrados_periodos_anteriores
+    totalizador['despesa_nao_demostrada_outros_periodos'][
+        'C'] += valor_custeio_rateios_nao_demonstrados_periodos_anteriores
     totalizador['saldo_reprogramado_proximo']['C'] += valor_saldo_reprogramado_proximo_periodo_custeio
-    totalizador['saldo_bancario']['C'] += valor_saldo_bancario_custeio
+    # totalizador['saldo_bancario']['C'] += valor_saldo_bancario_custeio
     totalizador['valor_saldo_reprogramado_proximo_periodo']['C'] += valor_saldo_reprogramado_proximo_periodo_custeio
     totalizador['valor_saldo_bancario']['C'] += valor_saldo_bancario_custeio
     totalizador['credito_nao_demonstrado']['C'] += valor_custeio_receitas_nao_demonstradas
@@ -295,7 +319,10 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
 
 
 def sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_periodo, totalizador):
-    saldo_reprogramado_anterior_capital = fechamento_periodo.fechamento_anterior.saldo_reprogramado_capital if fechamento_periodo and fechamento_periodo.fechamento_anterior else 0
+    fechamento_anterior = get_fechamento_anterior(conta_associacao=conta_associacao, acao_associacao=acao_associacao,
+                                                  periodo=periodo, fechamento_periodo=fechamento_periodo)
+    saldo_reprogramado_anterior_capital = fechamento_anterior.saldo_reprogramado_capital if fechamento_anterior else 0
+
     receitas_demonstradas_capital = Receita.receitas_da_acao_associacao_no_periodo(
         acao_associacao=acao_associacao, conta_associacao=conta_associacao, periodo=periodo, conferido=True,
         categoria_receita=APLICACAO_CAPITAL).aggregate(valor=Sum('valor'))
@@ -354,6 +381,7 @@ def sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_perio
         "despesa_nao_realizada": despesa_nao_realizada,
         "despesa_nao_demostrada_outros_periodos": despesa_nao_demostrada_outros_periodos,
         "saldo_reprogramado_proximo": saldo_reprogramado_proximo,
+        "saldo_reprogramado_proximo_vr": valor_saldo_reprogramado_proximo_periodo_capital,
         "saldo_bancario": saldo_bancario,
         "valor_saldo_reprogramado_proximo_periodo_capital": valor_saldo_reprogramado_proximo_periodo_capital,
         "valor_saldo_bancario_capital": valor_saldo_bancario_capital,
@@ -365,8 +393,9 @@ def sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_perio
     totalizador['despesa_realizada']['K'] += valor_capital_rateios_demonstrados
     totalizador['despesa_nao_realizada']['K'] += valor_capital_rateios_nao_demonstrados
     totalizador['despesa_nao_demostrada_outros_periodos']['K'] += valor_capital_rateios_nao_demonstrados_outros_periodos
-    totalizador['saldo_reprogramado_proximo']['K'] += valor_saldo_reprogramado_proximo_periodo_capital if valor_saldo_reprogramado_proximo_periodo_capital > 0 else 0
-    totalizador['saldo_bancario']['K'] += valor_saldo_bancario_capital
+    totalizador['saldo_reprogramado_proximo'][
+        'K'] += valor_saldo_reprogramado_proximo_periodo_capital if valor_saldo_reprogramado_proximo_periodo_capital > 0 else 0
+    # totalizador['saldo_bancario']['K'] += valor_saldo_bancario_capital
     totalizador['valor_saldo_reprogramado_proximo_periodo']['K'] += valor_saldo_reprogramado_proximo_periodo_capital
     totalizador['valor_saldo_bancario']['K'] += valor_saldo_bancario_capital
     totalizador['credito_nao_demonstrado']['K'] += valor_capital_receitas_nao_demonstradas
@@ -374,11 +403,14 @@ def sintese_capital(acao_associacao, conta_associacao, periodo, fechamento_perio
     return linha_capital, totalizador
 
 
-def sintese_livre(linha_capital, linha_custeio, acao_associacao,conta_associacao, periodo, fechamento_periodo, totalizador):
+def sintese_livre(linha_capital, linha_custeio, acao_associacao, conta_associacao, periodo, fechamento_periodo,
+                  totalizador):
     valor_saldo_reprogramado_proximo_periodo_custeio = linha_custeio['valor_saldo_reprogramado_proximo_periodo_custeio']
     valor_saldo_reprogramado_proximo_periodo_capital = linha_capital['valor_saldo_reprogramado_proximo_periodo_capital']
 
-    saldo_reprogramado_anterior_livre = fechamento_periodo.fechamento_anterior.saldo_reprogramado_livre if fechamento_periodo and fechamento_periodo.fechamento_anterior else 0
+    fechamento_anterior = get_fechamento_anterior(conta_associacao=conta_associacao, acao_associacao=acao_associacao,
+                                                  periodo=periodo, fechamento_periodo=fechamento_periodo)
+    saldo_reprogramado_anterior_livre = fechamento_anterior.saldo_reprogramado_livre if fechamento_anterior else 0
 
     receitas_demonstradas_livre = Receita.receitas_da_acao_associacao_no_periodo(
         acao_associacao=acao_associacao, conta_associacao=conta_associacao, periodo=periodo, conferido=True,
@@ -405,6 +437,7 @@ def sintese_livre(linha_capital, linha_custeio, acao_associacao,conta_associacao
         "saldo_anterior": saldo_anterior,
         "credito": credito,
         "saldo_reprogramado_proximo": saldo_reprogramado_proximo,
+        "saldo_reprogramado_proximo_vr": valor_saldo_reprogramado_proximo_periodo_livre,
         "valor_saldo_reprogramado_proximo_periodo_livre": valor_saldo_reprogramado_proximo_periodo_livre,
         "credito_nao_demonstrado": 0,
     }
@@ -415,7 +448,7 @@ def sintese_livre(linha_capital, linha_custeio, acao_associacao,conta_associacao
     totalizador['despesa_nao_realizada']['L'] += 0
     totalizador['despesa_nao_demostrada_outros_periodos']['L'] += 0
     totalizador['saldo_reprogramado_proximo']['L'] += valor_saldo_reprogramado_proximo_periodo_livre
-    totalizador['saldo_bancario']['L'] += 0
+    # totalizador['saldo_bancario']['L'] += 0
     totalizador['valor_saldo_reprogramado_proximo_periodo']['L'] += valor_saldo_reprogramado_proximo_periodo_livre
     totalizador['valor_saldo_bancario']['L'] += 0
     totalizador['credito_nao_demonstrado']['L'] += 0

--- a/sme_ptrf_apps/core/services/demonstrativo_financeiro_xlsx_service.py
+++ b/sme_ptrf_apps/core/services/demonstrativo_financeiro_xlsx_service.py
@@ -485,7 +485,7 @@ def sintese_custeio(row_custeio, linha, acao_associacao, conta_associacao, perio
         totalizador[SALDO_ANTERIOR]['C'] += saldo_reprogramado_anterior_custeio
         totalizador[CREDITO]['C'] += valor_custeio_receitas_demonstradas
         totalizador[DESPESA_REALIZADA]['C'] += valor_custeio_rateios_demonstrados
-        totalizador[DESPESA_NAO_REALIZADA]['C'] += valor_custeio_rateios_demonstrados
+        totalizador[DESPESA_NAO_REALIZADA]['C'] += valor_custeio_rateios_nao_demonstrados
         totalizador[SALDO_REPROGRAMADO_PROXIMO][
             'C'] += valor_saldo_reprogramado_proximo_periodo_custeio if valor_saldo_reprogramado_proximo_periodo_custeio > 0 else 0
         totalizador[DESPESA_NAO_DEMONSTRADA_OUTROS_PERIODOS][

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf.html
@@ -159,10 +159,10 @@
           <td>{{ acoes.linha_custeio.despesa_realizada }}</td>
           <td>{{ acoes.linha_custeio.despesa_nao_realizada }}</td>
           <td>{{ acoes.linha_custeio.saldo_reprogramado_proximo }}</td>
-          <td style="border-bottom: none !important;">{{ acoes.saldo_bancario }}</td>
-          <td>{{ acoes.linha_custeio.despesa_nao_demostrada_outros_periodos }}</td>
-          <td>{{ acoes.linha_custeio.valor_saldo_reprogramado_proximo_periodo_custeio }}</td>
           <td style="border-bottom: none !important;">{{ acoes.total_valores }}</td>
+          <td>{{ acoes.linha_custeio.despesa_nao_demostrada_outros_periodos }}</td>
+          <td>{{ acoes.linha_custeio.valor_saldo_bancario_custeio }}</td>
+          <td style="border-bottom: none !important;">{{ acoes.saldo_bancario }}</td>
           <td>{{ acoes.linha_custeio.credito_nao_demonstrado }}</td>
         </tr>
         <tr>
@@ -174,7 +174,7 @@
           <td>{{ acoes.linha_capital.saldo_reprogramado_proximo }}</td>
           <td style="border: none !important;"></td>
           <td>{{ acoes.linha_capital.despesa_nao_demostrada_outros_periodos }}</td>
-          <td>{{ acoes.linha_capital.valor_saldo_reprogramado_proximo_periodo_capital }}</td>
+          <td>{{ acoes.linha_capital.valor_saldo_bancario_capital }}</td>
           <td style="border: none !important;"></td>
           <td>{{ acoes.linha_capital.credito_nao_demonstrado }}</td>
         </tr>
@@ -201,10 +201,10 @@
           <td class="total">{{ dados.resumo_por_acao.total_valores.despesa_realizada.C }}</td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.despesa_nao_realizada.C }}</td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.saldo_reprogramado_proximo.C }}</td>
-          <td class="total" style="border-bottom: none !important;">{{ dados.resumo_por_acao.total_valores.saldo_bancario.C }}</td>
-          <td class="total">{{ dados.resumo_por_acao.total_valores.despesa_nao_demostrada_outros_periodos.C }}</td>
-          <td class="total">{{ dados.resumo_por_acao.total_valores.valor_saldo_reprogramado_proximo_periodo.C }}</td>
           <td class="total" style="border-bottom: none !important;">{{ dados.resumo_por_acao.total_valores.total_valores }}</td>
+          <td class="total">{{ dados.resumo_por_acao.total_valores.despesa_nao_demostrada_outros_periodos.C }}</td>
+          <td class="total">{{ dados.resumo_por_acao.total_valores.valor_saldo_bancario.C }}</td>
+          <td class="total" style="border-bottom: none !important;">{{ dados.resumo_por_acao.total_valores.saldo_bancario }}</td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.credito_nao_demonstrado.C }}</td>
         </tr>
         <tr>
@@ -216,7 +216,7 @@
           <td class="total">{{ dados.resumo_por_acao.total_valores.saldo_reprogramado_proximo.K }}</td>
           <td class="total" style="border: none !important;"></td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.despesa_nao_demostrada_outros_periodos.K }}</td>
-          <td class="total">{{ dados.resumo_por_acao.total_valores.valor_saldo_reprogramado_proximo_periodo.K }}</td>
+          <td class="total">{{ dados.resumo_por_acao.total_valores.valor_saldo_bancario.K }}</td>
           <td class="total" style="border: none !important;"></td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.credito_nao_demonstrado.K }}</td>
         </tr>
@@ -229,7 +229,7 @@
           <td class="total">{{ dados.resumo_por_acao.total_valores.saldo_reprogramado_proximo.L }}</td>
           <td class="total" style="border-top:none!important; border-bottom: solid 1px #dee2e6 !important;">{% comment %}{{ acoes.saldo_bancario }}{% endcomment %}</td>
           <td class="fundo-cinza total"></td>
-          <td class="total">{{ dados.resumo_por_acao.total_valores.valor_saldo_reprogramado_proximo_periodo.L }}</td>
+          <td class="total">{{ dados.resumo_por_acao.total_valores.saldo_reprogramado_proximo.L }}</td>
           <td class="total" style="border-top:none!important; border-bottom: solid 1px #dee2e6 !important;"></td>
           <td class="total">{{ dados.resumo_por_acao.total_valores.credito_nao_demonstrado.L }}</td>
         </tr>


### PR DESCRIPTION
Esse PR ajusta os cálculos do bloco 3 do demonstrativo financeiro em PDF que
estava divergente do XLSX.

História [AB#34020](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/34020)
