### PR TITLE
feat(31436): Cria filtro por unidade na API User

### DIFF
--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -65,6 +65,10 @@ class UserViewSet(ModelViewSet):
             e_servidor = servidor == 'True'
             qs = qs.filter(e_servidor=e_servidor)
 
+        unidade_uuid = self.request.query_params.get('unidade_uuid')
+        if unidade_uuid:
+            qs = qs.filter(unidades__uuid=unidade_uuid)
+
         return qs
 
     @action(detail=False, methods=["GET"])

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
@@ -97,7 +97,7 @@ def test_filtro_por_nome_lista_usuarios(
     assert result == esperado
 
 
-def test_lista_usuarios_por_unidade(
+def test_lista_usuarios_por_associacao(
         jwt_authenticated_client_u,
         usuario_para_teste,
         usuario_2,
@@ -191,4 +191,50 @@ def test_lista_usuarios_por_e_servidor_false(
             'groups': [{'id': grupo_1.id, 'name': grupo_1.name, 'descricao': grupo_1.descricao}]
         }
     ]
+    assert result == esperado
+
+
+def test_lista_usuarios_por_unidade(
+        jwt_authenticated_client_u,
+        usuario_para_teste,
+        usuario_2,
+        usuario_3,
+        unidade,
+        grupo_1,
+        grupo_2):
+
+    response = jwt_authenticated_client_u.get(f"/api/usuarios/?unidade_uuid={unidade.uuid}", content_type='application/json')
+    result = response.json()
+    esperado = [
+        {
+            'id': usuario_3.id,
+            'name': 'Arthur Marques',
+            'e_servidor': True,
+            'url': 'http://testserver/api/esqueci-minha-senha/7218198/',
+            'username': '7218198',
+            'email': 'sme8198@amcom.com.br',
+            'groups': [
+                {
+                    'descricao': 'Descrição grupo 2',
+                    'id': grupo_2.id,
+                    'name': 'grupo2'
+                }],
+        },
+        {
+            'id': usuario_para_teste.id,
+            'name': 'LUCIA HELENA',
+            'e_servidor': False,
+            'url': 'http://testserver/api/esqueci-minha-senha/7210418/',
+            'username': '7210418',
+            'email': 'luh@gmail.com',
+            'groups': [
+                {
+                    'descricao': 'Descrição grupo 1',
+                    'id': grupo_1.id,
+                    'name': 'grupo1'
+                }],
+        }
+
+    ]
+    print(result)
     assert result == esperado


### PR DESCRIPTION
Esse PR cria na api de usuários um filtro por unidade.

História [AB#37456](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/37456)