### PR TITLE
Feature(37456) Criação usuários ajustes finais parte1

### DIFF
--- a/sme_ptrf_apps/users/api/serializers/user.py
+++ b/sme_ptrf_apps/users/api/serializers/user.py
@@ -47,7 +47,7 @@ class UserLookupSerializer(serializers.ModelSerializer):
 
 class UserCreateSerializer(serializers.ModelSerializer):
     visao = serializers.CharField(write_only=True)
-    unidade = serializers.CharField(write_only=True)
+    unidade = serializers.CharField(write_only=True, required=False, allow_blank=True, allow_null=True)
 
     class Meta:
         model = User
@@ -95,7 +95,8 @@ class UserCreateSerializer(serializers.ModelSerializer):
         instance.add_visao_se_nao_existir(visao=visao)
 
         unidade = validated_data.pop('unidade')
-        instance.add_unidade_se_nao_existir(unidade=unidade)
+        if unidade:
+            instance.add_unidade_se_nao_existir(unidade=unidade)
 
         return super().update(instance, validated_data)
 

--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -180,22 +180,23 @@ class UserViewSet(ModelViewSet):
                 'mensagem': 'Erro ao buscar usuário no CoreSSO!'
             }
 
+        onde_e_membro = MembroAssociacao.associacoes_onde_cpf_e_membro(cpf=username) if not e_servidor else []
         try:
             user_sig_escola = User.objects.get(username=username)
-            onde_e_membro = MembroAssociacao.associacoes_onde_cpf_e_membro(cpf=username) if not e_servidor else []
             info_sig_escola = {
                 'info_sig_escola': {
                     'visoes': user_sig_escola.visoes.values_list('nome', flat=True),
                     'unidades': user_sig_escola.unidades.values_list('codigo_eol', flat=True),
-                    'associacoes_que_e_membro': onde_e_membro,
                     'user_id': user_sig_escola.id
                 },
-                'mensagem': 'Usuário encontrado no Sig.Escola.'
+                'mensagem': 'Usuário encontrado no Sig.Escola.',
+                'associacoes_que_e_membro': onde_e_membro,
             }
         except User.DoesNotExist as e:
             info_sig_escola = {
                 'info_sig_escola': None,
-                'mensagem': 'Usuário não encontrado no Sig.Escola.'
+                'mensagem': 'Usuário não encontrado no Sig.Escola.',
+                'associacoes_que_e_membro': onde_e_membro,
             }
 
         result = {

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_update_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_update_user.py
@@ -67,3 +67,65 @@ def test_atualizar_usuario_servidor(
         nome='Usuario 2'
     )
     mock_atribuir_perfil_core_sso.assert_called_once_with(login='7211981', visao='UE')
+
+
+def test_atualizar_usuario_servidor_visao_sme(
+        jwt_authenticated_client_u,
+        usuario_3,
+        usuario_2,
+        visao_ue,
+        visao_dre,
+        visao_sme,
+        grupo_1,
+        grupo_2,
+        unidade_ue_271170,
+        unidade_diferente,
+        dre
+):
+
+    assert not usuario_3.visoes.filter(nome='SME').first(), "Não deveria estar vinculado à SME antes do teste."
+
+    payload = {
+        'e_servidor': True,
+        'username': usuario_3.username,
+        'name': usuario_3.name,
+        'email': 'novoEmail@gmail.com',
+        'visao': "SME",
+        'unidade': None,
+        'groups': [
+            grupo_1.id
+        ]
+    }
+
+    api_usuario_core_sso_or_none = 'sme_ptrf_apps.users.api.views.user.SmeIntegracaoService.usuario_core_sso_or_none'
+    api_cria_usuario_core_sso = 'sme_ptrf_apps.users.api.views.user.SmeIntegracaoService.cria_usuario_core_sso'
+    api_atribuir_perfil_core_sso = 'sme_ptrf_apps.users.api.views.user.SmeIntegracaoService.atribuir_perfil_coresso'
+    with patch(api_usuario_core_sso_or_none) as mock_usuario_core_sso_or_none:
+        mock_usuario_core_sso_or_none.return_value = None
+        with patch(api_cria_usuario_core_sso) as mock_cria_usuario_core_sso:
+            with patch(api_atribuir_perfil_core_sso) as mock_atribuir_perfil_core_sso:
+                response = jwt_authenticated_client_u.put(
+                    f"/api/usuarios/{usuario_3.id}/", data=json.dumps(payload), content_type='application/json')
+
+    result = response.json()
+
+    esperado = {
+        'username': usuario_3.username,
+        'email': 'novoEmail@gmail.com',
+        'name': 'Arthur Marques',
+        'e_servidor': True,
+        'groups': [grupo_1.id]
+    }
+
+    assert usuario_3.visoes.filter(nome='SME').first(), "Deveria ter sido vinculado à visão SME."
+    assert result == esperado
+
+    mock_usuario_core_sso_or_none.assert_called_once_with(login='7218198')
+    mock_cria_usuario_core_sso.assert_called_once_with(
+        e_servidor=True,
+        email='novoEmail@gmail.com',
+        login='7218198',
+        nome='Arthur Marques'
+    )
+
+    mock_atribuir_perfil_core_sso.assert_called_once_with(login=usuario_3.username, visao='SME')

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_usuarios_status.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_usuarios_status.py
@@ -37,7 +37,8 @@ def test_get_usuario_status_cadastrado_core_sso_nao_cadastrado_sig_escola(jwt_au
             },
             'usuario_sig_escola': {
                 'info_sig_escola': None,
-                'mensagem': 'Usuário não encontrado no Sig.Escola.'
+                'mensagem': 'Usuário não encontrado no Sig.Escola.',
+                'associacoes_que_e_membro': [],
             },
             'validacao_username': {'mensagem': '', 'username_e_valido': True},
             'e_servidor_na_unidade': False
@@ -64,10 +65,10 @@ def test_get_usuario_status_servidor_cadastrado_sig_escola_nao_cadastrado_core_s
             'info_sig_escola': {
                 'visoes': ['UE'],
                 'unidades': ['123456', ],
-                'associacoes_que_e_membro': [],
                 'user_id': usuario_para_teste.id
             },
-            'mensagem': 'Usuário encontrado no Sig.Escola.'
+            'mensagem': 'Usuário encontrado no Sig.Escola.',
+            'associacoes_que_e_membro': [],
         }
         esperado = {
             'usuario_core_sso': {
@@ -100,7 +101,8 @@ def test_get_usuario_status_nao_servidor_username_invalido(jwt_authenticated_cli
 
         usuario_sig_escola_esperado = {
             'info_sig_escola': None,
-            'mensagem': 'Usuário não encontrado no Sig.Escola.'
+            'mensagem': 'Usuário não encontrado no Sig.Escola.',
+            'associacoes_que_e_membro': [],
         }
         esperado = {
             'usuario_core_sso': {
@@ -138,10 +140,10 @@ def test_get_usuario_status_nao_servidor_membro_associacoes(
             'info_sig_escola': {
                 'visoes': ['UE', 'DRE'],
                 'unidades': ['123456', ],
-                'associacoes_que_e_membro': [f'{associacao_271170.uuid}', ],
                 'user_id': usuario_nao_servidor.id
             },
-            'mensagem': 'Usuário encontrado no Sig.Escola.'
+            'mensagem': 'Usuário encontrado no Sig.Escola.',
+            'associacoes_que_e_membro': [f'{associacao_271170.uuid}', ],
         }
         esperado = {
             'usuario_core_sso': {
@@ -212,10 +214,10 @@ def test_get_usuario_status_servidor_lotado_na_unidade(jwt_authenticated_client_
             'info_sig_escola': {
                 'visoes': ['UE'],
                 'unidades': ['123456', ],
-                'associacoes_que_e_membro': [],
                 'user_id': usuario_para_teste.id
             },
-            'mensagem': 'Usuário encontrado no Sig.Escola.'
+            'mensagem': 'Usuário encontrado no Sig.Escola.',
+            'associacoes_que_e_membro': [],
         }
         esperado = {
             'usuario_core_sso': {
@@ -228,6 +230,42 @@ def test_get_usuario_status_servidor_lotado_na_unidade(jwt_authenticated_client_
                 'mensagem': "",
             },
             'e_servidor_na_unidade': True
+        }
+
+        result = json.loads(response.content)
+        assert response.status_code == status.HTTP_200_OK
+        assert result == esperado
+
+
+def test_get_usuario_status_nao_servidor_membro_associacoes_nao_cadastrado_sigescola(
+    jwt_authenticated_client_u,
+    associacao_271170,
+    membro_associacao_00746198701
+):
+    path = 'sme_ptrf_apps.users.api.views.user.SmeIntegracaoService.usuario_core_sso_or_none'
+    with patch(path) as mock_get:
+
+        mock_get.return_value = None
+
+        username = '00746198701'
+        response = jwt_authenticated_client_u.get(f'/api/usuarios/status/?username={username}&servidor=False')
+
+        usuario_sig_escola_esperado = {
+            'info_sig_escola': None,
+            'mensagem': 'Usuário não encontrado no Sig.Escola.',
+            'associacoes_que_e_membro': [f'{associacao_271170.uuid}', ],
+        }
+        esperado = {
+            'usuario_core_sso': {
+                'info_core_sso': None,
+                'mensagem': 'Usuário não encontrado no CoreSSO.'
+            },
+            'usuario_sig_escola': usuario_sig_escola_esperado,
+            'validacao_username': {
+                'username_e_valido': True,
+                'mensagem': "",
+            },
+            'e_servidor_na_unidade': False
         }
 
         result = json.loads(response.content)


### PR DESCRIPTION
Esse PR:
- Altera put da API de usuários para não exigir unidade;
- Altera o retorno da consulta de status de um username para
retornar as associações que o usuário é membro mesmo quando
o username não existir ainda no SigEscola.