### PR TITLE
Feat(39113) Cadastro usuários em várias visões a partir do perfil de acessos (Parte 2) 

### DIFF
--- a/sme_ptrf_apps/sme/tests/tests_api_saldos_bancarios/test_saldos_bancarios.py
+++ b/sme_ptrf_apps/sme/tests/tests_api_saldos_bancarios/test_saldos_bancarios.py
@@ -27,8 +27,13 @@ def test_saldo_bancario_por_tipo_de_unidade(jwt_authenticated_client_sme, observ
         {'tipo_de_unidade': 'EMEF', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
         {'tipo_de_unidade': 'EMEFM', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
         {'tipo_de_unidade': 'EMEI', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
-        {'tipo_de_unidade': 'CEU', 'qtde_unidades_informadas': 1, 'saldo_bancario_informado': 1000,
-         'total_unidades': 2}]
+        {'tipo_de_unidade': 'CEU', 'qtde_unidades_informadas': 1, 'saldo_bancario_informado': 1000, 'total_unidades': 2},
+        {'tipo_de_unidade': 'CEU CEI', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
+        {'tipo_de_unidade': 'CEU EMEF', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
+        {'tipo_de_unidade': 'CEU EMEI', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
+        {'tipo_de_unidade': 'CEU CEMEI', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
+        {'tipo_de_unidade': 'CEI DIRET', 'qtde_unidades_informadas': 0, 'saldo_bancario_informado': 0, 'total_unidades': 0},
+    ]
 
     assert response.status_code == status.HTTP_200_OK
     assert result == resultado_esperado
@@ -145,7 +150,13 @@ def test_saldo_bancario_por_ue_dre(jwt_authenticated_client_sme, observacao_conc
                                            {'associacao': 'EMEF', 'saldo_total': 0},
                                            {'associacao': 'EMEFM', 'saldo_total': 0},
                                            {'associacao': 'EMEI', 'saldo_total': 0},
-                                           {'associacao': 'CEU', 'saldo_total': 0}],
+                                           {'associacao': 'CEU', 'saldo_total': 0},
+                                           {'associacao': 'CEU CEI', 'saldo_total': 0},
+                                           {'associacao': 'CEU EMEF', 'saldo_total': 0},
+                                           {'associacao': 'CEU EMEI', 'saldo_total': 0},
+                                           {'associacao': 'CEU CEMEI', 'saldo_total': 0},
+                                           {'associacao': 'CEI DIRET', 'saldo_total': 0}
+                                           ],
                            'sigla_dre': dre.sigla,
                            'uuid_dre': f'{dre.uuid}'},
                           {'associacoes': [{'associacao': 'IFSP', 'saldo_total': 0},
@@ -158,7 +169,13 @@ def test_saldo_bancario_por_ue_dre(jwt_authenticated_client_sme, observacao_conc
                                            {'associacao': 'EMEF', 'saldo_total': 0},
                                            {'associacao': 'EMEFM', 'saldo_total': 0},
                                            {'associacao': 'EMEI', 'saldo_total': 0},
-                                           {'associacao': 'CEU', 'saldo_total': 1000.0}],
+                                           {'associacao': 'CEU', 'saldo_total': 1000.0},
+                                           {'associacao': 'CEU CEI', 'saldo_total': 0},
+                                           {'associacao': 'CEU EMEF', 'saldo_total': 0},
+                                           {'associacao': 'CEU EMEI', 'saldo_total': 0},
+                                           {'associacao': 'CEU CEMEI', 'saldo_total': 0},
+                                           {'associacao': 'CEI DIRET', 'saldo_total': 0}
+                                           ],
                            'sigla_dre': dre_saldos_bancarios.sigla,
                            'uuid_dre': f'{dre_saldos_bancarios.uuid}'}]
 

--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -271,4 +271,6 @@ class UserViewSet(ModelViewSet):
     @action(detail=True, methods=['delete'], url_path='unidades/(?P<codigo_eol>[0-9]+)')
     def deleta_vinculo_usuario_unidade(self, request, codigo_eol, id):
         """ (delete) /usuarios/{usuario.id}/unidades/{codigo_eol}  """
-        ...
+        usuario = self.get_object()
+        usuario.remove_unidade_se_existir(codigo_eol=codigo_eol)
+        return Response({"mensagem": "Unidade desvinculada com sucesso"}, status=status.HTTP_201_CREATED)

--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -264,7 +264,11 @@ class UserViewSet(ModelViewSet):
     def cria_vinculo_usuario_unidade(self, request, id):
         """ (post) /usuarios/{usuario.id}/unidades/  """
         usuario = self.get_object()
-        codigo_eol = request.data['codigo_eol']
+
+        codigo_eol = request.data.get('codigo_eol')
+        if not codigo_eol:
+            return Response("Campo 'codigo_eol' não encontrado no payload.", status=status.HTTP_400_BAD_REQUEST)
+
         usuario.add_unidade_se_nao_existir(codigo_eol=codigo_eol)
         return Response({"mensagem": "Unidade vinculada com sucesso"}, status=status.HTTP_201_CREATED)
 

--- a/sme_ptrf_apps/users/models.py
+++ b/sme_ptrf_apps/users/models.py
@@ -79,6 +79,12 @@ class User(AbstractUser):
             self.unidades.add(unidade)
             self.save()
 
+    def remove_unidade_se_existir(self, codigo_eol):
+        if self.unidades.filter(codigo_eol=codigo_eol).exists():
+            unidade = Unidade.objects.get(codigo_eol=codigo_eol)
+            self.unidades.remove(unidade)
+            self.save()
+
     @classmethod
     def criar_usuario(cls, dados):
         """ Recebe dados de usuário incluindo as listas de unidades, visões e grupos vinculados a ele e cria o usuário

--- a/sme_ptrf_apps/users/tests/test_api_user/conftest.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/conftest.py
@@ -227,6 +227,27 @@ def usuario_3(
 
 
 @pytest.fixture
+def usuario_duas_unidades(
+        unidade,
+        unidade_diferente,
+        grupo_2,
+        visao_dre,
+        visao_ue):
+
+    senha = 'Sgp8198'
+    login = '7218198'
+    email = 'sme8198@amcom.com.br'
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email, name="Arthur Marques", e_servidor=True)
+    user.unidades.add(unidade)
+    user.unidades.add(unidade_diferente)
+    user.groups.add(grupo_2)
+    user.visoes.add(visao_dre, visao_ue)
+    user.save()
+    return user
+
+
+@pytest.fixture
 def usuario_servidor(
         unidade,
         grupo_2,

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_create_vinculo_user_unidade.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_create_vinculo_user_unidade.py
@@ -3,6 +3,8 @@ import pytest
 
 from django.contrib.auth import get_user_model
 
+from rest_framework import status
+
 pytestmark = pytest.mark.django_db
 
 
@@ -20,11 +22,35 @@ def test_create_vinculo_usuario_unidade(
     u = User.objects.filter(username=usuario_3.username).first()
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade.codigo_eol, ]
 
-    jwt_authenticated_client_u.post(
+    response = jwt_authenticated_client_u.post(
         f"/api/usuarios/{usuario_3.id}/unidades/",
         data=json.dumps(payload),
         content_type='application/json'
     )
 
+    assert response.status_code == status.HTTP_201_CREATED
+
     u = User.objects.filter(username=usuario_3.username).first()
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade.codigo_eol, unidade_diferente.codigo_eol]
+
+
+def test_create_vinculo_usuario_unidade_sem_passar_codigo_eol(
+        jwt_authenticated_client_u,
+        usuario_3,
+        unidade,
+        unidade_diferente
+):
+    payload = {
+    }
+
+    response = jwt_authenticated_client_u.post(
+        f"/api/usuarios/{usuario_3.id}/unidades/",
+        data=json.dumps(payload),
+        content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    result = json.loads(response.content)
+    assert result == "Campo 'codigo_eol' não encontrado no payload."
+

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_delete_vinculo_user_unidade.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_delete_vinculo_user_unidade.py
@@ -1,0 +1,26 @@
+import json
+import pytest
+
+from django.contrib.auth import get_user_model
+
+pytestmark = pytest.mark.django_db
+
+
+def test_delete_vinculo_usuario_unidade(
+        jwt_authenticated_client_u,
+        usuario_duas_unidades,
+        unidade,
+        unidade_diferente
+):
+
+    User = get_user_model()
+    u = User.objects.filter(username=usuario_duas_unidades.username).first()
+    assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade.codigo_eol, unidade_diferente.codigo_eol ]
+
+    jwt_authenticated_client_u.delete(
+        f"/api/usuarios/{usuario_duas_unidades.id}/unidades/{unidade.codigo_eol}/",
+        content_type='application/json'
+    )
+
+    u = User.objects.filter(username=usuario_duas_unidades.username).first()
+    assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade_diferente.codigo_eol, ]

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_delete_vinculo_user_unidade.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_delete_vinculo_user_unidade.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 
 from django.contrib.auth import get_user_model


### PR DESCRIPTION
Esse PR traz a parte final das alterações necessárias na API de usuários para permitir o cadastro de usuários em várias visões a partir do perfil de acessos.

História [AB#39113](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39113)

## O que foi feito:

- [X] Endpoint para desvincular unidade do usuário  recebendo o id do usuário e uuid da unidade
- [X] Validações na adição de vínculo de unidade


