### PR TITLE
feat(39113): Add username no filtro de usuarios por nome

### DIFF
--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.contrib.auth import get_user_model
+from django.db.models import Q
+
 from requests import ConnectTimeout, ReadTimeout
 from rest_framework import status
 from rest_framework.decorators import action
@@ -56,7 +58,7 @@ class UserViewSet(ModelViewSet):
 
         search = self.request.query_params.get('search')
         if search is not None:
-            qs = qs.filter(name__unaccent__icontains=search)
+            qs = qs.filter(Q(name__unaccent__icontains=search) | Q(username=search))
 
         associacao_uuid = self.request.query_params.get('associacao_uuid')
         if associacao_uuid:

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
@@ -135,6 +135,50 @@ def test_lista_usuarios_filtro_por_nome(
     assert result == esperado
 
 
+def test_lista_usuarios_filtro_por_nome_ou_username(
+        jwt_authenticated_client_u2,
+        usuario_2,
+        usuario_3,
+        visao_ue,
+        visao_dre,
+        visao_sme,
+        permissao1,
+        permissao2,
+        grupo_1,
+        grupo_2,
+        unidade
+):
+
+    response = jwt_authenticated_client_u2.get(f"/api/usuarios/?visao=DRE&search=7218198", content_type='application/json')
+    result = response.json()
+    esperado = [
+        {'id': usuario_3.id,
+         'username': '7218198',
+         'email': 'sme8198@amcom.com.br',
+         'name': 'Arthur Marques',
+         'url': 'http://testserver/api/esqueci-minha-senha/7218198/',
+         'e_servidor': usuario_3.e_servidor,
+         'groups': [
+             {
+                 'id': grupo_2.id,
+                 'name': 'grupo2',
+                 'descricao': 'Descrição grupo 2'
+             }
+         ],
+         'unidades': [
+             {
+                 'uuid': f'{unidade.uuid}',
+                 'nome': unidade.nome,
+                 'codigo_eol': unidade.codigo_eol,
+                 'tipo_unidade': unidade.tipo_unidade
+             }
+         ]
+         }
+    ]
+    assert result == esperado
+
+
+
 def test_lista_usuarios_filtro_por_associacao(
         jwt_authenticated_client_u,
         usuario_para_teste,


### PR DESCRIPTION
Esse PR:
- Inclui no filtro de usuários por nome a verificação também do username.

Complemento da história [AB#39113](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39113)

- [X] Lista de usuários deve permitir filtro por username ou nome do usuário (qualquer parte). Hoje faz apenas nome.