### PR TITLE
feat(39146): Filtro de status do rateio pela despesa - Parte 2

### DIFF
--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -122,7 +122,7 @@ def despesas_nao_conciliadas_por_conta_e_acao_no_periodo(conta_associacao, acao_
 
 
 def despesas_conciliadas_por_conta_e_acao_na_conciliacao(conta_associacao, acao_associacao, periodo):
-    dataset = periodo.despesas_conciliadas_no_periodo.filter(status=STATUS_COMPLETO).filter(conta_associacao=conta_associacao)
+    dataset = periodo.despesas_conciliadas_no_periodo.filter(despesa__status=STATUS_COMPLETO).filter(conta_associacao=conta_associacao)
 
     if acao_associacao:
         dataset = dataset.filter(acao_associacao=acao_associacao)
@@ -281,7 +281,7 @@ def receitas_nao_conciliadas_por_conta_no_periodo(conta_associacao, periodo):
 
 
 def despesas_conciliadas_por_conta_na_conciliacao(conta_associacao, periodo):
-    dataset = periodo.despesas_conciliadas_no_periodo.filter(status=STATUS_COMPLETO)
+    dataset = periodo.despesas_conciliadas_no_periodo.filter(despesa__status=STATUS_COMPLETO)
     dataset = dataset.filter(conta_associacao=conta_associacao)
 
     return dataset.all()

--- a/sme_ptrf_apps/despesas/models/rateio_despesa.py
+++ b/sme_ptrf_apps/despesas/models/rateio_despesa.py
@@ -13,7 +13,7 @@ from ..tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CHOICES, APLI
 
 class RateiosCompletosManager(models.Manager):
     def get_queryset(self):
-        return super(RateiosCompletosManager, self).get_queryset().filter(status=STATUS_COMPLETO)
+        return super(RateiosCompletosManager, self).get_queryset().filter(despesa__status=STATUS_COMPLETO)
 
 
 class RateioDespesa(ModeloBase):


### PR DESCRIPTION
Esse PR complementa as alterações para atendimento da história [AB#39146](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39146). 

Altera o filtro de status dos rateios para serem feitos pelo status das despesas.

Isso porque, um rateio pode ter o status = COMPLETO, e porém ser parte de
uma despesa com status = INCOMPLETO.