### PR TITLE
Feat(39524) Seleção de períodos no resumo de recursos não exibir período de implantação

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -375,6 +375,13 @@ class AssociacoesViewSet(ModelViewSet):
         periodos = associacao.periodos_para_prestacoes_de_conta()
         return Response(PeriodoLookUpSerializer(periodos, many=True).data)
 
+    @action(detail=True, url_path='periodos-ate-agora-fora-implantacao', methods=['get'],
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def periodos_ate_agora_fora_implantacao(self, request, uuid=None):
+        associacao = self.get_object()
+        periodos = associacao.periodos_ate_agora_fora_implantacao()
+        return Response(PeriodoLookUpSerializer(periodos, many=True).data)
+
     @action(detail=True, url_path='processos', methods=['get'],
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def processos_da_associacao(self, request, uuid=None):

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -110,6 +110,18 @@ class Associacao(ModeloIdNome):
             periodos.append(proximo_periodo)
         return periodos
 
+    def periodos_ate_agora_fora_implantacao(self):
+        from datetime import datetime
+        from .periodo import Periodo
+
+        qry_periodos = Periodo.objects.filter(
+            data_inicio_realizacao_despesas__lte=datetime.today()).order_by('-referencia')
+
+        if self.periodo_inicial:
+            qry_periodos = qry_periodos.exclude(uuid=self.periodo_inicial.uuid)
+
+        return qry_periodos.all()
+
     @classmethod
     def acoes_da_associacao(cls, associacao_uuid):
         associacao = cls.objects.filter(uuid=associacao_uuid).first()

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -118,7 +118,9 @@ class Associacao(ModeloIdNome):
             data_inicio_realizacao_despesas__lte=datetime.today()).order_by('-referencia')
 
         if self.periodo_inicial:
-            qry_periodos = qry_periodos.exclude(uuid=self.periodo_inicial.uuid)
+            qry_periodos = qry_periodos.filter(
+                data_inicio_realizacao_despesas__gte=self.periodo_inicial.data_fim_realizacao_despesas
+            )
 
         return qry_periodos.all()
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_ate_agora_fora_implantacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_ate_agora_fora_implantacao.py
@@ -10,13 +10,24 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def periodo_2019_1():
+def periodo_2018_1():
+    return baker.make(
+        'Periodo',
+        referencia='2018.1',
+        data_inicio_realizacao_despesas=date(2018, 1, 1),
+        data_fim_realizacao_despesas=date(2018, 12, 31),
+        periodo_anterior=None
+    )
+
+
+@pytest.fixture
+def periodo_2019_1(periodo_2018_1):
     return baker.make(
         'Periodo',
         referencia='2019.1',
         data_inicio_realizacao_despesas=date(2019, 1, 1),
         data_fim_realizacao_despesas=date(2019, 6, 30),
-        periodo_anterior=None
+        periodo_anterior=periodo_2018_1
     )
 
 
@@ -68,9 +79,10 @@ def associacao_teste(unidade, periodo_2019_1):
 
 
 @freeze_time('2020-06-15')
-def test_get_periodos_prestacao_de_contas_da_associacao(
+def test_get_periodos_ate_agora_fora_implantacao_da_associacao(
     jwt_authenticated_client_a,
     associacao_teste,
+    periodo_2018_1,
     periodo_2019_1,
     periodo_2019_2,
     periodo_2020_1,

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_ate_agora_fora_implantacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_ate_agora_fora_implantacao.py
@@ -1,0 +1,104 @@
+import json
+from datetime import date
+
+import pytest
+from freezegun import freeze_time
+from model_bakery import baker
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def periodo_2019_1():
+    return baker.make(
+        'Periodo',
+        referencia='2019.1',
+        data_inicio_realizacao_despesas=date(2019, 1, 1),
+        data_fim_realizacao_despesas=date(2019, 6, 30),
+        periodo_anterior=None
+    )
+
+
+@pytest.fixture
+def periodo_2019_2(periodo_2019_1):
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=date(2019, 7, 1),
+        data_fim_realizacao_despesas=date(2019, 12, 31),
+        periodo_anterior=periodo_2019_1
+    )
+
+
+@pytest.fixture
+def periodo_2020_1(periodo_2019_2):
+    return baker.make(
+        'Periodo',
+        referencia='2020.1',
+        data_inicio_realizacao_despesas=date(2020, 1, 1),
+        data_fim_realizacao_despesas=date(2020, 6, 30),
+        periodo_anterior=periodo_2019_2
+    )
+
+
+@pytest.fixture
+def periodo_2020_2(periodo_2020_1):
+    return baker.make(
+        'Periodo',
+        referencia='2020.2',
+        data_inicio_realizacao_despesas=date(2020, 7, 1),
+        data_fim_realizacao_despesas=date(2020, 12, 31),
+        periodo_anterior=periodo_2020_1
+    )
+
+
+@pytest.fixture
+def associacao_teste(unidade, periodo_2019_1):
+    return baker.make(
+        'Associacao',
+        nome='Escola Teste',
+        cnpj='52.302.275/0001-83',
+        unidade=unidade,
+        periodo_inicial=periodo_2019_1,
+        ccm='0.000.00-0',
+        email="ollyverottoboni@gmail.com",
+        processo_regularidade='123456'
+    )
+
+
+@freeze_time('2020-06-15')
+def test_get_periodos_prestacao_de_contas_da_associacao(
+    jwt_authenticated_client_a,
+    associacao_teste,
+    periodo_2019_1,
+    periodo_2019_2,
+    periodo_2020_1,
+    periodo_2020_2,
+):
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao_teste.uuid}/periodos-ate-agora-fora-implantacao/',
+        content_type='application/json')
+
+    result = json.loads(response.content)
+
+    esperados = [
+        {
+            'data_fim_realizacao_despesas': f'{periodo_2020_1.data_fim_realizacao_despesas}',
+            'data_inicio_realizacao_despesas': f'{periodo_2020_1.data_inicio_realizacao_despesas}',
+            'referencia': '2020.1',
+            'referencia_por_extenso': periodo_2020_1.referencia_por_extenso,
+            'uuid': f'{periodo_2020_1.uuid}'
+        },
+        {
+            'data_fim_realizacao_despesas': f'{periodo_2019_2.data_fim_realizacao_despesas}',
+            'data_inicio_realizacao_despesas': f'{periodo_2019_2.data_inicio_realizacao_despesas}',
+            'referencia': '2019.2',
+            'referencia_por_extenso': periodo_2019_2.referencia_por_extenso,
+            'uuid': f'{periodo_2019_2.uuid}'
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert result == esperados


### PR DESCRIPTION
Esse PR cria um novo endpoint que retorna a lista de períodos a partir do período seguinte ao período de implantação da Associação até o período corrente.

História [AB#39524](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39524)
