### PR TITLE
Feat(39113) API de Usuários - Ajustes

### DIFF
--- a/sme_ptrf_apps/users/api/serializers/user.py
+++ b/sme_ptrf_apps/users/api/serializers/user.py
@@ -91,7 +91,7 @@ class UserCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["username", "email", "name", "e_servidor", "visao", "groups", "unidade", "visoes"]
+        fields = ["username", "email", "name", "e_servidor", "visao", "groups", "unidade", "visoes", "id"]
 
     def create(self, validated_data):
         dados_usuario = {

--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -17,7 +17,7 @@ from sme_ptrf_apps.users.api.serializers import (
     UserSerializer,
     UserRetrieveSerializer
 )
-from sme_ptrf_apps.users.models import Grupo
+from sme_ptrf_apps.users.models import Grupo, Visao
 from sme_ptrf_apps.users.services import SmeIntegracaoException, SmeIntegracaoService
 from sme_ptrf_apps.users.services.unidades_e_permissoes_service import unidades_do_usuario_e_permissoes_na_visao
 from sme_ptrf_apps.users.services.validacao_username_service import validar_username
@@ -280,3 +280,17 @@ class UserViewSet(ModelViewSet):
         usuario = self.get_object()
         usuario.remove_unidade_se_existir(codigo_eol=codigo_eol)
         return Response({"mensagem": "Unidade desvinculada com sucesso"}, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, url_path="visoes", methods=['get'])
+    def visoes(self, request):
+        try:
+            visoes = Visao.objects.all().order_by("nome")
+
+            return Response([{'id': str(visao.id), "nome": visao.nome} for visao in visoes])
+        except Exception as err:
+            erro = {
+                'erro': 'erro_ao_consultar_visoes',
+                'mensagem': str(err)
+            }
+            logging.info("Erro ao buscar visoes %s", erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_create_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_create_user.py
@@ -39,6 +39,10 @@ def test_criar_usuario_servidor_com_visao(
 
     result = response.json()
 
+
+    User = get_user_model()
+    u = User.objects.filter(username='9876543').first()
+
     esperado = {
         'username': '9876543',
         'email': 'lukaku@gmail.com',
@@ -46,9 +50,8 @@ def test_criar_usuario_servidor_com_visao(
         'e_servidor': True,
         'groups': [grupo_1.id, ],
         'visoes': [visao_ue.id, ],
+        'id': u.id
     }
-    User = get_user_model()
-    u = User.objects.filter(username='9876543').first()
 
     assert list(u.visoes.values_list('nome', flat=True)) == ["UE", ]
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade_ue_271170.codigo_eol,]
@@ -91,6 +94,9 @@ def test_criar_usuario_servidor_com_visoes(
 
     result = response.json()
 
+    User = get_user_model()
+    u = User.objects.filter(username='9876543').first()
+
     esperado = {
         'username': '9876543',
         'email': 'lukaku@gmail.com',
@@ -98,10 +104,8 @@ def test_criar_usuario_servidor_com_visoes(
         'e_servidor': True,
         'groups': [grupo_1.id, ],
         'visoes': [visao_ue.id, ],
-
+        'id': u.id
     }
-    User = get_user_model()
-    u = User.objects.filter(username='9876543').first()
 
     assert list(u.visoes.values_list('nome', flat=True)) == ["UE", ]
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade_ue_271170.codigo_eol,]
@@ -138,16 +142,19 @@ def test_criar_usuario_servidor_sem_email_e_sem_nome(
     response = jwt_authenticated_client_u.post(
         "/api/usuarios/", data=json.dumps(payload), content_type='application/json')
     result = response.json()
+
+    User = get_user_model()
+    u = User.objects.filter(username='9876543').first()
+
     esperado = {
         'username': '9876543',
         'email': '',
         'name': '',
         'e_servidor': True,
         'groups': [grupo_1.id, ],
-        'visoes': [visao_ue.id, ]
+        'visoes': [visao_ue.id, ],
+        'id': u.id
     }
-    User = get_user_model()
-    u = User.objects.filter(username='9876543').first()
 
     assert list(u.visoes.values_list('nome', flat=True)) == ["UE", ]
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == [unidade_ue_271170.codigo_eol, ]
@@ -183,6 +190,9 @@ def test_criar_usuario_servidor_visao_sme(
 
     result = response.json()
 
+    User = get_user_model()
+    u = User.objects.filter(username='9876543').first()
+
     esperado = {
         'username': '9876543',
         'email': 'lukaku@gmail.com',
@@ -190,9 +200,8 @@ def test_criar_usuario_servidor_visao_sme(
         'e_servidor': True,
         'visoes': [visao_ue.id, visao_sme.id],
         'groups': [grupo_1.id, ],
+        'id': u.id
     }
-    User = get_user_model()
-    u = User.objects.filter(username='9876543').first()
 
     assert list(u.visoes.values_list('nome', flat=True)) == ["UE", "SME"]
     assert response.status_code == status.HTTP_201_CREATED
@@ -234,6 +243,9 @@ def test_criar_usuario_servidor_com_visoes_sem_definir_unidade(
 
     result = response.json()
 
+    User = get_user_model()
+    u = User.objects.filter(username='9876543').first()
+
     esperado = {
         'username': '9876543',
         'email': 'lukaku@gmail.com',
@@ -241,10 +253,9 @@ def test_criar_usuario_servidor_com_visoes_sem_definir_unidade(
         'e_servidor': True,
         'groups': [grupo_1.id, ],
         'visoes': [visao_ue.id, ],
+        'id': u.id
 
     }
-    User = get_user_model()
-    u = User.objects.filter(username='9876543').first()
 
     assert list(u.visoes.values_list('nome', flat=True)) == ["UE", ]
     assert list(u.unidades.values_list('codigo_eol', flat=True)) == []

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_list_visoes_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_list_visoes_user.py
@@ -1,0 +1,36 @@
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_consulta_visoes(
+        jwt_authenticated_client_u2,
+        usuario_2,
+        visao_ue,
+        visao_dre,
+        visao_sme,
+        permissao1,
+        permissao2,
+        grupo_1,
+        grupo_2,
+        grupo_3):
+
+    response = jwt_authenticated_client_u2.get("/api/usuarios/visoes/", content_type='application/json')
+    result = response.json()
+    esperado = [
+
+        {
+            "id": str(visao_dre.id),
+            "nome": visao_dre.nome,
+        },
+        {
+            "id": str(visao_sme.id),
+            "nome": visao_sme.nome,
+        },
+        {
+            "id": str(visao_ue.id),
+            "nome": visao_ue.nome,
+        },
+    ]
+
+    assert result == esperado

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_update_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_update_user.py
@@ -52,6 +52,7 @@ def test_atualizar_usuario_servidor_com_visao(
         'e_servidor': True,
         'groups': [grupo_1.id],
         'visoes': [visao_ue.id, visao_dre.id, visao_sme.id],
+        'id': usuario_2.id
     }
 
     assert usuario_2.visoes.filter(nome='UE').first(), "Deveria ter sido vinculado à visão UE."
@@ -92,7 +93,8 @@ def test_atualizar_usuario_servidor_com_visoes(
         'email': 'novoEmail@gmail.com',
         'visoes': [visao_ue.id, visao_dre.id],
         'unidade': "271170",
-        'groups': [grupo_1.id]
+        'groups': [grupo_1.id],
+        'id': usuario_2.id
     }
 
     api_usuario_core_sso_or_none = 'sme_ptrf_apps.users.api.views.user.SmeIntegracaoService.usuario_core_sso_or_none'
@@ -114,6 +116,7 @@ def test_atualizar_usuario_servidor_com_visoes(
         'e_servidor': True,
         'groups': [grupo_1.id],
         'visoes': [visao_ue.id, visao_dre.id],
+        'id': usuario_2.id
     }
 
     assert usuario_2.visoes.filter(nome='UE').first(), "Deveria ter sido vinculado à visão UE."
@@ -178,6 +181,7 @@ def test_atualizar_usuario_servidor_visao_sme(
         'e_servidor': True,
         'groups': [grupo_1.id],
         'visoes': [visao_ue.id, visao_dre.id, visao_sme.id],
+        'id': usuario_3.id
     }
 
     assert usuario_3.visoes.filter(nome='SME').first(), "Deveria ter sido vinculado à visão SME."
@@ -239,6 +243,7 @@ def test_atualizar_usuario_servidor_com_visoes_sem_definir_unidade(
         'e_servidor': True,
         'groups': [grupo_1.id],
         'visoes': [visao_ue.id, visao_dre.id],
+        'id': usuario_2.id
     }
 
     assert usuario_2.unidades.filter(uuid=unidade_diferente.uuid).first(), "Deveria ter continuado vinculado à essa UE."


### PR DESCRIPTION
Esse PR altera a API de usuários para:
- Retornar o id nos posts e puts
- Endpoint para retornar lista de visões cadastradas

História [AB#39113](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39113)
