### PR TITLE
feat(39148): Não atualizar unidade com EOL inexistente

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -56,6 +56,7 @@ class AssociacaoAdmin(admin.ModelAdmin):
     search_fields = ('uuid', 'nome', 'cnpj', 'unidade__nome')
     list_filter = ('unidade__dre', 'periodo_inicial')
     readonly_fields = ('uuid', 'id')
+    list_display_links = ('nome', 'cnpj')
 
 
 @admin.register(ContaAssociacao)
@@ -89,7 +90,7 @@ class UnidadeAdmin(admin.ModelAdmin):
     ordering = ('nome',)
     search_fields = ('nome', 'codigo_eol', 'sigla')
     list_filter = ('tipo_unidade', 'dre')
-    list_display_links = ('nome',)
+    list_display_links = ('nome', 'codigo_eol')
     readonly_fields = ('uuid',)
 
     fieldsets = (

--- a/sme_ptrf_apps/core/services/unidade_service.py
+++ b/sme_ptrf_apps/core/services/unidade_service.py
@@ -50,6 +50,11 @@ def atualiza_dados_pessoais_unidade(unidade: Unidade) -> None:
         response = SmeIntegracaoService.get_dados_unidade_eol(unidade.codigo_eol)
 
         resultado = response.json()
+
+        if not resultado.get('nome'):
+            logger.info(f"API EOL não retornou informações para o código {unidade.codigo_eol}.")
+            return
+
         if resultado:
             unidade_retorno = resultado
             unidade.nome = unidade_retorno.get('nome') or ''


### PR DESCRIPTION
Essa PR altera o comportamento da atualização de dados das unidades para não gravar nome vazio quando  o código eol não é encontrado pela API do EOL.

História [AB#39148](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39148)