### PR TITLE
feat(42267): Créditos de recursos externos: permitir edição/exclusão a partir da entrada

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -268,12 +268,19 @@ def test_api_retrieve_prestacao_conta_por_uuid(jwt_authenticated_client_a, prest
                     'associacao': f'{prestacao_conta.associacao.uuid}',
                     'cpf_cnpj_fornecedor': '11.478.276/0001-04',
                     'data_documento': '2020-03-10',
+                    'data_transacao': '2020-03-10',
+                    'documento_transacao': '',
                     'nome_fornecedor': 'Fornecedor '
                                        'SA',
                     'numero_documento': '123456',
                     'tipo_documento': {
                         'id': devolucao_ao_tesouro.despesa.tipo_documento.id,
                         'nome': 'NFe'
+                    },
+                    'tipo_transacao': {
+                        'id': devolucao_ao_tesouro.despesa.tipo_transacao.id,
+                        'nome': devolucao_ao_tesouro.despesa.tipo_transacao.nome,
+                        'tem_documento': devolucao_ao_tesouro.despesa.tipo_transacao.tem_documento
                     },
                     'uuid': f'{devolucao_ao_tesouro.despesa.uuid}',
                     'valor_ptrf': 100.0,

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -84,11 +84,12 @@ class DespesaListSerializer(serializers.ModelSerializer):
     )
 
     tipo_documento = TipoDocumentoListSerializer()
+    tipo_transacao = TipoTransacaoSerializer()
 
     class Meta:
         model = Despesa
         fields = ('uuid', 'associacao', 'numero_documento', 'tipo_documento', 'data_documento', 'cpf_cnpj_fornecedor',
-                  'nome_fornecedor', 'valor_total', 'valor_ptrf')
+                  'nome_fornecedor', 'valor_total', 'valor_ptrf', 'data_transacao', 'tipo_transacao', 'documento_transacao')
 
 
 class DespesaConciliacaoSerializer(serializers.ModelSerializer):

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_com_filtros.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_com_filtros.py
@@ -108,7 +108,7 @@ def test_api_get_despesas_filtro_por_numero_documento(jwt_authenticated_client_d
 
 
 def test_api_get_despesas_campos(jwt_authenticated_client_d, associacao, despesa_fornecedor_a,
-                                 despesa_fornecedor_b, tipo_documento):
+                                 despesa_fornecedor_b, tipo_documento, tipo_transacao):
     response = jwt_authenticated_client_d.get(
         f'/api/despesas/?numero_documento=123456', content_type='application/json')
     result = json.loads(response.content)
@@ -118,11 +118,18 @@ def test_api_get_despesas_campos(jwt_authenticated_client_d, associacao, despesa
             'associacao': f'{associacao.uuid}',
             'cpf_cnpj_fornecedor': '11.478.276/0001-04',
             'data_documento': '2020-03-10',
+            'data_transacao': '2020-03-10',
+            'documento_transacao': '',
             'nome_fornecedor': 'Fornecedor A graça ARVORE',
             'numero_documento': '123456',
             'tipo_documento': {
                 'id': tipo_documento.id,
                 'nome': 'NFe',
+            },
+            'tipo_transacao': {
+                'id':tipo_transacao.id,
+                'nome': tipo_transacao.nome,
+                'tem_documento': tipo_transacao.tem_documento
             },
             'uuid': f'{despesa_fornecedor_a.uuid}',
             'valor_ptrf': 90.0,

--- a/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_api.py
+++ b/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_api.py
@@ -232,11 +232,18 @@ def test_get_receitas(
                     'associacao': str(despesa_saida_recurso.associacao.uuid),
                     'cpf_cnpj_fornecedor': '11.478.276/0001-04',
                     'data_documento': '2019-09-10',
+                    'data_transacao': '2019-09-10',
+                    'documento_transacao': '',
                     'nome_fornecedor': 'Fornecedor SA',
                     'numero_documento': '123456',
                     'tipo_documento': {
                         'id': despesa_saida_recurso.tipo_documento.id,
                         'nome': despesa_saida_recurso.tipo_documento.nome
+                    },
+                    'tipo_transacao': {
+                        'id': despesa_saida_recurso.tipo_transacao.id,
+                        'nome': despesa_saida_recurso.tipo_transacao.nome,
+                        'tem_documento': despesa_saida_recurso.tipo_transacao.tem_documento
                     },
                     'uuid': str(despesa_saida_recurso.uuid),
                     'valor_ptrf': 100.0,
@@ -411,11 +418,18 @@ def test_retrive_receitas(
                 'associacao': str(despesa_saida_recurso.associacao.uuid),
                 'cpf_cnpj_fornecedor': '11.478.276/0001-04',
                 'data_documento': '2019-09-10',
+                'data_transacao': '2019-09-10',
+                'documento_transacao': '',
                 'nome_fornecedor': 'Fornecedor SA',
                 'numero_documento': '123456',
                 'tipo_documento': {
                     'id': despesa_saida_recurso.tipo_documento.id,
                     'nome': despesa_saida_recurso.tipo_documento.nome
+                },
+                'tipo_transacao': {
+                    'id': despesa_saida_recurso.tipo_transacao.id,
+                    'nome': despesa_saida_recurso.tipo_transacao.nome,
+                    'tem_documento': despesa_saida_recurso.tipo_transacao.tem_documento
                 },
                 'uuid': str(despesa_saida_recurso.uuid),
                 'valor_ptrf': 100.0,


### PR DESCRIPTION
Esse PR:

- Altera o serializer  DespesaListSerializer, para trazer campos necessários para exibição no front

História: [AB#42267](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42267)