### PR TITLE
test(42276): Gastos da escola: Na edição de saídas vinculadas a créditos de recursos externos usar formulário simplificado Parte 2

### DIFF
--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas.py
@@ -15,6 +15,7 @@ def test_api_get_rateios_despesas(jwt_authenticated_client_d, associacao, despes
             "uuid": f'{rateio_despesa_capital.uuid}',
             "despesa": f'{despesa.uuid}',
             "numero_documento": despesa.numero_documento,
+            "receitas_saida_do_recurso": despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None,
             "status_despesa": despesa.status,
             "especificacao_material_servico": {
                 "id": rateio_despesa_capital.especificacao_material_servico.id,


### PR DESCRIPTION
Esse PR:

- Altera teste test_api_get_rateios_despesas para contemplar o campo receitas_saida_do_recurso

História: [AB#42276](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42276)