### PR TITLE
feat(34948) Adiciona nome da DRE ao retorno do endpoint

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/unidade_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/unidade_serializer.py
@@ -56,7 +56,7 @@ class UnidadeInfoAtaSerializer(serializers.ModelSerializer):
 class UnidadeListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Unidade
-        fields = ('uuid', 'codigo_eol', 'nome_com_tipo',)
+        fields = ('uuid', 'codigo_eol', 'nome_com_tipo', 'nome_dre')
 
 
 class UnidadeCreateSerializer(serializers.ModelSerializer):

--- a/sme_ptrf_apps/core/models/unidade.py
+++ b/sme_ptrf_apps/core/models/unidade.py
@@ -75,6 +75,10 @@ class Unidade(ModeloBase, TemNome):
     def nome_com_tipo(self):
         return f'{self.tipo_unidade} {self.nome}'
 
+    @property
+    def nome_dre(self):
+        return f'{self.dre.nome}'
+
     @classmethod
     def tipos_unidade_to_json(cls):
         result = []

--- a/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
@@ -26,7 +26,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas(jwt_authenticated_client_a,
             'unidade': {
                 'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
                 'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
-                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
             'status_regularidade': associacao_eco_delta_000087.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -56,7 +57,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome(jwt_authenticated_cl
             'unidade': {
                 'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
                 'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
-                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
             'status_regularidade': associacao_eco_delta_000087.status_regularidade,
             'motivo_nao_regularidade': '',

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
@@ -26,7 +26,8 @@ def test_retrieve_acao_associacao(
             'unidade': {
                 'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                 'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                'nome_dre': acao_associacao.associacao.unidade.nome_dre
             },
             'status_regularidade': acao_associacao.associacao.status_regularidade,
             'motivo_nao_regularidade': '',

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -31,7 +31,8 @@ def test_api_list_acoes_associacoes_todas(
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',
@@ -75,7 +76,8 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',
@@ -118,7 +120,8 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',
@@ -161,7 +164,8 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',
@@ -206,7 +210,8 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',
@@ -252,7 +257,8 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
                         'codigo_eol': acao_associacao.associacao.unidade.codigo_eol,
-                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo
+                        'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
+                        'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
                     'status_regularidade': acao_associacao.associacao.status_regularidade,
                     'motivo_nao_regularidade': '',

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
@@ -61,7 +61,8 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -73,7 +74,8 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'unidade': {
                 'uuid': f'{associacao_pinheiros_emef_mendes_dre_2.unidade.uuid}',
                 'codigo_eol': associacao_pinheiros_emef_mendes_dre_2.unidade.codigo_eol,
-                'nome_com_tipo': associacao_pinheiros_emef_mendes_dre_2.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_pinheiros_emef_mendes_dre_2.unidade.nome_com_tipo,
+                'nome_dre': associacao_pinheiros_emef_mendes_dre_2.unidade.nome_dre
             },
             'status_regularidade': associacao_pinheiros_emef_mendes_dre_2.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -99,7 +101,8 @@ def test_api_list_associacoes_de_uma_dre(jwt_authenticated_client_a, associacao_
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -123,7 +126,8 @@ def test_api_list_associacoes_pelo_nome_associacao_ignorando_acentos(jwt_authent
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -147,7 +151,8 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a, assoc
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -171,7 +176,8 @@ def test_api_list_associacoes_pelo_status_regularidade(jwt_authenticated_client_
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',
@@ -195,7 +201,8 @@ def test_api_list_associacoes_pelo_tipo_unidade(jwt_authenticated_client_a, asso
             'unidade': {
                 'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
                 'codigo_eol': associacao_valenca_ceu_vassouras_dre_1.unidade.codigo_eol,
-                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo
+                'nome_com_tipo': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_com_tipo,
+                'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
             },
             'status_regularidade': associacao_valenca_ceu_vassouras_dre_1.status_regularidade,
             'motivo_nao_regularidade': '',


### PR DESCRIPTION
feat(34948): Adiciona nome da DRE ao retorno do endpoint

Esse PR:
 
- Adiciona property ao modelo Unidade que retorna o nome da DRE,
- Adiciona nome da DRE ao retorno do endpoint,
- Adiciona nome da DRE em resultado esperado nos testes.

História: [AB#34948](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/34948)