### PR TITLE
feat(23153) Adiciona filtro por tipo de conta

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
@@ -9,7 +9,7 @@ from ...models import Despesa, RateioDespesa
 from ....core.api.serializers import TagLookupSerializer
 from ....core.api.serializers.acao_associacao_serializer import AcaoAssociacaoLookUpSerializer, AcaoAssociacaoSerializer
 from ....core.api.serializers.associacao_serializer import AssociacaoSerializer
-from ....core.api.serializers.conta_associacao_serializer import ContaAssociacaoSerializer
+from ....core.api.serializers.conta_associacao_serializer import ContaAssociacaoSerializer, ContaAssociacaoLookUpSerializer
 from ....core.models import AcaoAssociacao, Associacao, ContaAssociacao, Tag
 
 
@@ -71,6 +71,7 @@ class RateioDespesaListaSerializer(serializers.ModelSerializer):
         queryset=Despesa.objects.all()
     )
     acao_associacao = AcaoAssociacaoLookUpSerializer()
+    conta_associacao = ContaAssociacaoLookUpSerializer()
     especificacao_material_servico = EspecificacaoMaterialServicoLookUpSerializer()
     numero_documento = serializers.SerializerMethodField('get_numero_documento')
     status_despesa = serializers.SerializerMethodField('get_status_despesa')
@@ -132,6 +133,7 @@ class RateioDespesaListaSerializer(serializers.ModelSerializer):
             'data_transacao',
             'notificar_dias_nao_conferido',
             'receitas_saida_do_recurso',
+            'conta_associacao',
         )
 
 

--- a/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
@@ -35,7 +35,7 @@ class RateiosDespesasViewSet(mixins.CreateModelMixin,
     permission_classes = [IsAuthenticated & PermissaoApiUe]
     filter_backends = (filters.DjangoFilterBackend, SearchFilter, OrderingFilter)
     ordering_fields = ('data_documento',)
-    filter_fields = ('aplicacao_recurso', 'acao_associacao__uuid', 'despesa__status', 'associacao__uuid', 'conferido')
+    filter_fields = ('aplicacao_recurso', 'acao_associacao__uuid', 'despesa__status', 'associacao__uuid', 'conferido', 'conta_associacao__uuid', )
 
     def get_queryset(self):
         associacao_uuid = self.request.query_params.get('associacao_uuid') or self.request.query_params.get('associacao__uuid')

--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_get_rateios_despesas.py
@@ -6,7 +6,7 @@ from rest_framework import status
 pytestmark = pytest.mark.django_db
 
 
-def test_api_get_rateios_despesas(jwt_authenticated_client_d, associacao, despesa, rateio_despesa_capital):
+def test_api_get_rateios_despesas(jwt_authenticated_client_d, associacao, despesa, rateio_despesa_capital, conta_associacao):
     response = jwt_authenticated_client_d.get(f'/api/rateios-despesas/?associacao_uuid={associacao.uuid}', content_type='application/json')
     result = json.loads(response.content)
 
@@ -39,6 +39,10 @@ def test_api_get_rateios_despesas(jwt_authenticated_client_d, associacao, despes
             "tipo_transacao_nome": despesa.tipo_transacao.nome,
             "data_transacao": '2020-03-10',
             'notificar_dias_nao_conferido': 0,
+            'conta_associacao': {
+                'uuid': f'{conta_associacao.uuid}',
+                'nome': f'{conta_associacao.tipo_conta}'
+            }
         },
 
     ]


### PR DESCRIPTION
feat(23153): Adiciona filtro por tipo de conta

Esse PR:

- Adiciona tipo conta ao retorno da api,
- Adiciona filtro por tipo conta,
- Altera tests relacionados ao endpoint.

História: [AB#23153](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/23153)