### PR TITLE
feat(34048): Envio de e-mail para informar entrada de nova notificação - Parte 4

### DIFF
--- a/sme_ptrf_apps/core/services/notificacao_services/notificacao_comentario_pc_service.py
+++ b/sme_ptrf_apps/core/services/notificacao_services/notificacao_comentario_pc_service.py
@@ -40,12 +40,13 @@ def notificar_comentario_pc(dado):
 
         if usuario:
             for comentario in comentarios:
-                Notificacao.objects.create(
+                Notificacao.notificar(
                     tipo=tipo,
                     categoria=categoria,
                     remetente=remetente,
                     titulo=titulo,
                     descricao=comentario.comentario,
-                    usuario=usuario
+                    usuario=usuario,
+                    renotificar=False,
                 )
             logger.info("Notificações criadas com sucesso.")


### PR DESCRIPTION
Esse PR:

- Altera método notificar_comentario_pc, para também disparar email de nova notificação

Historia: [AB#34048](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/34048)