### PR TITLE
feat(43573) Preenche dados da unidade educacional

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -355,6 +355,7 @@ class AssociacoesViewSet(ModelViewSet):
         usuario_logado = self.request.user
         associacao = Associacao.by_uuid(uuid)
         contas = list(ContaAssociacao.objects.filter(associacao=associacao).all())
+        atualiza_dados_unidade(associacao)
 
         html_string = render_to_string('pdf/associacoes/exportarpdf/pdf.html', {'associacao': associacao, 'contas': contas, 'dataAtual': data_atual, 'usuarioLogado': usuario_logado}).encode(encoding="UTF-8")
 

--- a/sme_ptrf_apps/templates/pdf/associacoes/exportarpdf/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/associacoes/exportarpdf/pdf.html
@@ -38,7 +38,7 @@
         </tr></table><table class="tablebloco"><tr>
           <td class="tdbloco"><strong>Endereço:</strong><br> {{ associacao.unidade.logradouro }}, {{ associacao.unidade.numero }} {{ associacao.unidade.complemento }}</td><td class="tdbloco"><strong>Bairro:</strong><br> {{ associacao.unidade.bairro }}</td><td class="tdblocofim"><strong>CEP:</strong><br> {{ associacao.unidade.cep }}</td>
         </tr></table><table class="tablebloco"><tr>
-          <td class="tdbloco"><strong>Telefone:</strong><br> {{ associacao.unidade.telefone }}</td><td class="tdbloco"><strong>Código EOL:</strong><br> {{ associacao.unidade.codigo_eol }}</td><td class="tdblocofim"><strong>E-mail:</strong><br> {{ associacao.unidade.email }}</td>
+          <td class="tdbloco"><strong>Telefone:</strong><br> {{ associacao.unidade.telefone }}</td><td class="tdbloco"><strong>Código EOL:</strong><br> {{ associacao.unidade.codigo_eol }}</td><td class="tdblocofim"><strong>E-mail:</strong><br> {{ associacao.email }}</td>
         </tr></table>
       </td></tr>
     </tbody>


### PR DESCRIPTION
feat(43573): Preenche dados da unidade educacional

Esse PR:

- Atualiza modelo Unidade com o retorno da API do Sistema EOL, antes de gerar a ficha cadastral,
- Altera campo "email" da ficha cadastral, agora sendo preenchido pelo email cadastrado no modelo Associacao.

História: [AB#43573](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43573)