### PR TITLE
feat(43735) Altera regra de cadastro de uma conciliação

### DIFF
--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -26,6 +26,7 @@ from ...services import (
     transacoes_para_conciliacao,
     conciliar_transacao,
     desconciliar_transacao,
+    salva_conciliacao_bancaria
 )
 from ....despesas.models import Despesa
 from ....receitas.models import Receita
@@ -289,21 +290,15 @@ class ConciliacoesViewSet(GenericViewSet):
         saldo_extrato = request.data.get('saldo_extrato', 0.0)
 
         # Define texto
-        texto_observacao = request.data.get('observacao')
+        texto_observacao = request.data.get('observacao', None)
 
         # Define comprovante extrato bancario
         comprovante_extrato = request.data.get('comprovante_extrato', None)
         data_atualizacao_comprovante_extrato = request.data.get('data_atualizacao_comprovante_extrato', None)
 
-        ObservacaoConciliacao.criar_atualizar(
-            periodo=periodo,
-            conta_associacao=conta_associacao,
-            texto_observacao=texto_observacao,
-            data_extrato=data_extrato,
-            saldo_extrato=saldo_extrato,
-            comprovante_extrato=comprovante_extrato,
-            data_atualizacao_comprovante_extrato=data_atualizacao_comprovante_extrato,
-        )
+        salva_conciliacao_bancaria(texto_observacao, periodo, conta_associacao,
+                                   data_extrato, saldo_extrato, comprovante_extrato,
+                                   data_atualizacao_comprovante_extrato, ObservacaoConciliacao)
 
         return Response({'mensagem': 'Informações gravadas'}, status=status.HTTP_200_OK)
 

--- a/sme_ptrf_apps/core/models/observacao_conciliacao.py
+++ b/sme_ptrf_apps/core/models/observacao_conciliacao.py
@@ -31,12 +31,13 @@ class ObservacaoConciliacao(ModeloBase):
         return self.texto[:30]
 
     @classmethod
-    def criar_atualizar(cls, periodo, conta_associacao, texto_observacao="", data_extrato=None, saldo_extrato=0.0, comprovante_extrato=None, data_atualizacao_comprovante_extrato=None):
+    def criar_atualizar_extrato_bancario(cls, periodo, conta_associacao, data_extrato, saldo_extrato,
+                                         comprovante_extrato, data_atualizacao_comprovante_extrato):
 
         observacao = cls.objects.filter(periodo=periodo, conta_associacao=conta_associacao).first()
+
         if observacao:
-            if texto_observacao or data_extrato or saldo_extrato or comprovante_extrato or data_atualizacao_comprovante_extrato:
-                observacao.texto = texto_observacao
+            if data_extrato or saldo_extrato or comprovante_extrato or data_atualizacao_comprovante_extrato:
                 observacao.data_extrato = data_extrato
                 observacao.saldo_extrato = saldo_extrato
 
@@ -48,16 +49,34 @@ class ObservacaoConciliacao(ModeloBase):
                     observacao.comprovante_extrato = ''
 
                 observacao.save()
-            else:
-                observacao.delete()
-        elif texto_observacao or data_extrato or saldo_extrato or comprovante_extrato or data_atualizacao_comprovante_extrato:
-            cls.objects.create(
-                periodo=periodo,
-                conta_associacao=conta_associacao,
-                associacao=conta_associacao.associacao,
-                texto=texto_observacao,
-                data_extrato=data_extrato,
-                saldo_extrato=saldo_extrato,
-                comprovante_extrato=comprovante_extrato,
-                data_atualizacao_comprovante_extrato=data_atualizacao_comprovante_extrato,
-            )
+        else:
+            if data_extrato or saldo_extrato or comprovante_extrato or data_atualizacao_comprovante_extrato:
+                cls.objects.create(
+                    periodo=periodo,
+                    conta_associacao=conta_associacao,
+                    associacao=conta_associacao.associacao,
+                    data_extrato=data_extrato,
+                    saldo_extrato=saldo_extrato,
+                    comprovante_extrato=comprovante_extrato,
+                    data_atualizacao_comprovante_extrato=data_atualizacao_comprovante_extrato,
+                )
+
+    @classmethod
+    def criar_atualizar_justificativa(cls, periodo, conta_associacao, texto_observacao):
+        observacao = cls.objects.filter(periodo=periodo, conta_associacao=conta_associacao).first()
+
+        if observacao:
+            if texto_observacao:
+                observacao.texto = texto_observacao
+                observacao.save()
+        else:
+            if texto_observacao:
+                cls.objects.create(
+                    periodo=periodo,
+                    conta_associacao=conta_associacao,
+                    associacao=conta_associacao.associacao,
+                    texto=texto_observacao,
+                    data_extrato=None,
+                    comprovante_extrato=None,
+                    data_atualizacao_comprovante_extrato=None,
+                )

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -8,6 +8,7 @@ from .conciliacao_services import (
     transacoes_para_conciliacao,
     conciliar_transacao,
     desconciliar_transacao,
+    salva_conciliacao_bancaria,
 )
 from .exporta_associacao import gerar_planilha
 from .implantacao_saldos_services import implanta_saldos_da_associacao, implantacoes_de_saldo_da_associacao

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -479,3 +479,24 @@ def desconciliar_transacao(conta_associacao, transacao, tipo_transacao):
             rateio.desmarcar_conferido()
         despesa_desconciliada = Despesa.by_uuid(transacao.uuid)
         return DespesaConciliacaoSerializer(despesa_desconciliada, many=False).data
+
+
+def salva_conciliacao_bancaria(texto_observacao, periodo, conta_associacao,
+                               data_extrato, saldo_extrato, comprovante_extrato,
+                               data_atualizacao_comprovante_extrato,
+                               observacao_conciliacao):
+    if texto_observacao:
+        observacao_conciliacao.criar_atualizar_justificativa(
+            periodo=periodo,
+            conta_associacao=conta_associacao,
+            texto_observacao=texto_observacao,
+        )
+    else:
+        observacao_conciliacao.criar_atualizar_extrato_bancario(
+            periodo=periodo,
+            conta_associacao=conta_associacao,
+            data_extrato=data_extrato,
+            saldo_extrato=saldo_extrato,
+            comprovante_extrato=comprovante_extrato,
+            data_atualizacao_comprovante_extrato=data_atualizacao_comprovante_extrato,
+        )

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_salva_observacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_salva_observacoes.py
@@ -15,13 +15,33 @@ from ...models import ObservacaoConciliacao
 pytestmark = pytest.mark.django_db
 
 
-def test_api_salva_observacoes_conciliacao(jwt_authenticated_client_a, periodo, conta_associacao_cartao):
+def test_api_salva_observacoes_conciliacao_justificativa(jwt_authenticated_client_a, periodo, conta_associacao_cartao):
     url = f'/api/conciliacoes/salvar-observacoes/'
 
     payload = {
         "periodo_uuid": f'{periodo.uuid}',
         "conta_associacao_uuid": f'{conta_associacao_cartao.uuid}',
         "observacao": "Teste observações.",
+    }
+
+    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert ObservacaoConciliacao.objects.exists()
+
+    obj = ObservacaoConciliacao.objects.first()
+    assert obj.data_extrato is None
+    assert obj.saldo_extrato == 0.0
+    assert obj.texto == "Teste observações."
+
+
+def test_api_salva_observacoes_conciliacao_extrato_bancario(jwt_authenticated_client_a, periodo, conta_associacao_cartao):
+    url = f'/api/conciliacoes/salvar-observacoes/'
+
+    payload = {
+        "periodo_uuid": f'{periodo.uuid}',
+        "conta_associacao_uuid": f'{conta_associacao_cartao.uuid}',
         "data_extrato": "2021-01-01",
         "saldo_extrato": 1000.00,
     }
@@ -35,7 +55,6 @@ def test_api_salva_observacoes_conciliacao(jwt_authenticated_client_a, periodo, 
     obj = ObservacaoConciliacao.objects.first()
     assert obj.data_extrato == date(2021, 1, 1)
     assert obj.saldo_extrato == 1000.0
-    assert obj.texto == "Teste observações."
 
 
 def test_api_salva_observacoes_conciliacao_vazia(jwt_authenticated_client_a, periodo,


### PR DESCRIPTION
feat(43735) Altera regra de cadastro de uma conciliação

Esse PR:

- Permite cadastrar concilição bancária por blocos (extrato bancário ou justificativas),
- Adiciona tests relacionados ao cadastro de conciliação bancária

História: [AB#43735](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43735)