### PR TITLE
feat(43735) parte 2 aprimora cadastro de conciliacao por bloco

### DIFF
--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -248,6 +248,9 @@ class ConciliacoesViewSet(GenericViewSet):
         # Define o período de conciliação
         periodo_uuid = request.data.get('periodo_uuid')
 
+        # Define se é um cadastro de justificativa ou extrato bancario
+        justificativa_ou_extrato_bancario = request.data.get('justificativa_ou_extrato_bancario')
+
         if not periodo_uuid:
             erro = {
                 'erro': 'parametros_requeridos',
@@ -290,14 +293,14 @@ class ConciliacoesViewSet(GenericViewSet):
         saldo_extrato = request.data.get('saldo_extrato', 0.0)
 
         # Define texto
-        texto_observacao = request.data.get('observacao', None)
+        texto_observacao = request.data.get('observacao', "")
 
         # Define comprovante extrato bancario
         comprovante_extrato = request.data.get('comprovante_extrato', None)
         data_atualizacao_comprovante_extrato = request.data.get('data_atualizacao_comprovante_extrato', None)
 
-        salva_conciliacao_bancaria(texto_observacao, periodo, conta_associacao,
-                                   data_extrato, saldo_extrato, comprovante_extrato,
+        salva_conciliacao_bancaria(justificativa_ou_extrato_bancario, texto_observacao, periodo,
+                                   conta_associacao, data_extrato, saldo_extrato, comprovante_extrato,
                                    data_atualizacao_comprovante_extrato, ObservacaoConciliacao)
 
         return Response({'mensagem': 'Informações gravadas'}, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/models/observacao_conciliacao.py
+++ b/sme_ptrf_apps/core/models/observacao_conciliacao.py
@@ -66,11 +66,11 @@ class ObservacaoConciliacao(ModeloBase):
         observacao = cls.objects.filter(periodo=periodo, conta_associacao=conta_associacao).first()
 
         if observacao:
-            if texto_observacao:
+            if texto_observacao is not None:
                 observacao.texto = texto_observacao
                 observacao.save()
         else:
-            if texto_observacao:
+            if texto_observacao is not None:
                 cls.objects.create(
                     periodo=periodo,
                     conta_associacao=conta_associacao,

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -481,17 +481,18 @@ def desconciliar_transacao(conta_associacao, transacao, tipo_transacao):
         return DespesaConciliacaoSerializer(despesa_desconciliada, many=False).data
 
 
-def salva_conciliacao_bancaria(texto_observacao, periodo, conta_associacao,
-                               data_extrato, saldo_extrato, comprovante_extrato,
-                               data_atualizacao_comprovante_extrato,
+def salva_conciliacao_bancaria(justificativa_ou_extrato_bancario, texto_observacao, periodo,
+                               conta_associacao, data_extrato, saldo_extrato,
+                               comprovante_extrato, data_atualizacao_comprovante_extrato,
                                observacao_conciliacao):
-    if texto_observacao:
+
+    if justificativa_ou_extrato_bancario == "JUSTIFICATIVA":
         observacao_conciliacao.criar_atualizar_justificativa(
             periodo=periodo,
             conta_associacao=conta_associacao,
             texto_observacao=texto_observacao,
         )
-    else:
+    elif justificativa_ou_extrato_bancario == "EXTRATO_BANCARIO":
         observacao_conciliacao.criar_atualizar_extrato_bancario(
             periodo=periodo,
             conta_associacao=conta_associacao,

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_salva_observacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_salva_observacoes.py
@@ -22,6 +22,7 @@ def test_api_salva_observacoes_conciliacao_justificativa(jwt_authenticated_clien
         "periodo_uuid": f'{periodo.uuid}',
         "conta_associacao_uuid": f'{conta_associacao_cartao.uuid}',
         "observacao": "Teste observações.",
+        "justificativa_ou_extrato_bancario": "JUSTIFICATIVA"
     }
 
     response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
@@ -44,6 +45,7 @@ def test_api_salva_observacoes_conciliacao_extrato_bancario(jwt_authenticated_cl
         "conta_associacao_uuid": f'{conta_associacao_cartao.uuid}',
         "data_extrato": "2021-01-01",
         "saldo_extrato": 1000.00,
+        "justificativa_ou_extrato_bancario": "EXTRATO_BANCARIO"
     }
 
     response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')


### PR DESCRIPTION
feat(43735) parte 2 aprimora cadastro de conciliacao por bloco

Esse PR:

- Aprimora condição para identificar se é um cadastro de extrato bancario ou justificativa
- Permite cadastro de justificativa vazia

História [AB#43735](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43735)