### PR TITLE
feat(43799): Inclui arquivos de referência no retrieve de PC

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from sme_ptrf_apps.core.models import PrestacaoConta
+from sme_ptrf_apps.core.models import PrestacaoConta, ObservacaoConciliacao
 from sme_ptrf_apps.core.api.serializers import (AssociacaoCompletoSerializer, DevolucaoPrestacaoContaRetrieveSerializer,
                                                 AnaliseContaPrestacaoContaRetrieveSerializer,
                                                 DevolucaoAoTesouroRetrieveSerializer)
@@ -80,6 +80,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     analises_de_conta_da_prestacao = AnaliseContaPrestacaoContaRetrieveSerializer(many=True)
     devolucoes_ao_tesouro_da_prestacao = DevolucaoAoTesouroRetrieveSerializer(many=True)
     motivos_aprovacao_ressalva = MotivoAprovacaoRessalvaSerializer(many=True)
+    arquivos_referencia = serializers.SerializerMethodField('get_arquivos_referencia')
 
     def get_periodo_uuid(self, obj):
         return obj.periodo.uuid
@@ -90,12 +91,64 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     def get_devolucao_ao_tesouro(self, obj):
         return _str_devolucao_ao_tesouro(obj)
 
+    def get_arquivos_referencia(self, prestacao_contas):
+        result = []
+
+        for demonstrativo in prestacao_contas.demonstrativos_da_prestacao.all():
+            result.append(
+                {
+                    'tipo': 'DF',
+                    'nome': f'Demonstrativo Financeiro da Conta {demonstrativo.conta_associacao.tipo_conta.nome}',
+                    'uuid': f'{demonstrativo.uuid}',
+                    'conta_uuid': f'{demonstrativo.conta_associacao.uuid}'
+                }
+            )
+
+        for rel_bens in prestacao_contas.relacoes_de_bens_da_prestacao.all():
+            result.append(
+                {
+                    'tipo': 'RB',
+                    'nome': f'Relação de Bens da Conta {rel_bens.conta_associacao.tipo_conta.nome}',
+                    'uuid': f'{rel_bens.uuid}',
+                    'conta_uuid': f'{rel_bens.conta_associacao.uuid}'
+                }
+            )
+
+        extratos = ObservacaoConciliacao.objects.filter(
+            associacao=prestacao_contas.associacao).filter(periodo=prestacao_contas.periodo)
+
+        for extrato in extratos:
+            if extrato.comprovante_extrato:
+                result.append(
+                    {
+                        'tipo': 'EB',
+                        'nome': f'Extrato Bancário da Conta {extrato.conta_associacao.tipo_conta.nome}',
+                        'uuid': f'{extrato.uuid}',
+                        'conta_uuid': f'{extrato.conta_associacao.uuid}'
+                    }
+                )
+        return result
+
     class Meta:
         model = PrestacaoConta
-        fields = ('uuid', 'status', 'associacao', 'periodo_uuid', 'tecnico_responsavel', 'data_recebimento',
-                  'devolucoes_da_prestacao', 'processo_sei', 'data_ultima_analise', 'devolucao_ao_tesouro',
-                  'analises_de_conta_da_prestacao', 'motivos_reprovacao',
-                  'devolucoes_ao_tesouro_da_prestacao', 'motivos_aprovacao_ressalva', 'outros_motivos_aprovacao_ressalva')
+        fields = (
+            'uuid',
+            'status',
+            'associacao',
+            'periodo_uuid',
+            'tecnico_responsavel',
+            'data_recebimento',
+            'devolucoes_da_prestacao',
+            'processo_sei',
+            'data_ultima_analise',
+            'devolucao_ao_tesouro',
+            'analises_de_conta_da_prestacao',
+            'motivos_reprovacao',
+            'devolucoes_ao_tesouro_da_prestacao',
+            'motivos_aprovacao_ressalva',
+            'outros_motivos_aprovacao_ressalva',
+            'arquivos_referencia',
+        )
 
 
 def _str_devolucao_ao_tesouro(obj):

--- a/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
+++ b/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
@@ -310,3 +310,32 @@ class DemonstrativoFinanceiroViewSet(GenericViewSet):
             msg = str(demonstrativo_financeiro)
 
         return Response(msg)
+
+    @action(detail=True, methods=['get'], url_path='pdf',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComGravacao])
+    def pdf(self, request, uuid):
+        """/api/demonstrativo-financeiro/{uuid}/pdf"""
+        logger.info("Download do documento Final.")
+
+        demonstrativo_financeiro = DemonstrativoFinanceiro.by_uuid(uuid)
+
+        logger.info("Demonstrativo Financeiro: %s", str(demonstrativo_financeiro))
+
+        try:
+
+            filename = 'demonstrativo_financeiro.pdf'
+            response = HttpResponse(
+                open(demonstrativo_financeiro.arquivo_pdf.path, 'rb'),
+                content_type='application/pdf'
+            )
+            response['Content-Disposition'] = 'attachment; filename=%s' % filename
+
+        except Exception as err:
+            erro = {
+                'erro': 'arquivo_nao_gerado',
+                'mensagem': str(err)
+            }
+            logger.info("Erro: %s", str(err))
+            return Response(erro, status=status.HTTP_404_NOT_FOUND)
+
+        return response

--- a/sme_ptrf_apps/core/models/observacao_conciliacao.py
+++ b/sme_ptrf_apps/core/models/observacao_conciliacao.py
@@ -28,7 +28,7 @@ class ObservacaoConciliacao(ModeloBase):
         verbose_name_plural = '09.5) Informações de conciliação'
 
     def __str__(self):
-        return self.texto[:30]
+        return f'Conciliação: {self.periodo.referencia}'
 
     @classmethod
     def criar_atualizar_extrato_bancario(cls, periodo, conta_associacao, data_extrato, saldo_extrato,


### PR DESCRIPTION
Esse PR:
- Altera o retrieve de Prestação de contas passa a incluir lista de arquivos de
referência Demonstrativo Financeiro, Relação de Bens e Comprovante de
extrato.

- Implementa novos endpoints para baixar esses documentos por UUID.

História: [AB#43799](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43799)