### PR TITLE
feat(42261)-parte-2 Ajuste endpoint que retorna membros

### DIFF
--- a/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
@@ -58,12 +58,20 @@ class MembroAssociacaoViewSet(mixins.RetrieveModelMixin,
             }
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        result = MembroAssociacao.objects.filter(associacao__uuid=associacao_uuid).values(
-            'nome',
-            'cargo_associacao'
-        )
+        result = MembroAssociacao.objects.filter(associacao__uuid=associacao_uuid).all()
+        lista_content = []
 
-        return Response(result)
+        for membro in result:
+            content = {
+                'uuid': membro.uuid,
+                'nome': membro.nome,
+                'cargo_associacao_key': membro.cargo_associacao,
+                'cargo_associacao_value': membro.get_cargo_associacao_display()
+            }
+
+            lista_content.append(content)
+
+        return Response(lista_content)
 
     @action(detail=False, methods=['get'], url_path='codigo-identificacao',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])


### PR DESCRIPTION
feat(42261)-parte-2 Ajuste endpoint que retorna membros

Esse PR:

- Adiciona uuid ao retorno do endpoint
- Adiciona cargo_associaco_value ao retorno do endpoint

História: [AB#42261](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42261)