### PR TITLE
feat(43961)-parte-2 Permite cadastro de arquivo pelo admin

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -545,5 +545,5 @@ class AmbienteAdmin(admin.ModelAdmin):
 @admin.register(ArquivoDownload)
 class ArquivoDownloadAdmin(admin.ModelAdmin):
     list_display = ('identificador', 'status', 'alterado_em', 'lido')
-    readonly_fields = ('uuid', 'id', 'usuario')
+    readonly_fields = ('uuid', 'id',)
     list_display_links = ('identificador',)


### PR DESCRIPTION
feat(43961)-parte-2 Permite cadastro de arquivo pelo admin

Esse PR:

- Permite edição de usuario no admin do modelo ArquivoDownload

História: [AB#43961](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43961)