### PR TITLE
feat(48031)-parte-2 Remove campo admin

### DIFF
--- a/sme_ptrf_apps/users/admin.py
+++ b/sme_ptrf_apps/users/admin.py
@@ -55,6 +55,7 @@ class GrupoAdmin(admin.ModelAdmin):
     list_display = ["name"]
 
     def get_form(self, request, obj=None, **kwargs):
+        self.exclude = ("visoes_log",)
         form = super(GrupoAdmin, self).get_form(request, obj, **kwargs)
         print(form.__dict__)
         form.base_fields['permissions'].queryset = Permission.objects.filter(name__contains='Pode')


### PR DESCRIPTION
feat(48031)-parte-2 Remove campo admin

Esse PR:

- Remove a visualização do campo "visoes_log" do admin.

História: [AB#48031](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/48031)