### PR TITLE
feat(43993): Cria endpoint que lista devoluções de PC

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -52,7 +52,8 @@ from ..serializers import (
     PrestacaoContaLookUpSerializer,
     PrestacaoContaRetrieveSerializer,
     AnaliseLancamentoPrestacaoContaRetrieveSerializer,
-    AnaliseDocumentoPrestacaoContaRetrieveSerializer
+    AnaliseDocumentoPrestacaoContaRetrieveSerializer,
+    AnalisePrestacaoContaRetrieveSerializer
 )
 
 from django.core.exceptions import ValidationError
@@ -1363,3 +1364,10 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(AnaliseDocumentoPrestacaoContaRetrieveSerializer(analise_documento).data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['get'], url_path="devolucoes",
+            permission_classes=[IsAuthenticated & PermissaoAPIApenasDreComGravacao])
+    def devolucoes(self, request, uuid):
+        prestacao_conta = PrestacaoConta.by_uuid(uuid)
+        devolucoes = prestacao_conta.analises_da_prestacao.filter(status='DEVOLVIDA').order_by('id')
+        return Response(AnalisePrestacaoContaRetrieveSerializer(devolucoes, many=True).data, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 from model_bakery import baker
 
-
 @pytest.fixture
 def periodo_2019_2():
     return baker.make(
@@ -555,7 +554,6 @@ def fechamento_periodo_2019_2_role_1000(periodo_2019_2, associacao, conta_associ
 
 @pytest.fixture
 def prestacao_conta_2020_1_teste_analises(periodo_2020_1, associacao):
-    # Aqui PC
     return baker.make(
         'PrestacaoConta',
         periodo=periodo_2020_1,
@@ -574,9 +572,9 @@ def devolucao_prestacao_conta_2020_1_teste_analises(prestacao_conta_2020_1_teste
         data_limite_ue=datetime.date(2020, 8, 1),
     )
 
+
 @pytest.fixture
 def analise_prestacao_conta_2020_1_teste_analises(
-    # Aqui
     prestacao_conta_2020_1_teste_analises,
     devolucao_prestacao_conta_2020_1_teste_analises
 ):
@@ -658,7 +656,6 @@ def solicitacao_acerto_lancamento_devolucao_teste_analises(
         devolucao_ao_tesouro=devolucao_ao_tesouro_parcial_ajuste,
         detalhamento="teste"
     )
-
 
 
 @pytest.fixture

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_list_analise_prestacao_contas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_list_analise_prestacao_contas.py
@@ -1,0 +1,87 @@
+import json
+import datetime
+import pytest
+
+from model_bakery import baker
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def prestacao_conta_2020_1_teste_analises(periodo_2020_1, associacao):
+    # Aqui PC
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        data_recebimento=datetime.date(2020, 10, 1),
+        status="EM_ANALISE"
+    )
+
+
+@pytest.fixture
+def devolucao_prestacao_conta_2020_1_teste_analises(prestacao_conta_2020_1_teste_analises):
+    return baker.make(
+        'DevolucaoPrestacaoConta',
+        prestacao_conta=prestacao_conta_2020_1_teste_analises,
+        data=datetime.date(2020, 10, 5),
+        data_limite_ue=datetime.date(2020, 8, 1),
+    )
+
+@pytest.fixture
+def analise_prestacao_conta_2020_1_devolvida(
+    prestacao_conta_2020_1_teste_analises,
+    devolucao_prestacao_conta_2020_1_teste_analises
+):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_2020_1_teste_analises,
+        devolucao_prestacao_conta=devolucao_prestacao_conta_2020_1_teste_analises,
+        status='DEVOLVIDA'
+    )
+
+
+@pytest.fixture
+def analise_prestacao_conta_2020_1_aprovada(
+    prestacao_conta_2020_1_teste_analises,
+):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_2020_1_teste_analises,
+        devolucao_prestacao_conta=None,
+        status='APROVADA'
+    )
+
+
+def test_api_analise_prestacao_contas_list_devolucoes(
+    jwt_authenticated_client_a,
+    analise_prestacao_conta_2020_1_devolvida,
+    analise_prestacao_conta_2020_1_aprovada
+):
+    analise_prestacao = analise_prestacao_conta_2020_1_devolvida
+    prestacao_conta = analise_prestacao.prestacao_conta
+
+    result_esperado = [
+        {
+            'criado_em': analise_prestacao.criado_em.isoformat("T"),
+            'devolucao_prestacao_conta': {'cobrancas_da_devolucao': [],
+                                          'data': '2020-10-05',
+                                          'data_limite_ue': '2020-08-01',
+                                          'prestacao_conta': f'{analise_prestacao.prestacao_conta.uuid}',
+                                          'uuid': f'{analise_prestacao.devolucao_prestacao_conta.uuid}'},
+            'id': analise_prestacao.id,
+            'prestacao_conta': f'{prestacao_conta.uuid}',
+            'status': 'DEVOLVIDA',
+            'uuid': f'{analise_prestacao.uuid}'
+        },
+    ]
+
+    url = f'/api/prestacoes-contas/{prestacao_conta.uuid}/devolucoes/'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado


### PR DESCRIPTION
Esse PR:
- Cria o endpoint que retorna a lista de análises de prestação de contas que resultaram em devolução.

História [AB#43993](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43993)