### PR TITLE
feat(43893): Remove devolução tesouro da conclusão de análise PC

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -334,16 +334,6 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
     def salvar_analise(self, request, uuid):
         prestacao_conta = self.get_object()
 
-        devolucao_tesouro = request.data.get('devolucao_tesouro', None)
-        if devolucao_tesouro is None:
-            response = {
-                'uuid': f'{uuid}',
-                'erro': 'falta_de_informacoes',
-                'operacao': 'salvar-analise',
-                'mensagem': 'Faltou informar o campo devolucao_tesouro.'
-            }
-            return Response(response, status=status.HTTP_400_BAD_REQUEST)
-
         analises_de_conta_da_prestacao = request.data.get('analises_de_conta_da_prestacao', None)
         if analises_de_conta_da_prestacao is None:
             response = {
@@ -353,8 +343,6 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                 'mensagem': 'Faltou informar o campo analises_de_conta_da_prestacao.'
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
-
-        devolucoes_ao_tesouro_da_prestacao = request.data.get('devolucoes_ao_tesouro_da_prestacao', [])
 
         if prestacao_conta.status != PrestacaoConta.STATUS_EM_ANALISE:
             response = {
@@ -366,9 +354,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
-        prestacao_salva = prestacao_conta.salvar_analise(devolucao_tesouro=devolucao_tesouro,
-                                                         analises_de_conta_da_prestacao=analises_de_conta_da_prestacao,
-                                                         devolucoes_ao_tesouro_da_prestacao=devolucoes_ao_tesouro_da_prestacao)
+        prestacao_salva = prestacao_conta.salvar_analise(analises_de_conta_da_prestacao=analises_de_conta_da_prestacao)
 
         return Response(PrestacaoContaRetrieveSerializer(prestacao_salva, many=False).data,
                         status=status.HTTP_200_OK)
@@ -422,16 +408,6 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
-        devolucao_tesouro = request.data.get('devolucao_tesouro', None)
-        if devolucao_tesouro is None:
-            response = {
-                'uuid': f'{uuid}',
-                'erro': 'falta_de_informacoes',
-                'operacao': 'concluir-analise',
-                'mensagem': 'Faltou informar o campo devolucao_tesouro.'
-            }
-            return Response(response, status=status.HTTP_400_BAD_REQUEST)
-
         analises_de_conta_da_prestacao = request.data.get('analises_de_conta_da_prestacao', None)
         if analises_de_conta_da_prestacao is None:
             response = {
@@ -441,8 +417,6 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                 'mensagem': 'Faltou informar o campo analises_de_conta_da_prestacao.'
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
-
-        devolucoes_ao_tesouro_da_prestacao = request.data.get('devolucoes_ao_tesouro_da_prestacao', [])
 
         if prestacao_conta.status != PrestacaoConta.STATUS_EM_ANALISE:
             response = {
@@ -518,13 +492,11 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
 
         prestacao_salva = prestacao_conta.concluir_analise(
             resultado_analise=resultado_analise,
-            devolucao_tesouro=devolucao_tesouro,
             analises_de_conta_da_prestacao=analises_de_conta_da_prestacao,
             motivos_aprovacao_ressalva=motivos_aprovacao_ressalva,
             outros_motivos_aprovacao_ressalva=outros_motivos_aprovacao_ressalva,
             data_limite_ue=data_limite_ue,
             motivos_reprovacao=motivos_reprovacao,
-            devolucoes_ao_tesouro_da_prestacao=devolucoes_ao_tesouro_da_prestacao
         )
 
         return Response(PrestacaoContaRetrieveSerializer(prestacao_salva, many=False).data,

--- a/sme_ptrf_apps/core/models/analise_conta_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_conta_prestacao_conta.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
+
 class AnaliseContaPrestacaoConta(ModeloBase):
     prestacao_conta = models.ForeignKey('PrestacaoConta', on_delete=models.CASCADE,
                                         related_name='analises_de_conta_da_prestacao')

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta.py
@@ -54,38 +54,6 @@ def test_api_conclui_analise_prestacao_conta_exige_resultado_analise(jwt_authent
     assert result == result_esperado, "Deveria ter retornado erro falta_de_informacoes."
 
 
-def test_api_conclui_analise_prestacao_conta_exige_devolucao_tesouro(jwt_authenticated_client_a,
-                                                                     prestacao_conta_em_analise,
-                                                                     conta_associacao):
-    payload = {
-        'analises_de_conta_da_prestacao': [
-            {
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'data_extrato': '2020-07-01',
-                'saldo_extrato': 100.00,
-            },
-        ],
-        'resultado_analise': PrestacaoConta.STATUS_APROVADA
-    }
-
-    url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/concluir-analise/'
-
-    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    result = json.loads(response.content)
-
-    result_esperado = {
-        'uuid': f'{prestacao_conta_em_analise.uuid}',
-        'erro': 'falta_de_informacoes',
-        'operacao': 'concluir-analise',
-        'mensagem': 'Faltou informar o campo devolucao_tesouro.'
-    }
-
-    assert result == result_esperado, "Deveria ter retornado erro falta_de_informacoes."
-
-
 def test_api_conclui_analise_prestacao_conta_exige_analises_de_conta_da_prestacao(jwt_authenticated_client_a,
                                                                                   prestacao_conta_em_analise):
     payload = {

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_aprovada.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_aprovada.py
@@ -47,7 +47,6 @@ def test_api_conclui_analise_prestacao_conta_aprovada(jwt_authenticated_client_a
     prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_em_analise.uuid)
     assert prestacao_atualizada.status == PrestacaoConta.STATUS_APROVADA, 'Status deveria ter passado para APROVADA.'
     assert prestacao_atualizada.data_ultima_analise == date(2020, 9, 1), 'Data de última análise não atualizada.'
-    assert prestacao_atualizada.devolucao_tesouro, 'Devolução ao tesouro não atualizado.'
     assert prestacao_atualizada.analises_de_conta_da_prestacao.exists(), 'Não gravou a análise de conta'
     assert prestacao_atualizada.analises_de_conta_da_prestacao.first().data_extrato == date(2020, 7,
                                                                                             1), 'Não atualizou a data do extrato.'

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_devolvida.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_devolvida.py
@@ -115,17 +115,6 @@ def test_api_conclui_analise_prestacao_conta_devolvida(jwt_authenticated_client_
         ],
         'resultado_analise': PrestacaoConta.STATUS_DEVOLVIDA,
         'data_limite_ue': '2020-07-21',
-        'devolucoes_ao_tesouro_da_prestacao': [
-            {
-                'data': '2020-07-01',
-                'devolucao_total': True,
-                'motivo': 'teste',
-                'valor': 100.00,
-                'tipo': f'{tipo_devolucao_ao_tesouro.uuid}',
-                'despesa': f'{despesa.uuid}',
-                'visao_criacao': 'UE',
-            }
-        ]
     }
 
     url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/concluir-analise/'
@@ -139,7 +128,6 @@ def test_api_conclui_analise_prestacao_conta_devolvida(jwt_authenticated_client_
     assert prestacao_atualizada.devolucoes_da_prestacao.exists(), 'Não gravou o registro de devolução da PC.'
     assert prestacao_atualizada.devolucoes_da_prestacao.first().data_limite_ue == date(2020, 7,
                                                                                        21), 'Não gravou a data limite.'
-    assert prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.exists(), 'Não gravou as devoluções ao tesouro'
 
 
 def test_api_conclui_analise_prestacao_conta_aprovada_ressalva_exige_data_limite(jwt_authenticated_client_a,

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_analise_prestacao_conta.py
@@ -56,17 +56,6 @@ def test_api_salva_analise_prestacao_conta(jwt_authenticated_client_a, prestacao
                 'saldo_extrato': 100.00,
             },
         ],
-        'devolucoes_ao_tesouro_da_prestacao': [
-            {
-                'data': '2020-07-01',
-                'devolucao_total': True,
-                'motivo': 'teste',
-                'valor': 100.00,
-                'tipo': f'{tipo_devolucao_ao_tesouro.uuid}',
-                'despesa': f'{despesa.uuid}',
-                'visao_criacao': 'UE'
-            }
-        ]
     }
 
     url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/salvar-analise/'
@@ -78,31 +67,10 @@ def test_api_salva_analise_prestacao_conta(jwt_authenticated_client_a, prestacao
     prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_em_analise.uuid)
     assert prestacao_atualizada.status == PrestacaoConta.STATUS_EM_ANALISE, 'Status deveria ter sido mantido.'
     assert prestacao_atualizada.data_ultima_analise == date(2020, 9, 1), 'Data de última análise não atualizada.'
-    assert prestacao_atualizada.devolucao_tesouro, 'Devolução ao tesouro não atualizado.'
     assert prestacao_atualizada.analises_de_conta_da_prestacao.exists(), 'Não gravou a análise de conta'
     assert prestacao_atualizada.analises_de_conta_da_prestacao.first().data_extrato == date(2020, 7,
                                                                                             1), 'Não atualizou a data do extrato.'
     assert prestacao_atualizada.analises_de_conta_da_prestacao.first().saldo_extrato == 100.00, 'Não atualizou a saldo do extrato.'
-    assert prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.exists(), 'Não gravou as devoluções ao tesouro'
-    assert prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.first().visao_criacao == 'UE'
-
-def test_api_salvar_prestacao_conta_exige_devolucao_tesouro(jwt_authenticated_client_a, prestacao_conta_em_analise):
-    url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/salvar-analise/'
-
-    response = jwt_authenticated_client_a.patch(url, content_type='application/json')
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    result = json.loads(response.content)
-
-    result_esperado = {
-        'uuid': f'{prestacao_conta_em_analise.uuid}',
-        'erro': 'falta_de_informacoes',
-        'operacao': 'salvar-analise',
-        'mensagem': 'Faltou informar o campo devolucao_tesouro.'
-    }
-
-    assert result == result_esperado, "Deveria ter retornado erro falta_de_informacoes."
 
 
 def test_api_salvar_prestacao_conta_exige_analises_de_conta_da_prestacao(jwt_authenticated_client_a,


### PR DESCRIPTION
Esse PR altera a conclusão e salvamento de análise de prestação de contas para não mais gravar devoluções ao tesouro.

História: AB#43893