### PR TITLE
feat(43993): Cria endpoint que lista devoluções de PC - Pull Request 2

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -389,11 +389,16 @@ def _gerar_arquivos_demonstrativo_financeiro(acoes, periodo, conta_associacao, p
     return demonstrativo
 
 
+def tem_solicitacao_acerto_do_tipo(analise_lancamento, tipo_acerto):
+    return analise_lancamento.solicitacoes_de_ajuste_da_analise.filter(tipo_acerto=tipo_acerto).exists()
+
+
 def lancamentos_da_prestacao(
     analise_prestacao_conta,
     conta_associacao,
     acao_associacao=None,
     tipo_transacao=None,
+    tipo_acerto=None,
     com_ajustes=False,
 ):
     from sme_ptrf_apps.despesas.api.serializers.despesa_serializer import DespesaConciliacaoSerializer
@@ -447,6 +452,9 @@ def lancamentos_da_prestacao(
 
         analise_lancamento = analise_prestacao_conta.analises_de_lancamentos.filter(despesa=despesa).first()
 
+        if analise_lancamento and tipo_acerto and not tem_solicitacao_acerto_do_tipo(analise_lancamento, tipo_acerto):
+            continue
+
         if com_ajustes and (not analise_lancamento or analise_lancamento.resultado != 'AJUSTE'):
             continue
 
@@ -488,6 +496,9 @@ def lancamentos_da_prestacao(
     for receita in receitas:
 
         analise_lancamento = analise_prestacao_conta.analises_de_lancamentos.filter(receita=receita).first()
+
+        if analise_lancamento and tipo_acerto and not tem_solicitacao_acerto_do_tipo(analise_lancamento, tipo_acerto):
+            continue
 
         if com_ajustes and (not analise_lancamento or analise_lancamento.resultado != 'AJUSTE'):
             continue

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
@@ -595,7 +595,7 @@ def analise_lancamento_receita_prestacao_conta_2020_1_teste_analises(
         analise_prestacao_conta=analise_prestacao_conta_2020_1_teste_analises,
         tipo_lancamento='CREDITO',
         receita=receita_2020_1_ptrf_repasse_conferida,
-        resultado='CORRETO'
+        resultado='AJUSTE'
     )
 
 
@@ -657,6 +657,19 @@ def solicitacao_acerto_lancamento_devolucao_teste_analises(
         detalhamento="teste"
     )
 
+
+@pytest.fixture
+def solicitacao_acerto_lancamento_basico_tipo_teste_analises(
+    analise_lancamento_receita_prestacao_conta_2020_1_teste_analises,
+    tipo_acerto_lancamento_basico,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento_receita_prestacao_conta_2020_1_teste_analises,
+        tipo_acerto=tipo_acerto_lancamento_basico,
+        devolucao_ao_tesouro=None,
+        detalhamento="teste 2"
+    )
 
 @pytest.fixture
 def tipo_documento_prestacao_conta_declaracao():

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -184,10 +184,7 @@ def test_api_list_lancamentos_todos_da_conta(
     rateio_despesa_2020_role_nao_conferido,
     periodo_2020_1,
     conta_associacao_cartao,
-    receita_2020_1_ptrf_repasse_conferida,
-    receita_2020_1_role_outras_nao_conferida,
     analise_prestacao_conta_2020_1_teste_analises,
-    analise_lancamento_receita_prestacao_conta_2020_1_teste_analises,
     analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
     solicitacao_acerto_lancamento_devolucao_teste_analises
 ):
@@ -222,6 +219,64 @@ def test_api_list_lancamentos_todos_da_conta(
                                             conta=conta_associacao_cartao)
 
     url = f'/api/analises-prestacoes-contas/{analise_prestacao_conta_2020_1_teste_analises.uuid}/lancamentos-com-ajustes/?conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
+
+
+def test_api_list_lancamentos_todos_da_conta_por_tipo_ajuste(
+    jwt_authenticated_client_a,
+    despesa_2020_1,
+    rateio_despesa_2020_role_conferido,
+    rateio_despesa_2020_ptrf_conferido,
+    rateio_despesa_2020_role_cheque_conferido,
+    rateio_despesa_2020_role_nao_conferido,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    receita_2020_1_ptrf_repasse_conferida,
+    receita_2020_1_role_outras_nao_conferida,
+    analise_prestacao_conta_2020_1_teste_analises,
+    analise_lancamento_receita_prestacao_conta_2020_1_teste_analises,
+    analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
+    solicitacao_acerto_lancamento_devolucao_teste_analises,
+    solicitacao_acerto_lancamento_basico_tipo_teste_analises,
+    tipo_acerto_lancamento_devolucao,
+):
+    conta_uuid = conta_associacao_cartao.uuid
+
+    lancamentos_esperados = [
+        {
+            'mestre': despesa_2020_1,
+            'rateios': [
+                rateio_despesa_2020_role_conferido,
+                rateio_despesa_2020_ptrf_conferido,
+                rateio_despesa_2020_role_nao_conferido
+            ],
+            'tipo': 'Gasto',
+            'valor_transacao_na_conta': 300.0,
+            'valores_por_conta': [
+                {
+                    'conta_associacao__tipo_conta__nome': 'Cartão',
+                    'valor_rateio__sum': 300.0
+                },
+                {
+                    'conta_associacao__tipo_conta__nome': 'Cheque',
+                    'valor_rateio__sum': 100.0
+                }
+            ],
+            'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
+            'solicitacao_ajuste': solicitacao_acerto_lancamento_devolucao_teste_analises,
+        },
+    ]
+
+    result_esperado = monta_result_esperado(lancamentos_esperados=lancamentos_esperados, periodo=periodo_2020_1,
+                                            conta=conta_associacao_cartao)
+
+    url = f'/api/analises-prestacoes-contas/{analise_prestacao_conta_2020_1_teste_analises.uuid}/lancamentos-com-ajustes/?conta_associacao={conta_uuid}&tipo_acerto={tipo_acerto_lancamento_devolucao.uuid}'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
 


### PR DESCRIPTION
Esse PR:
- Alterar a conclusão de PC para atualizar o registro da análise corrente;
- Inclui filtro por tipo de acerto na consulta de lançamentos com ajustes em uma análise de PC

História: [AB#43993](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43993)
