### PR TITLE
fix(49747): [Gestão de perfil] O filtro por grupo deveria exibir os grupos das unidades subordinadas

### DIFF
--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -136,18 +136,43 @@ class UserViewSet(ModelViewSet):
             logging.info("Erro ao buscar grupos do usuário %s", erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            grupos = Grupo.objects.filter(visoes__nome=visao).all()
-
-            return Response(
-                [{'id': str(grupo.id), "nome": grupo.name, "descricao": grupo.descricao, "visao": visao} for grupo in grupos])
-        except Exception as err:
-            erro = {
-                'erro': 'erro_ao_consultar_grupos',
-                'mensagem': str(err)
-            }
-            logging.info("Erro ao buscar grupos do usuário %s", erro)
-            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+        if visao == 'SME':
+            try:
+                grupos = Grupo.objects.all().order_by('name')
+                return Response(
+                    [{'id': str(grupo.id), "nome": grupo.name, "descricao": grupo.descricao, "visao": visao} for grupo
+                     in grupos])
+            except Exception as err:
+                erro = {
+                    'erro': 'erro_ao_consultar_grupos',
+                    'mensagem': str(err)
+                }
+                logging.info("Erro ao buscar grupos do usuário %s", erro)
+                return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+        elif visao == "DRE":
+            try:
+                grupos = Grupo.objects.filter(Q(visoes__nome="DRE") | Q(visoes__nome="UE")).order_by('name')
+                return Response(
+                         [{'id': str(grupo.id), "nome": grupo.name, "descricao": grupo.descricao, "visao": visao} for grupo in grupos])
+            except Exception as err:
+                erro = {
+                    'erro': 'erro_ao_consultar_grupos',
+                    'mensagem': str(err)
+                }
+                logging.info("Erro ao buscar grupos do usuário %s", erro)
+                return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            try:
+                grupos = Grupo.objects.filter(visoes__nome="UE").order_by('name')
+                return Response(
+                         [{'id': str(grupo.id), "nome": grupo.name, "descricao": grupo.descricao, "visao": visao} for grupo in grupos])
+            except Exception as err:
+                erro = {
+                    'erro': 'erro_ao_consultar_grupos',
+                    'mensagem': str(err)
+                }
+                logging.info("Erro ao buscar grupos do usuário %s", erro)
+                return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
     # TODO Rever url_path 'usuarios/consultar'. É boa prática em APIs Rest evitar verbos. Poderia ser 'servidores'
     @action(detail=False, methods=['get'], url_path='consultar')

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_list_grupos_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_list_grupos_user.py
@@ -18,6 +18,12 @@ def test_consulta_grupos(
     result = response.json()
     esperado = [
         {
+            "id": str(grupo_1.id),
+            "nome": grupo_1.name,
+            "descricao": grupo_1.descricao,
+            "visao": 'DRE'
+        },
+        {
             "id": str(grupo_2.id),
             "nome": grupo_2.name,
             "descricao": grupo_2.descricao,


### PR DESCRIPTION
Esse PR:

- Altera retorno de grupos por visão

História: [AB#49747](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/49747)