### PR TITLE
bugfix(50224) Filtro de PCs por múltiplos status

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -780,25 +780,29 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        # Pega filtros
+        # Pega filtros por nome e tipo de unidade
         nome = self.request.query_params.get('nome')
         tipo_unidade = self.request.query_params.get('tipo_unidade')
-        status_pc = self.request.query_params.get('status')
 
-        if status_pc and status_pc not in ['TODOS']:
-            erro = {
-                'erro': 'status-invalido',
-                'operacao': 'todos-os-status',
-                'mensagem': 'Só é possível filtrar Todos pelo status TODOS'
-            }
-            logger.info('Erro: %r', erro)
-            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+        # Pega e valida filtro por status
+        status_pc = self.request.query_params.get('status')
+        status_pc_list = status_pc.split(',') if status_pc else []
+        for status_str in status_pc_list:
+            if status_str not in PrestacaoConta.STATUS_NOMES.keys():
+                erro = {
+                    'erro': 'status-invalido',
+                    'operacao': 'todos-os-status',
+                    'mensagem': 'Passe um status de prestação de contas válido.'
+                }
+                logger.info('Erro: %r', erro)
+                return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         result = lista_prestacoes_de_conta_todos_os_status(
             dre=dre,
             periodo=periodo,
             filtro_nome=nome,
             filtro_tipo_unidade=tipo_unidade,
+            filtro_por_status=status_pc_list,
         )
         return Response(result)
 

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -716,20 +716,22 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
         tipo_unidade = self.request.query_params.get('tipo_unidade')
         status_pc = self.request.query_params.get('status')
 
-        if status_pc and status_pc not in [PrestacaoConta.STATUS_NAO_APRESENTADA, PrestacaoConta.STATUS_NAO_RECEBIDA]:
-            erro = {
-                'erro': 'status-invalido',
-                'operacao': 'nao-recebidas',
-                'mensagem': 'Só é possível filtrar não recebidas pelos status NAO_APRESENTADA e NAO_RECEBIDA.'
-            }
-            logger.info('Erro: %r', erro)
-            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+        status_pc_list = status_pc.split(',') if status_pc else []
+        for status_str in status_pc_list:
+            if status_str not in [PrestacaoConta.STATUS_NAO_APRESENTADA, PrestacaoConta.STATUS_NAO_RECEBIDA]:
+                erro = {
+                    'erro': 'status-invalido',
+                    'operacao': 'nao-recebidas',
+                    'mensagem': 'Esse endpoint só aceita o filtro por status para os status NAO_APRESENTADA e NAO_RECEBIDA.'
+                }
+                logger.info('Erro: %r', erro)
+                return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         result = lista_prestacoes_de_conta_nao_recebidas(dre=dre,
                                                          periodo=periodo,
                                                          filtro_nome=nome,
                                                          filtro_tipo_unidade=tipo_unidade,
-                                                         filtro_status=status_pc
+                                                         filtro_status=status_pc_list
                                                          )
         return Response(result)
 

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -75,12 +75,10 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
     def get_queryset(self):
         qs = PrestacaoConta.objects.all().order_by('associacao__unidade__tipo_unidade', 'associacao__unidade__nome')
 
-        status = self.request.query_params.get('status')
-        if status is not None:
-            if status in ['APROVADA', 'APROVADA_RESSALVA']:
-                qs = qs.filter(Q(status='APROVADA') | Q(status='APROVADA_RESSALVA'))
-            else:
-                qs = qs.filter(status=status)
+        status_pc = self.request.query_params.get('status')
+        status_pc_list = status_pc.split(',') if status_pc else []
+        if status_pc_list:
+            qs = qs.filter(status__in=status_pc_list)
 
         nome = self.request.query_params.get('nome')
         if nome is not None:

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -321,7 +321,8 @@ def lista_prestacoes_de_conta_todos_os_status(
     dre,
     periodo,
     filtro_nome=None,
-    filtro_tipo_unidade=None
+    filtro_tipo_unidade=None,
+    filtro_por_status=[]
 ):
     associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(cnpj__exact='').order_by(
         'unidade__tipo_unidade', 'unidade__nome')
@@ -336,6 +337,14 @@ def lista_prestacoes_de_conta_todos_os_status(
     prestacoes = []
     for associacao in associacoes_da_dre:
         prestacao_conta = PrestacaoConta.objects.filter(associacao=associacao, periodo=periodo).first()
+
+        if filtro_por_status and not prestacao_conta and PrestacaoConta.STATUS_NAO_APRESENTADA not in filtro_por_status:
+            # Pula PCs não apresentadas se existir um filtro por status e não contiver o status não apresentada
+            continue
+
+        if filtro_por_status and prestacao_conta and prestacao_conta.status not in filtro_por_status:
+            # Pula PCs apresentadas se existir um filtro por status e não contiver o status da PC
+            continue
 
         info_prestacao = {
             'periodo_uuid': f'{periodo.uuid}',

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -267,7 +267,7 @@ def informacoes_financeiras_para_atas(prestacao_contas):
 def lista_prestacoes_de_conta_nao_recebidas(
     dre,
     periodo,
-    filtro_nome=None, filtro_tipo_unidade=None, filtro_status=None
+    filtro_nome=None, filtro_tipo_unidade=None, filtro_status=[]
 ):
     associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(cnpj__exact='').order_by(
         'unidade__tipo_unidade', 'unidade__nome')
@@ -289,12 +289,13 @@ def lista_prestacoes_de_conta_nao_recebidas(
             continue
 
         # Aplica o filtro por status
-        if filtro_status == PrestacaoConta.STATUS_NAO_RECEBIDA:
-            if not prestacao_conta or prestacao_conta.status != PrestacaoConta.STATUS_NAO_RECEBIDA:
-                continue
-        elif filtro_status == PrestacaoConta.STATUS_NAO_APRESENTADA:
-            if prestacao_conta and prestacao_conta.status != PrestacaoConta.STATUS_NAO_APRESENTADA:
-                continue
+        if filtro_status:
+            if PrestacaoConta.STATUS_NAO_APRESENTADA not in filtro_status:
+                if not prestacao_conta or prestacao_conta.status not in filtro_status:
+                    continue
+            else:
+                if prestacao_conta and prestacao_conta.status not in filtro_status:
+                    continue
 
         info_prestacao = {
             'periodo_uuid': f'{periodo.uuid}',

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta.py
@@ -432,19 +432,17 @@ def test_api_list_prestacoes_conta_por_data_recebimento(jwt_authenticated_client
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_por_status_aprovada_e_aprovada_ressalva(jwt_authenticated_client_a,
-                                                                           _prestacao_conta_2020_1_unidade_a_dre1,
-                                                                           # Entra
-                                                                           _prestacao_conta_2020_1_unidade_c_dre1,
-                                                                           # Não entra
-                                                                           _prestacao_conta_2019_2_unidade_a_dre1,
-                                                                           # Entra
-                                                                           _prestacao_conta_2020_1_unidade_b_dre2,
-                                                                           # Não entra
-                                                                           _dre_01,
-                                                                           periodo_2020_1,
-                                                                           periodo_2019_2):
-    url = f'/api/prestacoes-contas/?status=APROVADA'
+def test_api_list_prestacoes_conta_por_status_aprovada_e_aprovada_ressalva(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_c_dre1, # Não entra
+    _prestacao_conta_2019_2_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_b_dre2, # Não entra
+    _dre_01,
+    periodo_2020_1,
+    periodo_2019_2
+):
+    url = f'/api/prestacoes-contas/?status=APROVADA,APROVADA_RESSALVA'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
 
@@ -486,18 +484,91 @@ def test_api_list_prestacoes_conta_por_status_aprovada_e_aprovada_ressalva(jwt_a
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_por_status_recebida(jwt_authenticated_client_a,
-                                                       _prestacao_conta_2020_1_unidade_a_dre1,
-                                                       # Não entra
-                                                       _prestacao_conta_2020_1_unidade_c_dre1,
-                                                       # Entra
-                                                       _prestacao_conta_2019_2_unidade_a_dre1,
-                                                       # Não entra
-                                                       _prestacao_conta_2020_1_unidade_b_dre2,
-                                                       # Não entra
-                                                       _dre_01,
-                                                       periodo_2020_1,
-                                                       periodo_2019_2):
+def test_api_list_prestacoes_conta_por_status_aprovada(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_c_dre1, # Não entra
+    _prestacao_conta_2019_2_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_b_dre2, # Não entra
+    _dre_01,
+    periodo_2020_1,
+    periodo_2019_2
+):
+    url = f'/api/prestacoes-contas/?status=APROVADA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': '2020-01-01',
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'APROVADA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'unidade_tipo_unidade': 'EMEI',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        }
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_por_status_aprovada_ressalva(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_c_dre1, # Não entra
+    _prestacao_conta_2019_2_unidade_a_dre1, # Entra
+    _prestacao_conta_2020_1_unidade_b_dre2, # Não entra
+    _dre_01,
+    periodo_2020_1,
+    periodo_2019_2
+):
+    url = f'/api/prestacoes-contas/?status=APROVADA_RESSALVA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2019_2.uuid}',
+            'data_recebimento': '2019-01-01',
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'APROVADA_RESSALVA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'unidade_tipo_unidade': 'EMEI',
+            'uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2019_2_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': 'Não'
+
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_por_status_recebida(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1, # Não entra
+    _prestacao_conta_2020_1_unidade_c_dre1, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2, # Não entra
+    _dre_01,
+    periodo_2020_1,
+    periodo_2019_2
+):
     url = f'/api/prestacoes-contas/?status=RECEBIDA'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_nao_recebidas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_nao_recebidas.py
@@ -144,13 +144,17 @@ def _prestacao_conta_2020_1_unidade_b_dre2(periodo_2020_1, _unidade_b_dre_2, _as
     )
 
 
-def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre(jwt_authenticated_client_a,
-                                                                   _prestacao_conta_2020_1_unidade_a_dre1,  # Entra
-                                                                   _prestacao_conta_2019_2_unidade_a_dre1,  # Não entra
-                                                                   _prestacao_conta_2020_1_unidade_b_dre2,  # Não entra
-                                                                   _dre_01,
-                                                                   _associacao_c_dre_1,  # Entra como NAO_APRESENTADA
-                                                                   periodo_2020_1):
+def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_sem_filtro_por_status(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1,  # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1,  # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2,  # Não entra
+    _dre_01,
+    _associacao_c_dre_1,  # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    """ Deve listar todas as PC Não apresentadas ou Não recebidas """
+
     dre_uuid = _dre_01.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -208,17 +212,17 @@ def _prestacao_conta_2020_1_unidade_a_dre1_em_analise(periodo_2020_1, _unidade_a
     )
 
 
-def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_nao_inclui_outros_status(jwt_authenticated_client_a,
-                                                                                            _prestacao_conta_2020_1_unidade_a_dre1_em_analise,
-                                                                                            # Não Entra
-                                                                                            _prestacao_conta_2019_2_unidade_a_dre1,
-                                                                                            # Não entra
-                                                                                            _prestacao_conta_2020_1_unidade_b_dre2,
-                                                                                            # Não entra
-                                                                                            _dre_01,
-                                                                                            _associacao_c_dre_1,
-                                                                                            # Entra como NAO_APRESENTADA
-                                                                                            periodo_2020_1):
+def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_nao_inclui_outros_status(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_em_analise, # Não Entra
+    _prestacao_conta_2019_2_unidade_a_dre1, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2, # Não entra
+    _dre_01,
+    _associacao_c_dre_1, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    """ PCs de status diferente de Não Recebida devem ser ignoradas """
+
     dre_uuid = _dre_01.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -444,13 +448,17 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_tipo_unidade(jwt_authentica
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_nao_recebidas_por_status(jwt_authenticated_client_a,
-                                                            _prestacao_conta_2020_1_unidade_a_dre1,  # Entra
-                                                            _prestacao_conta_2019_2_unidade_a_dre1,  # Não entra
-                                                            _prestacao_conta_2020_1_unidade_b_dre2,  # Não entra
-                                                            _dre_01,
-                                                            _associacao_c_dre_1,  # Entra como NAO_APRESENTADA
-                                                            periodo_2020_1):
+def test_api_list_prestacoes_conta_nao_recebidas_por_status_nao_recebida(jwt_authenticated_client_a,
+                                                                         _prestacao_conta_2020_1_unidade_a_dre1,
+                                                                         # Entra
+                                                                         _prestacao_conta_2019_2_unidade_a_dre1,
+                                                                         # Não entra
+                                                                         _prestacao_conta_2020_1_unidade_b_dre2,
+                                                                         # Não entra
+                                                                         _dre_01,
+                                                                         _associacao_c_dre_1,
+                                                                         # Entra como NAO_APRESENTADA
+                                                                         periodo_2020_1):
     dre_uuid = _dre_01.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -480,6 +488,21 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_status(jwt_authenticated_cl
     assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado
 
+
+def test_api_list_prestacoes_conta_nao_recebidas_por_status_nao_apresentada(jwt_authenticated_client_a,
+                                                                            _prestacao_conta_2020_1_unidade_a_dre1,
+                                                                            # Entra
+                                                                            _prestacao_conta_2019_2_unidade_a_dre1,
+                                                                            # Não entra
+                                                                            _prestacao_conta_2020_1_unidade_b_dre2,
+                                                                            # Não entra
+                                                                            _dre_01,
+                                                                            _associacao_c_dre_1,
+                                                                            # Entra como NAO_APRESENTADA
+                                                                            periodo_2020_1):
+    dre_uuid = _dre_01.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
     url = f'/api/prestacoes-contas/nao-recebidas/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=NAO_APRESENTADA'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
@@ -507,6 +530,19 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_status(jwt_authenticated_cl
     assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado
 
+
+def test_api_list_prestacoes_conta_nao_recebidas_por_status_diferente_nao_recebida_nao_apresentada(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1,  # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1,  # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2,  # Não entra
+    _dre_01,
+    _associacao_c_dre_1,  # Entra como NAO_APRESENTADA
+    periodo_2020_1):
+
+    dre_uuid = _dre_01.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
     url = f'/api/prestacoes-contas/nao-recebidas/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=APROVADA'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
@@ -515,9 +551,63 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_status(jwt_authenticated_cl
 
     result_esperado = {
         'erro': 'status-invalido',
-        'mensagem': 'Só é possível filtrar não recebidas pelos status NAO_APRESENTADA e NAO_RECEBIDA.',
+        'mensagem': 'Esse endpoint só aceita o filtro por status para os status NAO_APRESENTADA e NAO_RECEBIDA.',
         'operacao': 'nao-recebidas'
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_nao_recebidas_por_mais_de_um_status(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1,  # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1,  # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2,  # Não entra
+    _dre_01,
+    _associacao_c_dre_1,  # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    dre_uuid = _dre_01.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
+    url = f'/api/prestacoes-contas/nao-recebidas/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=NAO_RECEBIDA,NAO_APRESENTADA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_APRESENTADA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000102',
+            'unidade_nome': 'Codorna',
+            'unidade_tipo_unidade': 'CEU',
+            'uuid': '',
+            'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+
+        },
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_RECEBIDA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'unidade_tipo_unidade': 'EMEI',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        }
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_todos_os_status.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_todos_os_status.py
@@ -161,17 +161,15 @@ def _prestacao_conta_2020_1_unidade_a_dre1_em_analise(periodo_2020_1, _unidade_a
     )
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre(jwt_authenticated_client_a,
-                                                                     _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status,
-                                                                     # Entra
-                                                                     _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                                     # Não entra
-                                                                     _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                                     # Não entra
-                                                                     _dre_01_todos_os_status,
-                                                                     _associacao_c_dre_1_todos_os_status,
-                                                                     # Entra como NAO_APRESENTADA
-                                                                     periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -217,19 +215,16 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre(jwt_authent
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre_inclui_outros_status(jwt_authenticated_client_a,
-                                                                                          _prestacao_conta_2020_1_unidade_a_dre1_em_analise,
-                                                                                          # Entra
-                                                                                          _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                                                          # Não entra
-                                                                                          _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                                                          # Não entra
-                                                                                          _dre_01_todos_os_status,
-                                                                                          _associacao_c_dre_1_todos_os_status,
-                                                                                          # Entra como NAO_APRESENTADA
-                                                                                          _associacao_a_dre_1_todos_os_status,
-                                                                                          # Entra como EM_ANALISE
-                                                                                          periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre_inclui_outros_status(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_em_analise, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    _associacao_a_dre_1_todos_os_status, # Entra como EM_ANALISE
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -274,17 +269,15 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre_inclui_outr
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(jwt_authenticated_client_a,
-                                                                  _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status,
-                                                                  # Entra
-                                                                  _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                                  # Não entra
-                                                                  _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                                  # Não entra
-                                                                  _dre_01_todos_os_status,
-                                                                  _associacao_c_dre_1_todos_os_status,
-                                                                  # Entra como NAO_APRESENTADA
-                                                                  periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -342,17 +335,15 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(jwt_authenti
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(jwt_authenticated_client_a,
-                                                                     _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status,
-                                                                     # Entra
-                                                                     _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                                     # Não entra
-                                                                     _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                                     # Não entra
-                                                                     _dre_01_todos_os_status,
-                                                                     _associacao_c_dre_1_todos_os_status,
-                                                                     # Entra como NAO_APRESENTADA
-                                                                     periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -410,17 +401,15 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(jwt_authe
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(jwt_authenticated_client_a,
-                                                                  _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status,
-                                                                  # Entra
-                                                                  _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                                  # Não entra
-                                                                  _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                                  # Não entra
-                                                                  _dre_01_todos_os_status,
-                                                                  _associacao_c_dre_1_todos_os_status,
-                                                                  # Entra como NAO_APRESENTADA
-                                                                  periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
@@ -478,21 +467,149 @@ def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(jwt_authenti
     assert result == result_esperado
 
 
-def test_api_list_prestacoes_conta_todos_os_status_por_status(jwt_authenticated_client_a,
-                                                            _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status,
-                                                            # Entra
-                                                            _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status,
-                                                            # Não entra
-                                                            _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status,
-                                                            # Não entra
-                                                            _dre_01_todos_os_status,
-                                                            _associacao_c_dre_1_todos_os_status,
-                                                            # Entra como NAO_APRESENTADA
-                                                            periodo_2020_1):
+def test_api_list_prestacoes_conta_todos_os_status_por_status_nao_apresentada(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
     dre_uuid = _dre_01_todos_os_status.uuid
     periodo_uuid = periodo_2020_1.uuid
 
-    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=TODOS'
+    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=NAO_APRESENTADA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_APRESENTADA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000102',
+            'unidade_nome': 'Codorna',
+            'unidade_tipo_unidade': 'CEU',
+            'uuid': '',
+            'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_todos_os_status_nao_recebida(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    dre_uuid = _dre_01_todos_os_status.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
+    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=NAO_RECEBIDA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_RECEBIDA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'unidade_tipo_unidade': 'EMEI',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_prestacoes_conta_todos_os_status_nao_recebida_nao_apresentada(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    dre_uuid = _dre_01_todos_os_status.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
+    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=NAO_RECEBIDA,NAO_APRESENTADA'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_APRESENTADA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000102',
+            'unidade_nome': 'Codorna',
+            'unidade_tipo_unidade': 'CEU',
+            'uuid': '',
+            'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        },
+        {
+            'periodo_uuid': f'{periodo_2020_1.uuid}',
+            'data_recebimento': None,
+            'data_ultima_analise': None,
+            'processo_sei': '',
+            'status': 'NAO_RECEBIDA',
+            'tecnico_responsavel': '',
+            'unidade_eol': '000101',
+            'unidade_nome': 'Andorinha',
+            'unidade_tipo_unidade': 'EMEI',
+            'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
+            'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
+            'devolucao_ao_tesouro': '0,00'
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+def test_api_list_prestacoes_conta_todos_os_status_sem_filtro_por_status(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    dre_uuid = _dre_01_todos_os_status.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
+    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
 
@@ -533,7 +650,19 @@ def test_api_list_prestacoes_conta_todos_os_status_por_status(jwt_authenticated_
     assert result == result_esperado
 
 
-    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=APROVADA'
+def test_api_list_prestacoes_conta_todos_os_status_por_status_invalido(
+    jwt_authenticated_client_a,
+    _prestacao_conta_2020_1_unidade_a_dre1_todos_os_status, # Entra
+    _prestacao_conta_2019_2_unidade_a_dre1_todos_os_status, # Não entra
+    _prestacao_conta_2020_1_unidade_b_dre2_todos_os_status, # Não entra
+    _dre_01_todos_os_status,
+    _associacao_c_dre_1_todos_os_status, # Entra como NAO_APRESENTADA
+    periodo_2020_1
+):
+    dre_uuid = _dre_01_todos_os_status.uuid
+    periodo_uuid = periodo_2020_1.uuid
+
+    url = f'/api/prestacoes-contas/todos-os-status/?associacao__unidade__dre__uuid={dre_uuid}&periodo__uuid={periodo_uuid}&status=TODOS'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
 
@@ -542,7 +671,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_status(jwt_authenticated_
     result_esperado = {
         'erro': 'status-invalido',
         'operacao': 'todos-os-status',
-        'mensagem': 'Só é possível filtrar Todos pelo status TODOS'
+        'mensagem': 'Passe um status de prestação de contas válido.'
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Esse PR altera o comportamento de alguns endpoints de Prestação de Contas incluindo a possibilidade de filtro por múltiplos status.

O que foi feito:
[X] Novo filtro em /api/prestacoes-contas/nao-recebidas/
[X] Novo filtro em /api/prestacoes-contas/
[X] Novo filtro em /api/prestacoes-contas/todos-os-status/

Resolve o bug [AB#50224](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50224)
