### PR TITLE
fix(50753): Cria novo serializer que retorna receitas_saida_do_recurso

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -419,7 +419,7 @@ def lancamentos_da_prestacao(
     tipo_acerto=None,
     com_ajustes=False,
 ):
-    from sme_ptrf_apps.despesas.api.serializers.despesa_serializer import DespesaConciliacaoSerializer
+    from sme_ptrf_apps.despesas.api.serializers.despesa_serializer import DespesaDocumentoMestreSerializer
     from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaConciliacaoSerializer
     from sme_ptrf_apps.receitas.api.serializers.receita_serializer import ReceitaConciliacaoSerializer
     from sme_ptrf_apps.core.api.serializers.analise_lancamento_prestacao_conta_serializer import AnaliseLancamentoPrestacaoContaRetrieveSerializer
@@ -492,7 +492,7 @@ def lancamentos_da_prestacao(
                 'conta_associacao__tipo_conta__nome').annotate(
                 Sum('valor_rateio')),
             'conferido': despesa.conferido,
-            'documento_mestre': DespesaConciliacaoSerializer(despesa, many=False).data,
+            'documento_mestre': DespesaDocumentoMestreSerializer(despesa, many=False).data,
             'rateios': RateioDespesaConciliacaoSerializer(
                 despesa.rateios.filter(status=STATUS_COMPLETO).filter(conta_associacao=conta_associacao).order_by('id'),
                 many=True).data,

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -14,6 +14,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta):
         mestre_esperado = {
             'associacao': f'{lancamento["mestre"].associacao.uuid}',
             'numero_documento': lancamento["mestre"].numero_documento,
+            'receitas_saida_do_recurso': None,
             'tipo_documento': {
                 'id': lancamento["mestre"].tipo_documento.id,
                 'nome': lancamento["mestre"].tipo_documento.nome,

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_get_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_get_lancamentos.py
@@ -14,6 +14,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta):
         mestre_esperado = {
             'associacao': f'{lancamento["mestre"].associacao.uuid}',
             'numero_documento': lancamento["mestre"].numero_documento,
+            'receitas_saida_do_recurso': None,
             'tipo_documento': {
                 'id': lancamento["mestre"].tipo_documento.id,
                 'nome': lancamento["mestre"].tipo_documento.nome,
@@ -160,20 +161,20 @@ def test_api_get_lancamentos_todos_da_conta(
             'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
         },
         {
-            'mestre': receita_2020_1_ptrf_repasse_conferida,
-            'rateios': [],
-            'tipo': 'Crédito',
-            'valor_transacao_na_conta': 100.0,
-            'valores_por_conta': [],
-            'analise_lancamento': analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
-        },
-        {
             'mestre': receita_2020_1_role_outras_nao_conferida,
             'rateios': [],
             'tipo': 'Crédito',
             'valor_transacao_na_conta': 100.0,
             'valores_por_conta': [],
             'analise_lancamento': None
+        },
+        {
+            'mestre': receita_2020_1_ptrf_repasse_conferida,
+            'rateios': [],
+            'tipo': 'Crédito',
+            'valor_transacao_na_conta': 100.0,
+            'valores_por_conta': [],
+            'analise_lancamento': analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
         },
     ]
 

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -149,3 +149,39 @@ class DespesaConciliacaoSerializer(serializers.ModelSerializer):
             'conferido',
             'uuid',
         )
+
+
+class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
+    associacao = serializers.SlugRelatedField(
+        slug_field='uuid',
+        required=False,
+        queryset=Associacao.objects.all()
+    )
+
+    tipo_documento = TipoDocumentoListSerializer()
+    tipo_transacao = TipoTransacaoSerializer()
+
+    receitas_saida_do_recurso = serializers.SerializerMethodField('get_recurso_externo')
+
+    def get_recurso_externo(self, despesa):
+        return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
+
+    class Meta:
+        model = Despesa
+        fields = (
+            'associacao',
+            'numero_documento',
+            'tipo_documento',
+            'tipo_transacao',
+            'documento_transacao',
+            'data_documento',
+            'data_transacao',
+            'cpf_cnpj_fornecedor',
+            'nome_fornecedor',
+            'valor_ptrf',
+            'valor_total',
+            'status',
+            'conferido',
+            'uuid',
+            'receitas_saida_do_recurso',
+        )


### PR DESCRIPTION
Esse PR:

- Cria novo serializer que retorna receitas_saida_do_recurso

História: [AB#50753](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50753)