### PR TITLE
feat(45684): Alterar verificação de status em operação analisar PC

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -292,13 +292,13 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
     def analisar(self, request, uuid):
         prestacao_conta = self.get_object()
 
-        if prestacao_conta.status != PrestacaoConta.STATUS_RECEBIDA:
+        if prestacao_conta.status not in (PrestacaoConta.STATUS_RECEBIDA, PrestacaoConta.STATUS_DEVOLVIDA_RECEBIDA):
             response = {
                 'uuid': f'{prestacao_conta.uuid}',
                 'erro': 'status_nao_permite_operacao',
                 'status': prestacao_conta.status,
                 'operacao': 'analisar',
-                'mensagem': 'Você não pode analisar uma prestação de contas com status diferente de RECEBIDA.'
+                'mensagem': 'Você não pode analisar uma prestação de contas com status diferente de RECEBIDA ou DEVOLVIDA_RECEBIDA.'
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_analisa_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_analisa_prestacao_conta.py
@@ -82,7 +82,7 @@ def test_api_analisar_prestacao_conta_nao_pode_aceitar_status_diferente_de_receb
         'erro': 'status_nao_permite_operacao',
         'status': prestacao_conta_aprovada.status,
         'operacao': 'analisar',
-        'mensagem': 'Você não pode analisar uma prestação de contas com status diferente de RECEBIDA.'
+        'mensagem': 'Você não pode analisar uma prestação de contas com status diferente de RECEBIDA ou DEVOLVIDA_RECEBIDA.'
     }
 
     assert result == result_esperado, "Deveria ter retornado erro status_nao_permite_operacao."


### PR DESCRIPTION
Esse PR:
- Altera a operação de análise de prestações de conta para permitir analisar PCs em status de recebida após acertos.

História AB#45684