### PR TITLE
feat(33225): Regularidade das Associações: Inclusão do motivo de não regularidade da Associação

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -542,7 +542,8 @@ class AssociacoesViewSet(ModelViewSet):
     @action(detail=True, url_path='atualiza-itens-verificacao', methods=['post'],
             permission_classes=[IsAuthenticated & PermissaoAPIApenasDreComGravacao])
     def atualiza_itens_verificacao(self, request, uuid=None):
-        itens = request.data
+        itens = request.data.get('itens')
+        motivo = request.data.get('motivo_nao_regularidade')
 
         if not itens:
             result_error = {
@@ -554,9 +555,9 @@ class AssociacoesViewSet(ModelViewSet):
         for item in itens:
             try:
                 if item['regular']:
-                    marca_item_verificacao_associacao(associacao_uuid=uuid, item_verificacao_uuid=item['uuid'])
+                    marca_item_verificacao_associacao(associacao_uuid=uuid, item_verificacao_uuid=item['uuid'], motivo=motivo)
                 else:
-                    desmarca_item_verificacao_associacao(associacao_uuid=uuid, item_verificacao_uuid=item['uuid'])
+                    desmarca_item_verificacao_associacao(associacao_uuid=uuid, item_verificacao_uuid=item['uuid'], motivo=motivo)
 
             except ValidationError as e:
                 result = {

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_associacoes_verificacao_regularidade_update.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_associacoes_verificacao_regularidade_update.py
@@ -209,16 +209,20 @@ def test_atualiza_itens_verificacao(jwt_authenticated_client_a, associacao,
                                     verificacao_regularidade_associacao_documento_cnpj,
                                     verificacao_regularidade_associacao_documento_rais
                                     ):
-    payload = [
-        {
-            "uuid": f'{item_verificacao_regularidade_documentos_associacao_cnpj.uuid}',
-            "regular": False
-        },
-        {
-            "uuid": f'{item_verificacao_regularidade_documentos_associacao_rais.uuid}',
-            "regular": True
-        }
-    ]
+    payload = {
+        'itens': [
+            {
+                "uuid": f'{item_verificacao_regularidade_documentos_associacao_cnpj.uuid}',
+                'regular': False
+            },
+            {
+                "uuid": f'{item_verificacao_regularidade_documentos_associacao_rais.uuid}',
+                'regular': True
+            },
+        ],
+        'motivo_nao_regularidade': ''
+    }
+
     response = jwt_authenticated_client_a.post(
         f'/api/associacoes/{associacao.uuid}/atualiza-itens-verificacao/', data=json.dumps(payload),
         content_type='application/json')
@@ -233,30 +237,35 @@ def test_atualiza_itens_verificacao(jwt_authenticated_client_a, associacao,
     assert result == esperado
 
     verificacao1 = VerificacaoRegularidadeAssociacao.objects.filter(associacao=associacao,
-                                                                   item_verificacao=item_verificacao_regularidade_documentos_associacao_cnpj)
+                                                                    item_verificacao=item_verificacao_regularidade_documentos_associacao_cnpj)
     assert verificacao1.count() == 0, 'Esse item não deveria existir'
 
     verificacao2 = VerificacaoRegularidadeAssociacao.objects.filter(associacao=associacao,
-                                                                   item_verificacao=item_verificacao_regularidade_documentos_associacao_rais)
+                                                                    item_verificacao=item_verificacao_regularidade_documentos_associacao_rais)
     assert verificacao2.count() == 1, 'Esse item deveria existir'
 
 
 def test_atualiza_itens_verificacao_associacao_regular(jwt_authenticated_client_a, associacao,
-                                    grupo_verificacao_regularidade_documentos,
-                                    lista_verificacao_regularidade_documentos_associacao,
-                                    item_verificacao_regularidade_documentos_associacao_cnpj,
-                                    item_verificacao_regularidade_documentos_associacao_rais
-                                    ):
-    payload = [
-        {
-            "uuid": f'{item_verificacao_regularidade_documentos_associacao_cnpj.uuid}',
-            "regular": True
-        },
-        {
-            "uuid": f'{item_verificacao_regularidade_documentos_associacao_rais.uuid}',
-            "regular": True
-        }
-    ]
+                                                       grupo_verificacao_regularidade_documentos,
+                                                       lista_verificacao_regularidade_documentos_associacao,
+                                                       item_verificacao_regularidade_documentos_associacao_cnpj,
+                                                       item_verificacao_regularidade_documentos_associacao_rais
+                                                       ):
+
+    payload = {
+        'itens': [
+            {
+                "uuid": f'{item_verificacao_regularidade_documentos_associacao_cnpj.uuid}',
+                'regular': True
+            },
+            {
+                "uuid": f'{item_verificacao_regularidade_documentos_associacao_rais.uuid}',
+                'regular': True
+            },
+        ],
+        'motivo_nao_regularidade': ''
+    }
+
     response = jwt_authenticated_client_a.post(
         f'/api/associacoes/{associacao.uuid}/atualiza-itens-verificacao/', data=json.dumps(payload),
         content_type='application/json')

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_associacoes_verificacao_regularidade.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_associacoes_verificacao_regularidade.py
@@ -57,6 +57,7 @@ def test_api_get_associacoes_verificacao_regularidade(jwt_authenticated_client_a
 
     esperado = {
         'uuid': f'{associacao.uuid}',
+        'motivo_nao_regularidade': '',
         'verificacao_regularidade': {
             'grupos_verificacao': [
                 {

--- a/sme_ptrf_apps/dre/tests/tests_services/test_verificacao_regularidade_associacao_service.py
+++ b/sme_ptrf_apps/dre/tests/tests_services/test_verificacao_regularidade_associacao_service.py
@@ -78,6 +78,7 @@ def test_verificacao_regularidade_associacao_regular(client, associacao,
 
     esperado = {
         'uuid': f'{associacao.uuid}',
+        'motivo_nao_regularidade': '',
         'verificacao_regularidade': {
             'grupos_verificacao': [
                 {
@@ -115,6 +116,7 @@ def test_verificacao_regularidade_associacao_pendente_quando_sem_verificacao(cli
 
     esperado = {
         'uuid': f'{associacao.uuid}',
+        'motivo_nao_regularidade': '',
         'verificacao_regularidade': {
             'grupos_verificacao': [
                 {
@@ -155,6 +157,7 @@ def test_verificacao_regularidade_associacao_pendente_quando_com_verificacao_irr
 
     esperado = {
         'uuid': f'{associacao.uuid}',
+        'motivo_nao_regularidade': '',
         'verificacao_regularidade': {
             'grupos_verificacao': [
                 {


### PR DESCRIPTION
Esse PR: 

- Salva motivo regularidade em regularidade_associacao_service.py

História: [AB#33225](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/33225)