### PR TITLE
fix(50979): Corrige cálculo do demonstrativo financeiro PDF

### DIFF
--- a/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
@@ -269,13 +269,13 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
     valor_custeio_rateios_nao_demonstrados_periodos_anteriores = rateios_nao_conferidos_custeio_periodos_anteriores[
                                                                      'valor'] or 0
 
-    saldo_anterior = ""
-    credito = ""
-    despesa_realizada = ""
-    despesa_nao_realizada = ""
-    despesa_nao_demostrada_outros_periodos = ""
-    saldo_reprogramado_proximo = ""
-    saldo_bancario = ""
+    saldo_anterior = 0
+    credito = 0
+    despesa_realizada = 0
+    despesa_nao_realizada = 0
+    despesa_nao_demostrada_outros_periodos = 0
+    saldo_reprogramado_proximo = 0
+    saldo_bancario = 0
     valor_saldo_reprogramado_proximo_periodo_custeio = 0
     valor_saldo_bancario_custeio = 0
 
@@ -322,7 +322,7 @@ def sintese_custeio(acao_associacao, conta_associacao, periodo, fechamento_perio
     totalizador['despesa_realizada']['C'] += valor_custeio_rateios_demonstrados
     totalizador['despesa_nao_realizada']['C'] += valor_custeio_rateios_nao_demonstrados
     totalizador['despesa_nao_demostrada_outros_periodos']['C'] += valor_custeio_rateios_nao_demonstrados_periodos_anteriores
-    totalizador['saldo_reprogramado_proximo']['C'] += valor_saldo_reprogramado_proximo_periodo_custeio
+    totalizador['saldo_reprogramado_proximo']['C'] += saldo_reprogramado_proximo
     totalizador['valor_saldo_reprogramado_proximo_periodo']['C'] += valor_saldo_reprogramado_proximo_periodo_custeio
     totalizador['valor_saldo_bancario']['C'] += valor_saldo_bancario_custeio
     totalizador['credito_nao_demonstrado']['C'] += valor_custeio_receitas_nao_demonstradas
@@ -436,9 +436,9 @@ def sintese_livre(linha_capital, linha_custeio, acao_associacao, conta_associaca
 
     valor_livre_receitas_demonstradas = receitas_demonstradas_livre['valor'] or 0
 
-    saldo_anterior = ""
-    credito = ""
-    saldo_reprogramado_proximo = ""
+    saldo_anterior = 0
+    credito = 0
+    saldo_reprogramado_proximo = 0
     valor_saldo_reprogramado_proximo_periodo_livre = 0
 
     if (
@@ -479,7 +479,7 @@ def sintese_livre(linha_capital, linha_custeio, acao_associacao, conta_associaca
     totalizador['despesa_realizada']['L'] += 0
     totalizador['despesa_nao_realizada']['L'] += 0
     totalizador['despesa_nao_demostrada_outros_periodos']['L'] += 0
-    totalizador['saldo_reprogramado_proximo']['L'] += valor_saldo_reprogramado_proximo_periodo_livre
+    totalizador['saldo_reprogramado_proximo']['L'] += saldo_reprogramado_proximo
     totalizador['valor_saldo_reprogramado_proximo_periodo']['L'] += valor_saldo_reprogramado_proximo_periodo_livre
     totalizador['valor_saldo_bancario']['L'] += 0
     totalizador['credito_nao_demonstrado']['L'] += 0

--- a/sme_ptrf_apps/core/tests/tests_services/tests_gerar_dados_demonstrativo_financeiro_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_gerar_dados_demonstrativo_financeiro_service/conftest.py
@@ -1,0 +1,285 @@
+import pytest
+
+from datetime import date
+
+from model_bakery import baker
+
+
+@pytest.fixture
+def dem_fin_periodo_2019_1():
+    return baker.make(
+        'Periodo',
+        referencia='2019.1',
+        data_inicio_realizacao_despesas=date(2019, 1, 1),
+        data_fim_realizacao_despesas=date(2019, 6, 30),
+    )
+
+
+@pytest.fixture
+def dem_fin_periodo_2019_2(dem_fin_periodo_2019_1):
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=date(2019, 7, 1),
+        data_fim_realizacao_despesas=date(2019, 12, 31),
+        data_prevista_repasse=date(2020, 1, 1),
+        data_inicio_prestacao_contas=date(2020, 1, 1),
+        data_fim_prestacao_contas=date(2020, 1, 5),
+        periodo_anterior=dem_fin_periodo_2019_1,
+    )
+
+
+@pytest.fixture
+def dem_fin_acao_ptrf():
+    return baker.make('Acao', nome='PTRF')
+
+
+@pytest.fixture
+def dem_fin_associacao(unidade, dem_fin_periodo_2019_1):
+    return baker.make(
+        'Associacao',
+        nome='Escola Teste',
+        cnpj='52.302.275/0001-83',
+        unidade=unidade,
+        periodo_inicial=dem_fin_periodo_2019_1,
+        ccm='0.000.00-0',
+        email="ollyverottoboni@gmail.com",
+        processo_regularidade='123456'
+    )
+
+
+@pytest.fixture
+def dem_fin_tipo_conta_cheque():
+    return baker.make(
+        'TipoConta',
+        nome='Cheque',
+        banco_nome='Banco do Inter',
+        agencia='67945',
+        numero_conta='935556-x',
+        numero_cartao='987644164221'
+    )
+
+
+@pytest.fixture
+def dem_fin_conta_associacao_cheque(dem_fin_associacao, dem_fin_tipo_conta_cheque):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=dem_fin_associacao,
+        tipo_conta=dem_fin_tipo_conta_cheque,
+        banco_nome='Banco do Brasil',
+        agencia='12345',
+        numero_conta='123456-x',
+        numero_cartao='534653264523'
+    )
+
+
+@pytest.fixture
+def dem_fin_acao_associacao_ptrf(dem_fin_associacao, dem_fin_acao_ptrf):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=dem_fin_associacao,
+        acao=dem_fin_acao_ptrf
+    )
+
+
+@pytest.fixture
+def dem_fin_tipo_receita_estorno():
+    return baker.make('TipoReceita', nome='Estorno')
+
+
+@pytest.fixture
+def dem_fin_receita_estorno_100_custeio_conferida(
+    dem_fin_periodo_2019_2,
+    dem_fin_associacao,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_tipo_receita_estorno,
+):
+    return baker.make(
+        'Receita',
+        associacao=dem_fin_associacao,
+        data=date(2019, 7, 10),
+        valor=356.56,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        tipo_receita=dem_fin_tipo_receita_estorno,
+        conferido=True,
+        update_conferido=True,
+        periodo_conciliacao=dem_fin_periodo_2019_2,
+        categoria_receita='CUSTEIO'
+    )
+
+
+@pytest.fixture
+def dem_fin_receita_custeio_conferida(
+    dem_fin_periodo_2019_2,
+    dem_fin_associacao,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_tipo_receita_estorno,
+):
+    return baker.make(
+        'Receita',
+        associacao=dem_fin_associacao,
+        data=date(2019, 7, 10),
+        valor=356.56,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        tipo_receita=dem_fin_tipo_receita_estorno,
+        conferido=True,
+        update_conferido=True,
+        periodo_conciliacao=dem_fin_periodo_2019_2,
+        categoria_receita='CUSTEIO'
+    )
+
+
+@pytest.fixture
+def dem_fin_receita_livre_conferida(
+    dem_fin_periodo_2019_2,
+    dem_fin_associacao,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_tipo_receita_estorno,
+):
+    return baker.make(
+        'Receita',
+        associacao=dem_fin_associacao,
+        data=date(2019, 7, 10),
+        valor=56389.58,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        tipo_receita=dem_fin_tipo_receita_estorno,
+        conferido=True,
+        update_conferido=True,
+        periodo_conciliacao=dem_fin_periodo_2019_2,
+        categoria_receita='LIVRE'
+    )
+
+@pytest.fixture
+def dem_fin_despesa(dem_fin_associacao, tipo_documento, tipo_transacao, dem_fin_periodo_2019_2):
+    return baker.make(
+        'Despesa',
+        associacao=dem_fin_associacao,
+        numero_documento='123456',
+        data_documento=date(2019, 7, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=date(2019, 7, 10),
+        valor_total=87186.89,
+        valor_recursos_proprios=0,
+    )
+
+
+@pytest.fixture
+def dem_fin_tipo_custeio_material():
+    return baker.make('TipoCusteio', nome='Material')
+
+
+@pytest.fixture
+def dem_fin_especificacao_material_eletrico(dem_fin_tipo_custeio_material):
+    return baker.make(
+        'EspecificacaoMaterialServico',
+        descricao='Material elétrico',
+        aplicacao_recurso='CUSTEIO',
+        tipo_custeio=dem_fin_tipo_custeio_material,
+    )
+
+
+@pytest.fixture
+def dem_fin_rateio_despesa(
+    dem_fin_associacao,
+    dem_fin_despesa,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_tipo_custeio_material,
+    dem_fin_especificacao_material_eletrico
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=dem_fin_despesa,
+        associacao=dem_fin_associacao,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        aplicacao_recurso='CUSTEIO',
+        tipo_custeio=dem_fin_tipo_custeio_material,
+        especificacao_material_servico=dem_fin_especificacao_material_eletrico,
+        valor_rateio=87186.89,
+    )
+
+
+@pytest.fixture
+def dem_fin_observacao_conciliacao_2019_2(dem_fin_periodo_2019_2, dem_fin_conta_associacao_cheque):
+    return baker.make(
+        'ObservacaoConciliacao',
+        periodo=dem_fin_periodo_2019_2,
+        associacao=dem_fin_conta_associacao_cheque.associacao,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        texto="Uma bela observação.",
+        data_extrato=date(2019, 12, 31),
+        saldo_extrato=1000
+    )
+
+
+@pytest.fixture
+def dem_fin_fechamento_2019_1(
+    dem_fin_periodo_2019_1,
+    dem_fin_associacao,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf
+):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=dem_fin_periodo_2019_1,
+        associacao=dem_fin_associacao,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        fechamento_anterior=None,
+        total_receitas_capital=4927.24,
+        total_repasses_capital=0,
+        total_despesas_capital=0,
+        total_receitas_custeio=31285.67,
+        total_repasses_custeio=0,
+        total_despesas_custeio=0,
+        total_receitas_livre=65998.35,
+        status='FECHADO'
+    )
+
+
+@pytest.fixture
+def dem_fin_prestacao_conta_2019_2(dem_fin_periodo_2019_2, dem_fin_associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=dem_fin_periodo_2019_2,
+        associacao=dem_fin_associacao,
+        data_recebimento=date(2020, 1, 10),
+        status='RECEBIDA'
+    )
+
+
+@pytest.fixture
+def dem_fin_fechamento_2019_2(
+    dem_fin_periodo_2019_2,
+    dem_fin_associacao,
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_fechamento_2019_1
+):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=dem_fin_periodo_2019_2,
+        associacao=dem_fin_associacao,
+        conta_associacao=dem_fin_conta_associacao_cheque,
+        acao_associacao=dem_fin_acao_associacao_ptrf,
+        fechamento_anterior=dem_fin_fechamento_2019_1,
+        total_receitas_capital=0,
+        total_repasses_capital=0,
+        total_despesas_capital=0,
+        total_receitas_custeio=356.56,
+        total_repasses_custeio=0,
+        total_despesas_custeio=87186.89,
+        total_receitas_livre=56389.58,
+        total_repasses_livre=0,
+        status='FECHADO'
+    )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_gerar_dados_demonstrativo_financeiro_service/test_gerar_dados_demonstrativo_financeiro.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_gerar_dados_demonstrativo_financeiro_service/test_gerar_dados_demonstrativo_financeiro.py
@@ -1,0 +1,34 @@
+import pytest
+
+from sme_ptrf_apps.core.services.dados_demo_financeiro_service import gerar_dados_demonstrativo_financeiro
+
+pytestmark = pytest.mark.django_db
+
+
+def test_deve_gerar_dados_para_demonstrativo_financeiro_da_prestacao_de_contas(
+    dem_fin_conta_associacao_cheque,
+    dem_fin_acao_associacao_ptrf,
+    dem_fin_receita_estorno_100_custeio_conferida,
+    dem_fin_receita_livre_conferida,
+    dem_fin_rateio_despesa,
+    dem_fin_observacao_conciliacao_2019_2,
+    dem_fin_prestacao_conta_2019_2,
+    dem_fin_fechamento_2019_2,
+):
+
+    prestacao = dem_fin_prestacao_conta_2019_2
+    periodo = prestacao.periodo
+    acoes = prestacao.associacao.acoes.filter(status="ATIVA")
+    contas = prestacao.associacao.contas.filter(status="ATIVA")
+
+    dados_demonstrativo = gerar_dados_demonstrativo_financeiro(
+        "usuarioteste",
+        acoes,
+        periodo,
+        contas[0],
+        prestacao,
+        dem_fin_observacao_conciliacao_2019_2,
+        previa=False
+    )
+
+    assert dados_demonstrativo == {}


### PR DESCRIPTION
Esse PR corrige o cálculo do demonstrativo financeiro em PDF que não estava
tratando corretamente os valores custeio negativos após uso de saldo de
livre aplicação.

Fix [AB#50979](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50979)