### PR TITLE
fix(50221) Ordena filtro de periodo

### DIFF
--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -6,6 +6,9 @@ from ..choices import MembroEnum
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
 
+# necessario para utilizacao da funcao sorted
+from .periodo import Periodo
+
 
 class Associacao(ModeloIdNome):
     history = AuditlogHistoryField()
@@ -112,7 +115,9 @@ class Associacao(ModeloIdNome):
         proximo_periodo = self.proximo_periodo_de_prestacao_de_contas()
         if proximo_periodo:
             periodos.append(proximo_periodo)
-        return periodos
+
+        periodos_ordenados = sorted(periodos, key=Periodo.get_referencia, reverse=True)
+        return periodos_ordenados
 
     def periodos_ate_agora_fora_implantacao(self):
         from datetime import datetime

--- a/sme_ptrf_apps/core/models/periodo.py
+++ b/sme_ptrf_apps/core/models/periodo.py
@@ -88,6 +88,10 @@ class Periodo(ModeloBase):
         self.notificacao_proximidade_fim_pc_realizada = True
         self.save()
 
+    def get_referencia(self):
+        # Necessario para utilizar a função "sorted", que retornará um erro se for um property
+        return self.referencia
+
     class Meta:
         verbose_name = "Período"
         verbose_name_plural = "08.0) Períodos"


### PR DESCRIPTION
fix(50221) Ordena filtro de periodo

Esse PR:

- Ordena lista de periodos por ordem decrescente

História: [AB#50221](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50221)