### PR TITLE
fix(50234) Exibicao de usuario sem visão associada

### DIFF
--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -48,13 +48,14 @@ class UserViewSet(ModelViewSet):
 
     def get_queryset(self, *args, **kwargs):
         """
-        Visão == SME - Se a visão for SME, todos os usuários devem ser retornados
+        Visão == SME - Se a visão for SME, todos os usuários devem ser retornados, caso tenham alguma visão associada
 
         Visão == DRE - Se a visão for DRE, devem ser retornados todos os usuários da DRE e das UEs subordinadas
 
         Visão == UE - Se a visão for UE, devem ser retornados apenas os usuários da unidade
         """
         qs = self.queryset
+        qs = qs.exclude(visoes=None)
 
         visao = self.request.query_params.get('visao')
         unidade_uuid = self.request.query_params.get('unidade_uuid')


### PR DESCRIPTION
fix(50234) Exibicao de usuario sem visão associada

Esse PR:

- Adiciona filtro para não exibir usuario que não tenha visão associada.

História: [AB#50234](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50234)