### PR TITLE
feat(45693): Altera login para retornar uuid pc devolvida

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_notificacoes_services/test_notificacoes_pc_devolvida_para_acertos.py
+++ b/sme_ptrf_apps/core/tests/tests_notificacoes_services/test_notificacoes_pc_devolvida_para_acertos.py
@@ -17,7 +17,7 @@ def test_deve_notificar_usuarios(prestacao_notifica_pc_devolvida_para_acertos, u
     notificacao = Notificacao.objects.first()
 
     assert notificacao.tipo == Notificacao.TIPO_NOTIFICACAO_ALERTA
-    assert notificacao.categoria == Notificacao.CATEGORIA_NOTIFICACAO_ANALISE_PC
+    assert notificacao.categoria == Notificacao.CATEGORIA_NOTIFICACAO_DEVOLUCAO_PC
     assert notificacao.remetente == Notificacao.REMETENTE_NOTIFICACAO_DRE
     assert notificacao.titulo == f"Ajustes necessários na PC"
     assert notificacao.descricao == f"A DRE solicitou alguns ajustes em sua prestação de contas do período {prestacao_notifica_pc_devolvida_para_acertos.periodo.referencia}. O seu prazo para envio das mudanças é {formata_data_dd_mm_yyyy(data_limite_ue)}"

--- a/sme_ptrf_apps/users/api/views/login.py
+++ b/sme_ptrf_apps/users/api/views/login.py
@@ -68,11 +68,13 @@ class LoginView(ObtainJSONWebToken):
 
                         if notificao_devolucao_pc and notificao_devolucao_pc.prestacao_conta:
                             notificar_devolucao_referencia = notificao_devolucao_pc.prestacao_conta.periodo.referencia
+                            notificar_devolucao_pc_uuid = notificao_devolucao_pc.prestacao_conta.uuid
                             notificacao_uuid = notificao_devolucao_pc.uuid
                             logger.info(f"Notificação de devolução encontrada para o período {notificar_devolucao_referencia}.")
                         else:
                             notificar_devolucao_referencia = None
                             notificacao_uuid = None
+                            notificar_devolucao_pc_uuid = None
 
                         unidades.append({
                             'uuid': unidade.uuid,
@@ -83,6 +85,7 @@ class LoginView(ObtainJSONWebToken):
                                 'nome': associacao.nome if associacao else ''
                             },
                             'notificar_devolucao_referencia': notificar_devolucao_referencia,
+                            'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
                             'notificacao_uuid': notificacao_uuid,
                         })
 


### PR DESCRIPTION
Esse PR altera o endpoint de login para retornar o UUID de uma PC devolvida para que o usuário para
ser notificado e acessar os ajustes.

História: [AB#45693](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/45693)