### PR TITLE
feat(45693): Corrige retorno de pc devolvida quando SME

### DIFF
--- a/sme_ptrf_apps/users/api/views/login.py
+++ b/sme_ptrf_apps/users/api/views/login.py
@@ -21,7 +21,10 @@ UNIDADE_SME = {
     'associacao': {
         'uuid': '',
         'nome': ''
-    }
+    },
+    'notificacao_uuid': None,
+    'notificar_devolucao_pc_uuid': None,
+    'notificar_devolucao_referencia': None,
 }
 
 


### PR DESCRIPTION
O login não estava retornando os campos corretos para a identificação
de mensagens de devolução de PC pelo front. No caso de SME, esse
retorno deveria ser none sempre.