### PR TITLE
feat(53365) Incluir campo no PDF

### DIFF
--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
@@ -261,6 +261,17 @@
                   <span><strong>Tipo de Acerto</strong></span>
                   <br>
                   <span>{{ acertos.tipo_acerto.nome }}</span>
+
+                  {% if acertos.detalhamento %}
+                    <div class="row pb-1 mt-2">
+                      <div class="col-12">
+                        <span><strong>Detalhamento do acerto (opcional)</strong></span>
+                        <br>
+                        <span class="">{{ acertos.detalhamento }}</span>
+                      </div>
+                    </div>
+                  {% endif %}
+
                 </div>
               </div>
             {% endfor %}


### PR DESCRIPTION
feat(53365) Incluir campo no PDF

Esse PR:

- Adiciona campo detalhamento de acerto do documento ao PDF

História: [AB#53365](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/53365)