### PR TITLE
feat(54223): Altera ordem da lista presentes na ata

### DIFF
--- a/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
+++ b/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
@@ -13,6 +13,7 @@ from django.db.models import Q
 from sme_ptrf_apps.core.choices import MembroEnum, RepresentacaoCargo
 from rest_framework import status
 from django.core.exceptions import ValidationError
+from sme_ptrf_apps.utils.remove_digitos_str import remove_digitos
 
 
 class PresentesAtaViewSet(mixins.CreateModelMixin,
@@ -50,7 +51,7 @@ class PresentesAtaViewSet(mixins.CreateModelMixin,
 
         ata = Ata.objects.filter(uuid=ata_uuid).first()
         presentes_ata_membros = PresenteAta.objects.filter(ata=ata).filter(membro=True).values()
-        presentes_ata_nao_membros = PresenteAta.objects.filter(ata=ata).filter(membro=False).values()
+        presentes_ata_nao_membros = PresenteAta.objects.filter(ata=ata).filter(membro=False).order_by('nome').values()
         presentes_ata_conselho_fiscal = PresenteAta.objects.filter(
             ata=ata).filter(membro=True).filter(conselho_fiscal=True).values()
 
@@ -84,14 +85,14 @@ class PresentesAtaViewSet(mixins.CreateModelMixin,
 
         ata = Ata.objects.filter(uuid=ata_uuid).first()
 
-        membros_associacao = MembroAssociacao.objects.filter(associacao=ata.associacao)
+        membros_associacao = ata.associacao.membros_por_cargo()
 
         membros = []
         for membro in membros_associacao:
 
             dado = {
                 "ata": ata_uuid,
-                "cargo": MembroEnum[membro.cargo_associacao].value,
+                "cargo": remove_digitos(MembroEnum[membro.cargo_associacao].value),
                 "identificacao": membro.codigo_identificacao if membro.codigo_identificacao != "" else membro.cpf,
                 "nome": membro.nome,
                 "editavel": False,

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -162,6 +162,14 @@ class Associacao(ModeloIdNome):
 
         return qry_periodos.all()
 
+    def membros_por_cargo(self):
+        cargos = []
+        for key in MembroEnum:
+            cargo = self.cargos.filter(cargo_associacao=key.name).first()
+            if cargo:
+                cargos.append(cargo)
+        return cargos
+
     @classmethod
     def acoes_da_associacao(cls, associacao_uuid):
         associacao = cls.objects.filter(uuid=associacao_uuid).first()

--- a/sme_ptrf_apps/core/services/ata_dados_service.py
+++ b/sme_ptrf_apps/core/services/ata_dados_service.py
@@ -30,7 +30,7 @@ def presentes_ata(ata):
     presentes_ata_membros = PresenteAta.objects.filter(ata=ata).filter(membro=True).filter(
         conselho_fiscal=False).values()
     presentes_ata_nao_membros = PresenteAta.objects.filter(ata=ata).filter(membro=False).filter(
-        conselho_fiscal=False).values()
+        conselho_fiscal=False).order_by('nome').values()
     presentes_ata_conselho_fiscal = PresenteAta.objects.filter(ata=ata).filter(membro=True).filter(
         conselho_fiscal=True).values()
 

--- a/sme_ptrf_apps/core/tests/tests_api_presentes_ata/test_api_presentes_ata.py
+++ b/sme_ptrf_apps/core/tests/tests_api_presentes_ata/test_api_presentes_ata.py
@@ -15,6 +15,13 @@ def test_get_presentes_ata_nao_agrupados(
     result = json.loads(response.content)
 
     esperado = [
+        {'ata': f'{presente_ata_nao_membro.ata.uuid}',
+         'cargo': presente_ata_nao_membro.cargo,
+         'editavel': presente_ata_nao_membro.editavel,
+         'identificacao': presente_ata_nao_membro.identificacao,
+         'membro': presente_ata_nao_membro.membro,
+         'nome': presente_ata_nao_membro.nome
+         },
         {'ata': f'{presente_ata_membro.ata.uuid}',
          'cargo': presente_ata_membro.cargo,
          'editavel': presente_ata_membro.editavel,
@@ -28,14 +35,8 @@ def test_get_presentes_ata_nao_agrupados(
          'identificacao': presente_ata_membro_e_conselho_fiscal.identificacao,
          'membro': presente_ata_membro_e_conselho_fiscal.membro,
          'nome': presente_ata_membro_e_conselho_fiscal.nome
-         },
-        {'ata': f'{presente_ata_nao_membro.ata.uuid}',
-         'cargo': presente_ata_nao_membro.cargo,
-         'editavel': presente_ata_nao_membro.editavel,
-         'identificacao': presente_ata_nao_membro.identificacao,
-         'membro': presente_ata_nao_membro.membro,
-         'nome': presente_ata_nao_membro.nome
          }
+
     ]
 
     assert response.status_code == status.HTTP_200_OK
@@ -67,18 +68,6 @@ def test_get_presentes_agrupados(
         ],
         'presentes_membros': [
             {
-                'alterado_em': presente_ata_membro.alterado_em.isoformat("T"),
-                'ata_id': presente_ata_membro.ata.id,
-                'cargo': presente_ata_membro.cargo,
-                'conselho_fiscal': presente_ata_membro.conselho_fiscal,
-                'criado_em': presente_ata_membro.criado_em.isoformat("T"),
-                'id': presente_ata_membro.id,
-                'identificacao': presente_ata_membro.identificacao,
-                'membro': presente_ata_membro.membro,
-                'nome': presente_ata_membro.nome,
-                'uuid': f'{presente_ata_membro.uuid}'
-            },
-            {
                 'alterado_em': presente_ata_membro_e_conselho_fiscal.alterado_em.isoformat("T"),
                 'ata_id': presente_ata_membro_e_conselho_fiscal.ata.id,
                 'cargo': presente_ata_membro_e_conselho_fiscal.cargo,
@@ -89,6 +78,18 @@ def test_get_presentes_agrupados(
                 'membro': presente_ata_membro_e_conselho_fiscal.membro,
                 'nome': presente_ata_membro_e_conselho_fiscal.nome,
                 'uuid': f'{presente_ata_membro_e_conselho_fiscal.uuid}'
+            },
+            {
+                'alterado_em': presente_ata_membro.alterado_em.isoformat("T"),
+                'ata_id': presente_ata_membro.ata.id,
+                'cargo': presente_ata_membro.cargo,
+                'conselho_fiscal': presente_ata_membro.conselho_fiscal,
+                'criado_em': presente_ata_membro.criado_em.isoformat("T"),
+                'id': presente_ata_membro.id,
+                'identificacao': presente_ata_membro.identificacao,
+                'membro': presente_ata_membro.membro,
+                'nome': presente_ata_membro.nome,
+                'uuid': f'{presente_ata_membro.uuid}'
             }
         ],
         'presentes_nao_membros': [

--- a/sme_ptrf_apps/utils/remove_digitos_str.py
+++ b/sme_ptrf_apps/utils/remove_digitos_str.py
@@ -1,0 +1,7 @@
+def remove_digitos(string):
+    """
+    Recebe uma steing e retorna a mesma string sem qualquer dígito.
+
+    Exemplo: remove_digitos('teste 123') -> 'teste '
+    """
+    return ''.join([i for i in string if not i.isdigit()])


### PR DESCRIPTION
Esse PR:
- Altera a ordem das listas de presentes na ata. A lista de membros passa a ser ordenada pelo cargo e a de não membros pelo nome.

História: [AB#54223](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/54223)