### PR TITLE
fix(55522): Corrige duplicação de notificações

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_notificacao/test_notificar_service.py
+++ b/sme_ptrf_apps/core/tests/tests_notificacao/test_notificar_service.py
@@ -1,6 +1,7 @@
 import pytest
 
 from model_bakery import baker
+from freezegun import freeze_time
 
 from ...models import Notificacao, NotificacaoCreateException
 
@@ -124,6 +125,7 @@ def test_notificar_re_notificar_false(notificacao, usuario_permissao_associacao)
     assert Notificacao.objects.count() == 1
 
 
+@freeze_time("2021-01-01 10:20:30")
 def test_notificar_re_notificar_true(notificacao, usuario_permissao_associacao):
 
     assert Notificacao.objects.count() == 1


### PR DESCRIPTION
Esse PR corrige o serviço de geração de notificação para não criar a mesma notificação no mesmo dia.

Bug: [AB#55522](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55522)