### PR TITLE
feat(55954): 

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -389,6 +389,7 @@ class PrestacaoConta(ModeloBase):
         card_nao_recebidas = {
             "titulo": titulos_por_status['NAO_RECEBIDA'],
             "quantidade_prestacoes": quantidade_pcs_nao_apresentadas,
+            "quantidade_nao_recebida": qs.filter(status=cls.STATUS_NAO_RECEBIDA).count(),
             "status": 'NAO_RECEBIDA'
         }
         cards.insert(0, card_nao_recebidas)

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_dashboard.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_dashboard.py
@@ -224,6 +224,7 @@ def test_dashboard(
         'cards': [
             {
                 'titulo': 'Prestações de contas não recebidas',
+                'quantidade_nao_recebida': 1,
                 'quantidade_prestacoes': 2,  # Uma PC não recebida + Uma Associação sem PC.
                 'status': 'NAO_RECEBIDA'},
             {
@@ -273,6 +274,7 @@ def test_dashboard_add_aprovada_ressalva(
         'cards': [
             {
                 'titulo': 'Prestações de contas não recebidas',
+                'quantidade_nao_recebida': 1,
                 'quantidade_prestacoes': 2,
                 'status': 'NAO_RECEBIDA'},
             {
@@ -331,6 +333,7 @@ def test_dashboard_outro_periodo(jwt_authenticated_client_a, prestacao_conta_apr
         'cards': [
             {
                 'titulo': 'Prestações de contas não recebidas',
+                'quantidade_nao_recebida': 0,
                 'quantidade_prestacoes': 2,
                 'status': 'NAO_RECEBIDA'},
             {

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
@@ -60,6 +60,7 @@ def test_dash_board(prestacao_conta1, prestacao_conta2, periodo, dre):
     esperado = [
         {
             'titulo': 'Prestações de contas não recebidas',
+            'quantidade_nao_recebida': 0,
             'quantidade_prestacoes': 0,
             'status': 'NAO_RECEBIDA'},
         {


### PR DESCRIPTION
Esse PR:

- Adiciona retorno de quantidade_nao_recebida de pcs ao endpoint prestacao_de_contas/dashboard

História: [AB#55954](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55954)