### PR TITLE
feat(55187): Altera texto PDF ata conforme comentários

### DIFF
--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -336,10 +336,18 @@
   {% comment %} Comentários {% endcomment %}
   <p class="mt-4 texto-justificado">{{ dados.dados_texto_da_ata.comentarios }}</p>
 
-  <p class="mt-4 texto-justificado">Esgotados os assuntos o(a) senhor(a) presidente ofereceu a palavra a quem dela desejasse fazer uso e,
-    como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual
-    eu, {{ dados.dados_texto_da_ata.secretario_reuniao }}, lavrei a presente ata, que vai por mim assinada e pelos
-    demais presentes.</p>
+  {% if not dados.dados_texto_da_ata.comentarios %}
+    <p class="mt-4 texto-justificado">Esgotados os assuntos o(a) senhor(a) presidente ofereceu a palavra a quem dela desejasse fazer uso e,
+      como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual
+      eu, {{ dados.dados_texto_da_ata.secretario_reuniao }}, lavrei a presente ata, que vai por mim assinada e pelos
+      demais presentes.</p>
+  {% endif %}
+
+  {% if dados.dados_texto_da_ata.comentarios %}
+    <p class="mt-4 texto-justificado">Esgotados os assuntos o(a) senhor(a) presidente agradeceu a presença de todos e
+      considerou encerrada a reunião, a qual  eu, {{ dados.dados_texto_da_ata.secretario_reuniao }},
+      lavrei a presente ata, que vai por mim assinada e pelos demais presentes.</p>
+  {% endif %}
 
   {% language 'pt-br' %}
     <p class="mt-4">São Paulo, dia {{ dados.dados_da_ata.data_reuniao|date:"d" }}


### PR DESCRIPTION
Esse PR:
- Altera o texto de fechamento no PDF das atas conforme a existência ou não de comentários.

História: [AB#55187](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55187)