### PR TITLE
feat(55188): Altera textos da ata de retificação

### DIFF
--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -56,6 +56,26 @@
       do(a) {{ dados.dados_texto_da_ata.unidade_tipo }} {{ dados.dados_texto_da_ata.unidade_nome }}
     </strong>
   </p>
+  {% if dados.cabecalho.tipo_ata == 'Retificação' %}
+    <p class="font-12 texto-justificado">
+      {{ dados.dados_texto_da_ata.data_reuniao_por_extenso }}
+      no(a) {{ dados.dados_texto_da_ata.local_reuniao }}, {{ dados.dados_texto_da_ata.unidade_tipo }} {{ dados.dados_texto_da_ata.unidade_nome }},
+      com início às {{ dados.dados_texto_da_ata.hora_reuniao }}, reuniram-se os membros
+      da {{ dados.dados_texto_da_ata.associacao_nome }},
+      para tratar da seguinte pauta: Retificação da Prestação de Contas do PTRF e suas ações agregadas, do período
+      de {{ dados.cabecalho.periodo_data_inicio }}
+      a {{ dados.cabecalho.periodo_data_fim }},
+      referente ao {{ dados.dados_texto_da_ata.periodo_referencia }}.
+      Aberta a reunião em
+      {% if dados.dados_da_ata.get_convocacao_display %}{{ dados.dados_da_ata.get_convocacao_display }}{% else %}
+        "___"{% endif %},
+      pelo(a) Senhor(a) {{ dados.dados_texto_da_ata.presidente_reuniao }},
+      {{ dados.dados_texto_da_ata.cargo_presidente_reuniao }} e verificada a existência de número legal de membros
+      presentes, o(a) senhor(a)
+      {{ dados.dados_texto_da_ata.presidente_reuniao }} apresentou as alterações realizadas, conforme solicitado pela
+      DRE, resultando nos dados consolidados, conforme segue:
+    </p>
+  {% else %}
   <p class="font-12 texto-justificado">
     {{ dados.dados_texto_da_ata.data_reuniao_por_extenso }}
     no(a) {{ dados.dados_texto_da_ata.local_reuniao }}, {{ dados.dados_texto_da_ata.unidade_tipo }} {{ dados.dados_texto_da_ata.unidade_nome }},
@@ -73,15 +93,13 @@
     {{ dados.dados_texto_da_ata.presidente_reuniao }} apresentou os documentos fiscais referentes às despesas realizadas
     no período para análise dos presentes, conforme segue:
   </p>
+  {% endif %}
 
   {% if dados.cabecalho.tipo_ata == 'Retificação' %}
 
     {% if dados.retificacoes %}
       <p><strong>Retificações</strong></p>
       <p>{{ dados.retificacoes|linebreaks }}</p>
-    {% else %}
-      <p class="mb-0"><strong>Retificações</strong></p>
-      <p>...</p>
     {% endif %}
 
     {% if dados.devolucoes_ao_tesouro %}


### PR DESCRIPTION
Esse PR:
- Altera o PDF da ata para exibir tópico "Retificações" apenas se houver retificações
- Altera o texto inicial conforme tipo da ata (Apresentação ou Retificação)

História: [AB#55188](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55188)