### PR TITLE
feat(56099): Altera cálculos de conciliação

### DIFF
--- a/sme_ptrf_apps/core/models/periodo.py
+++ b/sme_ptrf_apps/core/models/periodo.py
@@ -63,6 +63,9 @@ class Periodo(ModeloBase):
         # O período não pode ser editado pelo usuário se houver um período que o referencia como período anterior
         return not self.periodo_seguinte.exists()
 
+    def data_pertence_ao_periodo(self, data):
+        return self.data_inicio_realizacao_despesas <= data <= self.data_fim_realizacao_despesas
+
     @classmethod
     def periodo_atual(cls):
         return cls.objects.latest('data_inicio_realizacao_despesas') if cls.objects.exists() else None
@@ -72,6 +75,7 @@ class Periodo(ModeloBase):
         periodos_da_data = cls.objects.filter(data_inicio_realizacao_despesas__lte=data).filter(
             Q(data_fim_realizacao_despesas__gte=data) | Q(data_fim_realizacao_despesas__isnull=True))
         return periodos_da_data.first() if periodos_da_data else None
+
 
     def notificacao_inicio_prestacao_de_contas_realizada(self):
         self.notificacao_inicio_periodo_pc_realizada = True

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
@@ -372,7 +372,7 @@ def despesa_2019_2(associacao, tipo_documento, tipo_transacao):
 @pytest.fixture
 def rateio_despesa_2019_role_conferido(associacao, despesa_2019_2, conta_associacao_cartao, acao,
                                        tipo_aplicacao_recurso_custeio,
-                                       tipo_custeio_servico,
+                                       tipo_custeio_servico, periodo_2019_2,
                                        especificacao_cadeira, acao_associacao_role_cultural):
     return baker.make(
         'RateioDespesa',
@@ -386,7 +386,7 @@ def rateio_despesa_2019_role_conferido(associacao, despesa_2019_2, conta_associa
         valor_rateio=100.00,
         update_conferido=True,
         conferido=True,
-
+        periodo_conciliacao=periodo_2019_2
     )
 
 

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_tabela_valores_pendentes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_tabela_valores_pendentes.py
@@ -38,16 +38,21 @@ def test_tabela_valores_pendentes(
     result = json.loads(response.content)
 
     esperado = {
-        'saldo_anterior': 2000.0,
-        'receitas_conciliadas': 500.0,
-        'despesas_conciliadas': 300.0,
+        'despesas_conciliadas': 200.0,
         'despesas_nao_conciliadas': 100.0,
+        'despesas_outros_periodos': 100.0,
+        'despesas_outros_periodos_conciliadas': 100.0,
+        'despesas_outros_periodos_nao_conciliadas': 0,
+        'despesas_total': 300.0,
+        'receitas_conciliadas': 500.0,
         'receitas_nao_conciliadas': 200.0,
-        'despesas_total': 400.0,
         'receitas_total': 700.0,
-        'saldo_posterior_conciliado': 2200.0,
+        'saldo_anterior': 2000.0,
+        'saldo_anterior_conciliado': 2000.0,
+        'saldo_anterior_nao_conciliado': 0.0,
+        'saldo_posterior_conciliado': 2300.0,
         'saldo_posterior_nao_conciliado': 100.0,
-        'saldo_posterior_total': 2300.0,
+        'saldo_posterior_total': 2400.0
     }
 
     assert result == esperado


### PR DESCRIPTION
Altera os cálculos dos saldos de conciliação para que:

- Valores não conciliados de períodos anteriores quando conciliados em períodos futuros, não sejam considerados como conciliados em seu período original.
- A conciliação de lançamentos de períodos anteriores movimente a linha de saldo anterior no quadro resumo e não as linhas de débito ou crédito.
- Despesas sejam listadas como conciliadas apenas nos períodos onde foram efetivamente conciliados.

História: [AB#56099](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/56099)