### PR TITLE
feat(55187): Corrige erro geração das atas PC

### DIFF
--- a/sme_ptrf_apps/core/templatetags/paracer_do_conselho.py
+++ b/sme_ptrf_apps/core/templatetags/paracer_do_conselho.py
@@ -1,0 +1,19 @@
+from django import template
+
+import logging
+
+register = template.Library()
+
+LOGGER = logging.getLogger(__name__)
+
+
+@register.simple_tag(name='parecer_do_conselho')
+def parecer_do_conselho(parecer_conselho):
+    texto_parecer = ""
+
+    if parecer_conselho == "APROVADA":
+        texto_parecer = "Os membros do Conselho Fiscal, à vista dos registros contábeis e verificando nos documentos apresentados a exatidão das despesas realizadas, julgaram exata a presente prestação de contas considerando-a em condições de ser aprovada e emitindo parecer favorável à sua aprovação."
+    elif parecer_conselho == "REJEITADA":
+        texto_parecer = "Os membros do Conselho Fiscal, à vista dos registros contábeis e verificando nos documentos apresentados, não consideram a presente prestação de contas em condições de ser aprovada emitindo parecer contrário à sua aprovação."
+
+    return texto_parecer

--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -5,6 +5,7 @@
 {% load staticfiles %}
 {% load static %}
 {% load formata_valores %}
+{% load paracer_do_conselho %}
 {% load i18n %}
 
 <head>
@@ -419,7 +420,7 @@
   {% comment %} Texto dinâmico inferior - Parecer do conselho fiscal com quebra de página {% endcomment %}
   <div id="parecer-do-conselho-fiscal-quebra-de-pagina">
     <p class="font-12"><strong>PARECER DO CONSELHO FISCAL</strong></p>
-    <p class="mt-4 texto-justificado">{% parecer_conselho dados.dados_texto_da_ata.parecer_conselho %}</p>
+    <p class="mt-4 texto-justificado">{% parecer_do_conselho dados.dados_texto_da_ata.parecer_conselho %}</p>
 
     {% language 'pt-br' %}
       <p class="mt-5">São Paulo, dia {{ dados.dados_da_ata.data_reuniao|date:"d" }}


### PR DESCRIPTION
Esse PR corrige um erro que ocorria ao gerar as atas de prestação de contas.

O template não carregava o templatetag parecer_conselho.

O problema foi resolvido extraindo o código do tamplatetag para um arquivo próprio.