### PR TITLE
fix(57992): Mensagem não é possivel devolver PC

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -224,7 +224,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                     'uuid': f'{uuid}',
                     'erro': 'prestacao_de_contas_posteriores',
                     'operacao': 'reabrir',
-                    'mensagem': 'Essa prestação de contas não pode ser reaberta porque há prestação de contas dessa mesma associação de um período posterior. Se necessário, reabra primeiramente a prestação de contas mais recente.'
+                    'mensagem': 'Essa prestação de contas não pode ser devolvida, ou reaberta porque há prestação de contas dessa associação de um período posterior. Se necessário, reabra ou devolva primeiro a prestação de contas mais recente.'
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
@@ -515,7 +515,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                     'uuid': f'{uuid}',
                     'erro': 'prestacao_de_contas_posteriores',
                     'operacao': 'concluir-analise',
-                    'mensagem': 'Essa prestação de contas não pode ser devolvida porque há prestação de contas dessa mesma associação de um período posterior. Se necessário, devolva para ajuste a prestação de contas mais recente.'
+                    'mensagem': 'Essa prestação de contas não pode ser devolvida, ou reaberta porque há prestação de contas dessa associação de um período posterior. Se necessário, reabra ou devolva primeiro a prestação de contas mais recente.'
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
 

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_devolvida.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_conclui_analise_prestacao_conta_como_devolvida.py
@@ -225,7 +225,7 @@ def test_api_conclui_analise_prestacao_conta_pc_posterior(jwt_authenticated_clie
         'uuid': f'{prestacao_conta_01_pc_posterior.uuid}',
         'erro': 'prestacao_de_contas_posteriores',
         'operacao': 'concluir-analise',
-        'mensagem': 'Essa prestação de contas não pode ser devolvida porque há prestação de contas dessa mesma associação de um período posterior. Se necessário, devolva para ajuste a prestação de contas mais recente.'
+        'mensagem': 'Essa prestação de contas não pode ser devolvida, ou reaberta porque há prestação de contas dessa associação de um período posterior. Se necessário, reabra ou devolva primeiro a prestação de contas mais recente.'
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
@@ -88,7 +88,7 @@ def test_api_nao_reabre_prestacao_conta_pc_posterior(jwt_authenticated_client_a,
             'uuid': f'{prestacao_conta_01.uuid}',
             'erro': 'prestacao_de_contas_posteriores',
             'operacao': 'reabrir',
-            'mensagem': 'Essa prestação de contas não pode ser reaberta porque há prestação de contas dessa mesma associação de um período posterior. Se necessário, reabra primeiramente a prestação de contas mais recente.'
+            'mensagem': 'Essa prestação de contas não pode ser devolvida, ou reaberta porque há prestação de contas dessa associação de um período posterior. Se necessário, reabra ou devolva primeiro a prestação de contas mais recente.'
         }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
fix(57992): Mensagem não é possivel devolver PC

Esse PR:

- Altera mensagem de erro
- Altera testes relacionados

História: [AB#57992](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/57992)