### PR TITLE
fix(57992)-parte-2: Mensagem não é possivel devolver PC

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -93,6 +93,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     arquivos_referencia = serializers.SerializerMethodField('get_arquivos_referencia')
     analise_atual = AnalisePrestacaoContaSerializer(many=False)
     permite_analise_valores_reprogramados = serializers.SerializerMethodField()
+    pode_reabrir = serializers.SerializerMethodField('get_pode_reabrir')
 
     def get_permite_analise_valores_reprogramados(self, obj):
 
@@ -186,6 +187,15 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
                 )
         return result
 
+    def get_pode_reabrir(self, obj):
+        associacao = obj.associacao
+        prestacao_de_contas_posteriores = PrestacaoConta.objects.filter(associacao=associacao,
+                                                                        id__gt=obj.id)
+        if prestacao_de_contas_posteriores:
+            return False
+        else:
+            return True
+
     class Meta:
         model = PrestacaoConta
         fields = (
@@ -210,6 +220,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
             'analise_atual',
             'permite_analise_valores_reprogramados',
             'recomendacoes',
+            'pode_reabrir'
         )
 
 

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -319,6 +319,7 @@ def test_api_retrieve_prestacao_conta_por_uuid(
                 'uuid': f'{_devolucao_prestacao_conta.uuid}'
             }
         ],
+        'pode_reabrir': True,
         'processo_sei': '123456',
         'data_ultima_analise': f'{prestacao_conta.data_ultima_analise}',
         'devolucao_ao_tesouro': '100,00',


### PR DESCRIPTION
fix(57992)-parte-2: Mensagem não é possivel devolver PC

Esse PR:

- Adiciona method field "pode_reabrir" ao retrieve de prestacao de contas

História: [AB#57992](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/57992)