### PR TITLE
feat(58666): Créditos referentes a estornos de gastos - parte 2

### DIFF
--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -6,9 +6,12 @@ from rest_framework.exceptions import ValidationError
 from sme_ptrf_apps.core.api.serializers.acao_associacao_serializer import AcaoAssociacaoLookUpSerializer
 from sme_ptrf_apps.core.api.serializers.conta_associacao_serializer import ContaAssociacaoLookUpSerializer
 from sme_ptrf_apps.core.api.serializers.periodo_serializer import PeriodoLookUpSerializer
+from sme_ptrf_apps.core.models import AcaoAssociacao, Associacao, ContaAssociacao, Periodo
+
 from sme_ptrf_apps.despesas.api.serializers.despesa_serializer import DespesaListSerializer
 from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaListaSerializer
-from sme_ptrf_apps.core.models import AcaoAssociacao, Associacao, ContaAssociacao, Periodo
+from sme_ptrf_apps.despesas.models import RateioDespesa
+
 from sme_ptrf_apps.receitas.models import Receita, Repasse
 
 from ...services import atualiza_repasse_para_pendente, atualiza_repasse_para_realizado
@@ -48,6 +51,12 @@ class ReceitaCreateSerializer(serializers.ModelSerializer):
         slug_field='uuid',
         required=False,
         queryset=Periodo.objects.all()
+    )
+
+    rateio_estornado = serializers.SlugRelatedField(
+        slug_field='uuid',
+        required=False,
+        queryset=RateioDespesa.objects.all()
     )
 
     def create(self, validated_data):

--- a/sme_ptrf_apps/receitas/tests/conftest.py
+++ b/sme_ptrf_apps/receitas/tests/conftest.py
@@ -153,6 +153,22 @@ def payload_receita_repasse_livre_aplicacao(associacao, conta_associacao, acao_a
 
 
 @pytest.fixture
+def payload_receita_estorno(associacao, conta_associacao, acao_associacao, tipo_receita_estorno, rateio_no_periodo_100_custeio):
+    payload = {
+        'associacao': str(associacao.uuid),
+        'data': '2019-09-26',
+        'valor': 1000.28,
+        'categoria_receita': 'CAPITAL',
+        'conta_associacao': str(conta_associacao.uuid),
+        'acao_associacao': str(acao_associacao.uuid),
+        'tipo_receita': tipo_receita_estorno.id,
+        'rateio_estornado': str(rateio_no_periodo_100_custeio.uuid),
+    }
+    return payload
+
+
+
+@pytest.fixture
 def receita_xxx_estorno(associacao, conta_associacao_cheque, acao_associacao_ptrf, tipo_receita_estorno):
     return baker.make(
         'Receita',

--- a/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_api.py
+++ b/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_api.py
@@ -92,6 +92,32 @@ def test_create_receita_repasse(
         assert Repasse.objects.get(uuid=repasse.uuid).status == 'PENDENTE'
 
 
+def test_create_receita_estorno(
+    jwt_authenticated_client_p,
+    tipo_receita,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao,
+    repasse,
+    payload_receita_estorno,
+    rateio_no_periodo_100_custeio
+):
+    response = jwt_authenticated_client_p.post('/api/receitas/', data=json.dumps(payload_receita_estorno),
+                                               content_type='application/json')
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    result = json.loads(response.content)
+
+    assert Receita.objects.filter(uuid=result["uuid"]).exists()
+
+    receita = Receita.objects.get(uuid=result["uuid"])
+
+    assert receita.rateio_estornado == rateio_no_periodo_100_custeio
+
+
 def test_create_receita_repasse_valor_diferente(
     jwt_authenticated_client_p,
     tipo_receita,


### PR DESCRIPTION
Esse PR:
- Altera o create e update de créditos para atualizar o rateio estornado.

História: [AB#58666](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58666)