### PR TITLE
feat(58666): Créditos referentes a estornos de gastos - parte 3

### DIFF
--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -56,6 +56,8 @@ class ReceitaCreateSerializer(serializers.ModelSerializer):
     rateio_estornado = serializers.SlugRelatedField(
         slug_field='uuid',
         required=False,
+        allow_empty=True,
+        allow_null=True,
         queryset=RateioDespesa.objects.all()
     )
 

--- a/sme_ptrf_apps/receitas/tests/conftest.py
+++ b/sme_ptrf_apps/receitas/tests/conftest.py
@@ -102,6 +102,7 @@ def payload_receita(associacao, conta_associacao, acao_associacao, tipo_conta, t
         'tipo_receita': tipo_receita.id,
         'detalhe_tipo_receita': detalhe_tipo_receita.id,
         'detalhe_outros': 'teste',
+        'rateio_estornado': None,
     }
     return payload
 


### PR DESCRIPTION
Esse PR:
- Alterar o serializer de receita para aceitar gravação com rateio_estornado vazio.

História: [AB#58666](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58666)