### PR TITLE
feat(58666): Altera atualização de rateios da despesa

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
@@ -38,6 +38,8 @@ class RateioDespesaSerializer(serializers.ModelSerializer):
 
 
 class RateioDespesaCreateSerializer(serializers.ModelSerializer):
+    uuid = serializers.UUIDField(required=False)
+
     associacao = serializers.SlugRelatedField(
         slug_field='uuid',
         required=False,


### PR DESCRIPTION
Esse PR: 

- Altera a atualização de rateios para não mais apagar todos os rateios e regrava-los em uma atualização de
despesa. Agora os novos rateios são incluídos, os editados são atualizados e os apagados são excluídos.

Necessário para evitar que os registros de estorno sejam apagados quando uma despesa for alterada.

História: [AB#58666](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58666)