### PR TITLE
feat(59496): Gastos da Escola: Lançamento de imposto retido na fonte - Parte 02

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -229,8 +229,11 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
 
             despesa_do_imposto.atualiza_status()
 
-            instance.despesa_imposto = despesa_do_imposto
-            instance.save()
+            despesa_updated = Despesa.objects.get(uuid=instance.uuid)
+
+            despesa_updated.despesa_imposto = despesa_do_imposto
+
+            despesa_updated.save()
 
         elif not validated_data.get('retem_imposto'):
 
@@ -281,6 +284,13 @@ class DespesaListComRateiosSerializer(serializers.ModelSerializer):
     rateios = RateioDespesaTabelaGastosEscolaSerializer(many=True)
 
     receitas_saida_do_recurso = serializers.SerializerMethodField('get_recurso_externo')
+    despesa_imposto = DespesaImpostoSerializer(many=False, required=False)
+    despesa_geradora_do_imposto = serializers.SerializerMethodField(method_name="get_despesa_de_imposto",
+                                                                    required=False)
+
+    def get_despesa_de_imposto(self, despesa):
+        despesa_geradora_do_imposto = despesa.despesa_geradora_do_imposto.first()
+        return DespesaImpostoSerializer(despesa_geradora_do_imposto, many=False).data
 
     def get_recurso_externo(self, despesa):
         return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
@@ -290,7 +300,7 @@ class DespesaListComRateiosSerializer(serializers.ModelSerializer):
         fields = (
         'uuid', 'associacao', 'numero_documento', 'status', 'tipo_documento', 'data_documento', 'cpf_cnpj_fornecedor',
         'nome_fornecedor', 'valor_total', 'valor_ptrf', 'data_transacao', 'tipo_transacao', 'documento_transacao',
-        'rateios', 'receitas_saida_do_recurso',)
+        'rateios', 'receitas_saida_do_recurso', 'despesa_imposto', 'despesa_geradora_do_imposto')
 
 
 class DespesaConciliacaoSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Esse PR

- Inclui Imposto retido na fonte inclui despesa imposto no DespesaListComRateiosSerializer, para ser usado na exibição da lista de gastos da escola

História: [AB#59496](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/59496)