### PR TITLE
feat(59671): Exibir informações de vínculo entre despesa e imposto

### DIFF
--- a/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
@@ -651,7 +651,7 @@ def cria_despesas(rateios):
     linhas = []
     for _, rateio in enumerate(rateios):
         razao_social = rateio.despesa.nome_fornecedor
-        cnpj_cpf = rateio.despesa.cpf_cnpj_fornecedor
+        cnpj_cpf = rateio.despesa.cpf_cnpj_fornecedor if rateio.despesa.cpf_cnpj_fornecedor else ''
         tipo_documento = rateio.despesa.tipo_documento.nome if rateio.despesa.tipo_documento else ''
         numero_documento = rateio.despesa.numero_documento
         nome_acao_documento = rateio.acao_associacao.acao.nome if rateio and rateio.acao_associacao and rateio.acao_associacao.acao.nome else ""
@@ -686,6 +686,22 @@ def cria_despesas(rateios):
         if rateio.estorno.first():
             receita = rateio.estorno.first()
             linha["data_estorno"] = receita.data.strftime("%d/%m/%Y")
+
+        if rateio.despesa.despesa_imposto:
+            # Despesas que possuem despesa imposto são despesas geradoras
+            linha["despesa_imposto"] = {
+                "data_transacao": rateio.despesa.despesa_imposto.data_transacao.strftime("%d/%m/%Y") if rateio.despesa.despesa_imposto.data_transacao else "",
+                "valor": rateio.despesa.despesa_imposto.valor_total if rateio.despesa.despesa_imposto.valor_total else ""
+            }
+
+        if rateio.despesa.despesa_geradora_do_imposto.first():
+            # Despesas que possuem despesa geradora, são despesas imposto
+            despesa_geradora = rateio.despesa.despesa_geradora_do_imposto.first()
+            linha["despesa_geradora"] = {
+                "numero_documento": despesa_geradora.numero_documento if despesa_geradora.numero_documento else "",
+                "data_transacao": despesa_geradora.data_transacao.strftime("%d/%m/%Y") if despesa_geradora.data_transacao else "",
+                "valor": despesa_geradora.valor_total if despesa_geradora.valor_total else ""
+            }
 
         linhas.append(linha)
 

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -123,10 +123,10 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
 
             despesa_do_imposto.rateios.set(rateios_do_imposto_lista)
 
-            despesa_do_imposto.atualiza_status()
-
             despesa.despesa_imposto = despesa_do_imposto
             despesa.save()
+            despesa_do_imposto.verifica_data_documento_vazio()
+            despesa_do_imposto.atualiza_status()
 
             log.info("Despesa do imposto {}, Rateios do imposto: {}".format(despesa_do_imposto.uuid,
                                                                             rateios_do_imposto_lista))
@@ -231,6 +231,7 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
             despesa_do_imposto.rateios.set(rateios_do_imposto_lista)
             despesa_do_imposto.save()
 
+            despesa_do_imposto.verifica_data_documento_vazio()
             despesa_do_imposto.atualiza_status()
 
             despesa_updated = Despesa.objects.get(uuid=instance.uuid)

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -91,10 +91,10 @@ class Despesa(ModeloBase):
         completo = self.data_transacao and \
                    self.valor_total > 0
 
-        if completo and not self.eh_despesa_sem_comprovacao_fiscal:
+        if completo and not self.eh_despesa_sem_comprovacao_fiscal and not self.despesa_geradora_do_imposto.first():
             completo = completo and self.cpf_cnpj_fornecedor
 
-        if completo and not self.eh_despesa_sem_comprovacao_fiscal:
+        if completo and not self.eh_despesa_sem_comprovacao_fiscal and not self.despesa_geradora_do_imposto.first():
             completo = completo and self.nome_fornecedor
 
         if completo and not self.eh_despesa_sem_comprovacao_fiscal:
@@ -103,7 +103,7 @@ class Despesa(ModeloBase):
         if completo and not self.eh_despesa_sem_comprovacao_fiscal:
             completo = completo and self.tipo_documento
 
-        if completo and not self.eh_despesa_sem_comprovacao_fiscal:
+        if completo and not self.eh_despesa_sem_comprovacao_fiscal and not self.despesa_geradora_do_imposto.first():
             completo = completo and self.data_documento
 
         if completo and not self.eh_despesa_sem_comprovacao_fiscal:

--- a/sme_ptrf_apps/static/css/pdf-demo-financeiro-horizontal.css
+++ b/sme_ptrf_apps/static/css/pdf-demo-financeiro-horizontal.css
@@ -219,3 +219,7 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
   color: #086397 !important;
   font-weight: bold !important;
 }
+
+.texto-imposto {
+  color: #000 !important;
+}

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
@@ -382,6 +382,27 @@
             </td>
           </tr>
         {% endif %}
+
+        {% if despesa.despesa_imposto %}
+          <tr>
+            <td colspan="11" class="texto-imposto">
+                <strong>Nota com retenção de imposto:</strong> Esse gasto teve retenção de imposto em
+                {{ despesa.despesa_imposto.data_transacao }}
+                no valor de R$ {{ despesa.despesa_imposto.valor|formata_valor }}.
+            </td>
+          </tr>
+        {% endif %}
+
+        {% if despesa.despesa_geradora %}
+          <tr>
+            <td colspan="11" class="texto-imposto">
+              <strong>Imposto retido:</strong> Esse gasto refere-se à retenção de imposto da nota
+              {{ despesa.despesa_geradora.numero_documento }}
+              de {{ despesa.despesa_geradora.data_transacao }} e valor R$ {{ despesa.despesa_geradora.valor|formata_valor }}.
+            </td>
+          </tr>
+        {% endif %}
+
       {% endfor %}
       <tr>
         <td class="total sem-borda" style="border-right: 1px solid #F5F6F8; !important;"><strong>Total</strong></td>
@@ -443,6 +464,27 @@
             </td>
           </tr>
         {% endif %}
+
+      {% if despesa.despesa_imposto %}
+        <tr>
+          <td colspan="11" class="texto-imposto">
+              <strong>Nota com retenção de imposto:</strong> Esse gasto teve retenção de imposto em
+              {{ despesa.despesa_imposto.data_transacao }}
+              no valor de R$ {{ despesa.despesa_imposto.valor|formata_valor }}.
+          </td>
+        </tr>
+      {% endif %}
+
+      {% if despesa.despesa_geradora %}
+        <tr>
+          <td colspan="11" class="texto-imposto">
+            <strong>Imposto retido:</strong> Esse gasto refere-se à retenção de imposto da nota
+            {{ despesa.despesa_geradora.numero_documento }}
+            de {{ despesa.despesa_geradora.data_transacao }} e valor R$ {{ despesa.despesa_geradora.valor|formata_valor }}.
+          </td>
+        </tr>
+      {% endif %}
+
       {% endfor %}
       <tr>
         <td class="total sem-borda" style="border-right: 1px solid #F5F6F8; !important;"><strong>Total</strong></td>
@@ -501,6 +543,26 @@
           <tr>
             <td colspan="11" class="texto-estorno">
                 O estorno do dia {{ despesa.data_estorno }} está vinculado a essa despesa
+            </td>
+          </tr>
+        {% endif %}
+
+        {% if despesa.despesa_imposto %}
+          <tr>
+            <td colspan="11" class="texto-imposto">
+                <strong>Nota com retenção de imposto:</strong> Esse gasto teve retenção de imposto em
+                {{ despesa.despesa_imposto.data_transacao }}
+                no valor de R$ {{ despesa.despesa_imposto.valor|formata_valor }}.
+            </td>
+          </tr>
+        {% endif %}
+
+        {% if despesa.despesa_geradora %}
+          <tr>
+            <td colspan="11" class="texto-imposto">
+              <strong>Imposto retido:</strong> Esse gasto refere-se à retenção de imposto da nota
+              {{ despesa.despesa_geradora.numero_documento }}
+              de {{ despesa.despesa_geradora.data_transacao }} e valor R$ {{ despesa.despesa_geradora.valor|formata_valor }}.
             </td>
           </tr>
         {% endif %}


### PR DESCRIPTION
feat(59671): Exibir informações de vínculo entre despesa e imposto

Esse PR:

- Adiciona informações de imposto ao serviço que gera os dados do PDF
- Adiciona novos campos ao template do PDF
- Altera função cadastro_completo do modelo de Despesa