### PR TITLE
feat(58642): Altera na ata o cálculo de despesas demonstradas/não demonstradas - Parte 1

### DIFF
--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -318,14 +318,20 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
             if rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
                 info['despesas_no_periodo_custeio'] += rateio.valor_rateio
                 info['saldo_atual_custeio'] -= rateio.valor_rateio
-                info['despesas_nao_conciliadas_custeio'] += rateio.valor_rateio if not rateio.conferido else 0
-                info['despesas_conciliadas_custeio'] += rateio.valor_rateio if rateio.conferido else 0
+
+                if not rateio.conferido or rateio.conferido and rateio.periodo_conciliacao.referencia > periodo_final.referencia:
+                    info['despesas_nao_conciliadas_custeio'] += rateio.valor_rateio
+                else:
+                    info['despesas_conciliadas_custeio'] += rateio.valor_rateio
 
             else:
                 info['despesas_no_periodo_capital'] += rateio.valor_rateio
                 info['saldo_atual_capital'] -= rateio.valor_rateio
-                info['despesas_nao_conciliadas_capital'] += rateio.valor_rateio if not rateio.conferido else 0
-                info['despesas_conciliadas_capital'] += rateio.valor_rateio if rateio.conferido else 0
+
+                if not rateio.conferido or rateio.conferido and rateio.periodo_conciliacao.referencia > periodo_final.referencia:
+                    info['despesas_nao_conciliadas_capital'] += rateio.valor_rateio
+                else:
+                    info['despesas_conciliadas_capital'] += rateio.valor_rateio
 
         return info
 


### PR DESCRIPTION
Esse PR altera a lógica de sumarização de despesas demonstradas e não demonstradas para considerar o período de conciliação da despesa.

Essa alteração foi feita apenas na apuração de prévias com valores ainda não fechados.

[AB#58642](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58642)