### PR TITLE
feat(58639): Altera Demo financ quanto a despesas demostradas

### DIFF
--- a/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
@@ -180,35 +180,35 @@ def cria_resumo_por_acao(acoes, conta_associacao, periodo):
 
         resumo_acoes (lista com os valores por ação):
 
-            12-Ação                         : acao_associacao
+             1-Ação                         : acao_associacao
 
-            13-Saldo anterior           (C): linha_custeio.saldo_anterior
+             2-Saldo anterior           (C): linha_custeio.saldo_anterior
                                         (K): linha_capital.saldo_anterior
                                         (L): linha_livre.saldo_anterior
 
-            14-Créditos                 (C): linha_custeio.credito
+             3-Créditos                 (C): linha_custeio.credito
                                         (K): linha_capital.credito
                                         (L): linha_livre.credito
 
-            15-Despesas Demonstradas    (C): linha_custeio.despesa_realizada
+             4-Despesas Demonstradas    (C): linha_custeio.despesa_realizada
                                         (K): linha_capital.despesa_realizada
                                         (L): XXXXX Não tem
 
-            16-Despesas Ñ Demonstradas  (C): linha_custeio.despesa_nao_realizada
+             5-Despesas Ñ Demonstradas  (C): linha_custeio.despesa_nao_realizada
                                         (K): linha_capital.despesa_nao_realizada
                                         (L): XXXXX Não tem
 
-            17-Saldo próximo período    (C): linha_custeio.saldo_reprogramado_proximo
+             6-Saldo próximo período    (C): linha_custeio.saldo_reprogramado_proximo
                                         (K): linha_capital.saldo_reprogramado_proximo
                                         (L): linha_livre.saldo_reprogramado_proximo
                                         (T): total_valores
                                         (*): 13+14-15-16
 
-            18-Despesas Ñ Demonstr.Ant. (C): linha_custeio.despesa_nao_demostrada_outros_periodos
+             7-Despesas Ñ Demonstr.Ant. (C): linha_custeio.despesa_nao_demostrada_outros_periodos
                                         (K): linha_capital.despesa_nao_demostrada_outros_periodos
                                         (L): XXXXX Não tem
 
-            19-Saldo parcial próximo    (C): linha_custeio.valor_saldo_bancario_custeio
+             8-Saldo parcial próximo    (C): linha_custeio.valor_saldo_bancario_custeio
                                         (K): linha_capital.valor_saldo_bancario_capital
                                         (L): linha_livre.saldo_reprogramado_proximo  (mesmo da coluna 17)
                                         (T): saldo_bancario
@@ -216,33 +216,33 @@ def cria_resumo_por_acao(acoes, conta_associacao, periodo):
 
         total_valores (Totais):
 
-            13-Saldo anterior           (C): saldo_anterior.C
+             2-Saldo anterior           (C): saldo_anterior.C
                                         (K): saldo_anterior.K
                                         (L): saldo_anterior.L
 
-            14-Créditos                 (C): credito.C
+             3-Créditos                 (C): credito.C
                                         (K): credito.K
                                         (L): credito.L
 
-            15-Despesas Demonstradas    (C): despesa_realizada.C
+             4-Despesas Demonstradas    (C): despesa_realizada.C
                                         (K): despesa_realizada.K
                                         (L): XXXXX Não tem
 
-            16-Despesas Ñ Demonstradas  (C): despesa_nao_realizada.C
+             5-Despesas Ñ Demonstradas  (C): despesa_nao_realizada.C
                                         (K): despesa_nao_realizada.K
                                         (L): XXXXX Não tem
 
-            17-Saldo próximo período    (C): saldo_reprogramado_proximo.C
+             6-Saldo próximo período    (C): saldo_reprogramado_proximo.C
                                         (K): saldo_reprogramado_proximo.K
                                         (L): saldo_reprogramado_proximo.L
                                         (T): total_valores
 
 
-            18-Despesas Ñ Demonstr.Ant. (C): despesa_nao_demostrada_outros_periodos.C
+             7-Despesas Ñ Demonstr.Ant. (C): despesa_nao_demostrada_outros_periodos.C
                                         (K): despesa_nao_demostrada_outros_periodos.K
                                         (L): XXXXX Não tem
 
-            19-Saldo parcial próximo    (C): valor_saldo_bancario.C
+             8-Saldo parcial próximo    (C): valor_saldo_bancario.C
                                         (K): valor_saldo_bancario.K
                                         (L): saldo_reprogramado_proximo.L  (mesmo da coluna 17)
                                         (T): saldo_bancario

--- a/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/conftest.py
@@ -1,0 +1,379 @@
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from sme_ptrf_apps.core.models.fechamento_periodo import STATUS_FECHADO
+from sme_ptrf_apps.receitas.tipos_aplicacao_recurso_receitas import (APLICACAO_CAPITAL, APLICACAO_CUSTEIO,
+                                                                     APLICACAO_LIVRE)
+
+
+@pytest.fixture
+def df_periodo_2019_2():
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=datetime.date(2019, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2019, 12, 31),
+        periodo_anterior=None
+    )
+
+
+@pytest.fixture
+def df_periodo_2020_1(df_periodo_2019_2):
+    return baker.make(
+        'Periodo',
+        referencia='2020.1',
+        data_inicio_realizacao_despesas=datetime.date(2020, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 6, 30),
+        periodo_anterior=df_periodo_2019_2
+    )
+
+
+@pytest.fixture
+def df_periodo_2020_2(df_periodo_2020_1):
+    return baker.make(
+        'Periodo',
+        referencia='2020.2',
+        data_inicio_realizacao_despesas=datetime.date(2020, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 12, 31),
+        periodo_anterior=df_periodo_2020_1
+    )
+
+
+@pytest.fixture
+def df_periodo_2021_1(df_periodo_2020_2):
+    return baker.make(
+        'Periodo',
+        referencia='2021.1',
+        data_inicio_realizacao_despesas=datetime.date(2021, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2021, 6, 30),
+        periodo_anterior=df_periodo_2020_2
+    )
+
+
+@pytest.fixture
+def df_tipo_conta_cartao():
+    return baker.make('TipoConta', nome='Cartão')
+
+
+@pytest.fixture
+def df_acao_ptrf():
+    return baker.make('Acao', nome='PTRF')
+
+
+@pytest.fixture
+def df_acao_associacao_ptrf(associacao, df_acao_ptrf):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=associacao,
+        acao=df_acao_ptrf
+    )
+
+
+@pytest.fixture
+def df_conta_associacao_cartao(associacao, df_tipo_conta_cartao):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=df_tipo_conta_cartao
+    )
+
+
+@pytest.fixture
+def df_tipo_receita_repasse():
+    return baker.make('TipoReceita', nome='Repasse', e_repasse=True)
+
+
+@pytest.fixture
+def df_receita_2020_1_cartao_ptrf_repasse_capital_conferida_em_2020_1(
+    associacao,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    df_tipo_receita_repasse,
+    df_periodo_2020_1,
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        tipo_receita=df_tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_1,
+        categoria_receita=APLICACAO_CAPITAL,
+    )
+
+
+@pytest.fixture
+def df_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1(
+    associacao,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_receita_repasse,
+    df_periodo_2020_1
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        tipo_receita=tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_1,
+        categoria_receita=APLICACAO_CUSTEIO,
+    )
+
+
+@pytest.fixture
+def df_receita_2020_1_cartao_ptrf_repasse_livre_conferida_em_2020_1(
+    associacao,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_receita_repasse,
+    df_periodo_2020_1
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        tipo_receita=tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_1,
+        categoria_receita=APLICACAO_LIVRE,
+    )
+
+
+@pytest.fixture
+def df_tipo_custeio_servico():
+    return baker.make('TipoCusteio', nome='Servico')
+
+
+@pytest.fixture
+def df_especificacao_instalacao_eletrica(
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico
+):
+    return baker.make(
+        'EspecificacaoMaterialServico',
+        descricao='Instalação elétrica',
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+    )
+
+
+@pytest.fixture
+def df_despesa_2020_1(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    df_periodo_2020_1
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+    )
+
+
+@pytest.fixture
+def df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_1(
+    associacao,
+    df_despesa_2020_1,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico,
+    df_especificacao_instalacao_eletrica,
+    df_periodo_2020_1
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=df_despesa_2020_1,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+        especificacao_material_servico=df_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_1,
+    )
+
+
+@pytest.fixture
+def df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_2(
+    associacao,
+    df_despesa_2020_1,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico,
+    df_especificacao_instalacao_eletrica,
+    df_periodo_2020_2
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=df_despesa_2020_1,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+        especificacao_material_servico=df_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_2,
+    )
+
+
+@pytest.fixture
+def df_despesa_2019_2(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    df_periodo_2019_2
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2019, 12, 1),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2019, 12, 1),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+    )
+
+
+@pytest.fixture
+def df_rateio_despesa_2019_2_cartao_ptrf_custeio_nao_conferido(
+    associacao,
+    df_despesa_2019_2,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico,
+    df_especificacao_instalacao_eletrica,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=df_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+        especificacao_material_servico=df_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=False,
+    )
+
+@pytest.fixture
+def df_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2020_2(
+    associacao,
+    df_despesa_2019_2,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico,
+    df_especificacao_instalacao_eletrica,
+    df_periodo_2020_2,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=df_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+        especificacao_material_servico=df_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2020_2,
+    )
+
+
+@pytest.fixture
+def df_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2021_1(
+    associacao,
+    df_despesa_2019_2,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    df_tipo_custeio_servico,
+    df_especificacao_instalacao_eletrica,
+    df_periodo_2021_1,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=df_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=df_tipo_custeio_servico,
+        especificacao_material_servico=df_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=df_periodo_2021_1,
+    )
+
+@pytest.fixture
+def df_prestacao_conta_2020_1(df_periodo_2020_1, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=df_periodo_2020_1,
+        associacao=associacao,
+    )
+
+
+@pytest.fixture
+def df_fechamento_periodo_2020_1(
+    df_periodo_2020_1,
+    associacao,
+    df_conta_associacao_cartao,
+    df_acao_associacao_ptrf,
+    df_prestacao_conta_2020_1
+):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=df_periodo_2020_1,
+        associacao=associacao,
+        conta_associacao=df_conta_associacao_cartao,
+        acao_associacao=df_acao_associacao_ptrf,
+        fechamento_anterior=None,
+        total_receitas_custeio=100,
+        total_repasses_custeio=100,
+        total_despesas_custeio=100,
+        status=STATUS_FECHADO,
+        prestacao_conta=df_prestacao_conta_2020_1
+    )

--- a/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_api.py
+++ b/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_api.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from rest_framework import status
 

--- a/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_blocos_de_despesas.py
+++ b/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_blocos_de_despesas.py
@@ -1,0 +1,101 @@
+import pytest
+
+from sme_ptrf_apps.core.services.dados_demo_financeiro_service import gerar_dados_demonstrativo_financeiro
+
+pytestmark = pytest.mark.django_db
+
+
+def test_despesas_demonstradas_despesa_conciliada_no_periodo(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_prestacao_conta_2020_1,
+    df_fechamento_periodo_2020_1,
+    df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_1
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = gerar_dados_demonstrativo_financeiro(
+        usuario='teste',
+        acoes=acoes,
+        periodo=df_periodo_2020_1,
+        conta_associacao=df_conta_associacao_cartao,
+        prestacao=df_prestacao_conta_2020_1,
+        observacao_conciliacao="",
+        previa=False,
+    )
+
+    assert resultado['despesas_demonstradas']['valor_total'] == 100
+    assert resultado['despesas_nao_demonstradas']['valor_total'] == 0
+    assert resultado['despesas_anteriores_nao_demonstradas']['valor_total'] == 0
+
+
+def test_despesas_demonstradas_despesa_conciliada_em_periodo_futuro(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_prestacao_conta_2020_1,
+    df_fechamento_periodo_2020_1,
+    df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_2
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = gerar_dados_demonstrativo_financeiro(
+        usuario='teste',
+        acoes=acoes,
+        periodo=df_periodo_2020_1,
+        conta_associacao=df_conta_associacao_cartao,
+        prestacao=df_prestacao_conta_2020_1,
+        observacao_conciliacao="",
+        previa=False,
+    )
+
+    assert resultado['despesas_demonstradas']['valor_total'] == 0
+    assert resultado['despesas_nao_demonstradas']['valor_total'] == 100
+    assert resultado['despesas_anteriores_nao_demonstradas']['valor_total'] == 0
+
+
+def test_despesas_demonstradas_despesa_anteriores_conciliadas_em_periodo_futuro(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_prestacao_conta_2020_1,
+    df_fechamento_periodo_2020_1,
+    df_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2021_1
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = gerar_dados_demonstrativo_financeiro(
+        usuario='teste',
+        acoes=acoes,
+        periodo=df_periodo_2020_1,
+        conta_associacao=df_conta_associacao_cartao,
+        prestacao=df_prestacao_conta_2020_1,
+        observacao_conciliacao="",
+        previa=False,
+    )
+
+    assert resultado['despesas_demonstradas']['valor_total'] == 0, "Não deveria estar em demonstradas"
+    assert resultado['despesas_nao_demonstradas']['valor_total'] == 0, "Não deveria estar em não demonstradas"
+    assert resultado['despesas_anteriores_nao_demonstradas']['valor_total'] == 100, "Deveria estar em anteriores não demonstradas"
+
+
+def test_despesas_demonstradas_despesa_anteriores_nao_conciliadas(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_prestacao_conta_2020_1,
+    df_fechamento_periodo_2020_1,
+    df_rateio_despesa_2019_2_cartao_ptrf_custeio_nao_conferido
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = gerar_dados_demonstrativo_financeiro(
+        usuario='teste',
+        acoes=acoes,
+        periodo=df_periodo_2020_1,
+        conta_associacao=df_conta_associacao_cartao,
+        prestacao=df_prestacao_conta_2020_1,
+        observacao_conciliacao="",
+        previa=False,
+    )
+
+    assert resultado['despesas_demonstradas']['valor_total'] == 0, "Não deveria estar em demonstradas"
+    assert resultado['despesas_nao_demonstradas']['valor_total'] == 0, "Não deveria estar em não demonstradas"
+    assert resultado['despesas_anteriores_nao_demonstradas']['valor_total'] == 100, "Deveria estar em anteriores não demonstradas"

--- a/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_resumo_por_acao.py
+++ b/sme_ptrf_apps/core/tests/tests_dados_demo_financeiro_service/test_resumo_por_acao.py
@@ -1,0 +1,149 @@
+import pytest
+from decimal import Decimal
+from sme_ptrf_apps.core.services.dados_demo_financeiro_service import cria_resumo_por_acao
+
+pytestmark = pytest.mark.django_db
+
+
+def test_resumo_por_acao_sem_movimento(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+):
+    esperado = {
+        'resumo_acoes': [],
+        'total_conciliacao': 0,
+        'total_valores': {
+            'credito': {'C': 0, 'K': 0, 'L': 0},
+            'credito_nao_demonstrado': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_nao_demostrada_outros_periodos': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_nao_realizada': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_realizada': {'C': 0, 'K': 0, 'L': 0},
+            'saldo_anterior': {'C': 0, 'K': 0, 'L': 0},
+            'saldo_bancario': 0,
+            'saldo_reprogramado_proximo': {'C': 0, 'K': 0, 'L': 0},
+            'total_valores': 0,
+            'valor_saldo_bancario': {'C': 0, 'K': 0, 'L': 0},
+            'valor_saldo_reprogramado_proximo_periodo': {'C': 0, 'K': 0, 'L': 0}
+        }
+    }
+
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = cria_resumo_por_acao(acoes, df_conta_associacao_cartao, df_periodo_2020_1)
+    assert resultado == esperado
+
+
+def test_resumo_por_acao_com_despesa_conciliada_no_periodo(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1,
+    df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_1
+):
+    esperado = {
+        'resumo_acoes': [
+            {
+                'acao_associacao': 'PTRF',
+                'linha_capital': {
+                    'credito': 0,
+                    'credito_nao_demonstrado': 0,
+                    'despesa_nao_demostrada_outros_periodos': 0,
+                    'despesa_nao_realizada': 0,
+                    'despesa_realizada': 0,
+                    'saldo_anterior': 0,
+                    'saldo_bancario': 0,
+                    'saldo_reprogramado_proximo': 0,
+                    'saldo_reprogramado_proximo_vr': 0,
+                    'valor_saldo_bancario_capital': 0,
+                    'valor_saldo_reprogramado_proximo_periodo_capital': 0
+                },
+                'linha_custeio': {
+                    'credito': Decimal('100.00'),
+                    'credito_nao_demonstrado': 0,
+                    'despesa_nao_demostrada_outros_periodos': 0,
+                    'despesa_nao_realizada': 0,
+                    'despesa_realizada': Decimal('100.00'),
+                    'saldo_anterior': 0,
+                    'saldo_bancario': 0,
+                    'saldo_reprogramado_proximo': 0,
+                    'saldo_reprogramado_proximo_vr': 0,
+                    'valor_saldo_bancario_custeio': 0,
+                    'valor_saldo_reprogramado_proximo_periodo_custeio': 0
+                },
+                'linha_livre': {
+                    'credito': 0,
+                    'credito_nao_demonstrado': 0,
+                    'saldo_anterior': 0,
+                    'saldo_reprogramado_proximo': 0,
+                    'saldo_reprogramado_proximo_vr': 0,
+                    'valor_saldo_reprogramado_proximo_periodo_livre': 0
+                },
+                'saldo_bancario': 0,
+                'total_conciliacao': 0,
+                'total_valores': 0
+            }
+        ],
+        'total_conciliacao': 0,
+        'total_valores': {
+            'credito': {'C': Decimal('100.00'), 'K': 0, 'L': 0},
+            'credito_nao_demonstrado': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_nao_demostrada_outros_periodos': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_nao_realizada': {'C': 0, 'K': 0, 'L': 0},
+            'despesa_realizada': {'C': Decimal('100.00'), 'K': 0, 'L': 0},
+            'saldo_anterior': {'C': 0, 'K': 0, 'L': 0},
+            'saldo_bancario': 0,
+            'saldo_reprogramado_proximo': {'C': 0, 'K': 0, 'L': 0},
+            'total_valores': 0,
+            'valor_saldo_bancario': {'C': 0, 'K': 0, 'L': 0},
+            'valor_saldo_reprogramado_proximo_periodo': {'C': 0, 'K': 0, 'L': 0}
+        }
+    }
+
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = cria_resumo_por_acao(acoes, df_conta_associacao_cartao, df_periodo_2020_1)
+    assert resultado == esperado
+
+
+def test_resumo_por_acao_com_despesa_conciliada_em_periodo_futuro(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1,
+    df_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_2
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = cria_resumo_por_acao(acoes, df_conta_associacao_cartao, df_periodo_2020_1)
+
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_nao_realizada'] == Decimal('100.00')
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_realizada'] == 0
+
+
+def test_resumo_por_acao_com_despesa_nao_conciliada_de_periodos_anteriores(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1,
+    df_rateio_despesa_2019_2_cartao_ptrf_custeio_nao_conferido
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = cria_resumo_por_acao(acoes, df_conta_associacao_cartao, df_periodo_2020_1)
+
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_nao_realizada'] == 0
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_nao_demostrada_outros_periodos'] == Decimal('100.00')
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_realizada'] == 0
+
+
+def test_resumo_por_acao_com_despesa_nao_conciliada_de_periodos_anteriores_conciliacao_em_periodo_futuro(
+    associacao,
+    df_conta_associacao_cartao,
+    df_periodo_2020_1,
+    df_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1,
+    df_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2020_2
+):
+    acoes = associacao.acoes.filter(status='ATIVA')
+    resultado = cria_resumo_por_acao(acoes, df_conta_associacao_cartao, df_periodo_2020_1)
+
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_nao_realizada'] == 0
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_nao_demostrada_outros_periodos'] == Decimal('100.00')
+    assert resultado['resumo_acoes'][0]['linha_custeio']['despesa_realizada'] == 0
+

--- a/sme_ptrf_apps/despesas/models/rateio_despesa.py
+++ b/sme_ptrf_apps/despesas/models/rateio_despesa.py
@@ -2,6 +2,7 @@ from datetime import date
 from decimal import Decimal
 
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
@@ -135,8 +136,12 @@ class RateioDespesa(ModeloBase):
             dataset = cls.completos.filter(acao_associacao=acao_associacao).filter(
                 despesa__data_transacao__gte=periodo.data_inicio_realizacao_despesas)
 
+        # Para determinar se a despesa está ou não conciliada é necessário considera-se o período de conciliação
         if conferido is not None:
-            dataset = dataset.filter(conferido=conferido)
+            if conferido:
+                dataset = dataset.filter(conferido=True, periodo_conciliacao__referencia__lte=periodo.referencia)
+            else:
+                dataset = dataset.filter(Q(conferido=False) | Q(periodo_conciliacao__referencia__gt=periodo.referencia))
 
         if conta_associacao:
             dataset = dataset.filter(conta_associacao=conta_associacao)
@@ -194,7 +199,10 @@ class RateioDespesa(ModeloBase):
                 despesa__data_transacao__gte=periodo.data_inicio_realizacao_despesas)
 
         if conferido is not None:
-            dataset = dataset.filter(conferido=conferido)
+            if conferido:
+                dataset = dataset.filter(conferido=True, periodo_conciliacao__referencia__lte=periodo.referencia)
+            else:
+                dataset = dataset.filter(Q(conferido=False) | Q(periodo_conciliacao__referencia__gt=periodo.referencia))
 
         if exclude_despesa:
             dataset = dataset.exclude(despesa__uuid=exclude_despesa)
@@ -248,7 +256,10 @@ class RateioDespesa(ModeloBase):
             despesa__data_transacao__lte=periodo.data_inicio_realizacao_despesas)
 
         if conferido is not None:
-            dataset = dataset.filter(conferido=conferido)
+            if conferido:
+                dataset = dataset.filter(conferido=True, periodo_conciliacao__referencia__lte=periodo.referencia)
+            else:
+                dataset = dataset.filter(Q(conferido=False) | Q(periodo_conciliacao__referencia__gt=periodo.referencia))
 
         if exclude_despesa:
             dataset = dataset.exclude(despesa__uuid=exclude_despesa)
@@ -311,7 +322,10 @@ class RateioDespesa(ModeloBase):
                                        despesa__data_transacao__lte=periodo.data_inicio_realizacao_despesas)
 
         if conferido is not None:
-            dataset = dataset.filter(conferido=conferido)
+            if conferido:
+                dataset = dataset.filter(conferido=True, periodo_conciliacao__referencia__lte=periodo.referencia)
+            else:
+                dataset = dataset.filter(Q(conferido=False) | Q(periodo_conciliacao__referencia__gt=periodo.referencia))
 
         if exclude_despesa:
             dataset = dataset.exclude(despesa__uuid=exclude_despesa)


### PR DESCRIPTION
Esse PR:
- Altera a lógica de sumarização de despesas demonstradas e não demonstradas para considerar o período de conciliação da despesa.

No relatório Demonstrativo Financeiro (PDF)

- [X] No Bloco 3 - Resumo por ação, na coluna 4-Despesas demonstradas, devem ser consideradas apenas as despesas conciliadas cujo período de conciliação é o período do relatório financeiro

- [X] No Bloco 3 - Resumo por ação, na coluna 5-Despesas não demonstradas, devem ser consideradas, além das despesas não conciliadas, também as que foram conciliadas em períodos posteriores ao período do relatório financeiro;

- [X] No Bloco 3 - Resumo por ação, na coluna 7-Despesas não demonstradas de períodos anteriores, devem ser consideradas, além das despesas não conciliadas de períodos anteriores, também as despesas de períodos anteriores e que foram conciliadas em períodos posteriores ao período do relatório financeiro;

- [X] No Bloco 5 - Despesas demonstradas, devem ser listadas apenas as despesas conciliadas, cujo período de conciliação é o período do relatório financeiro;

- [X] No Bloco 6 - Despesas não demonstradas, devem ser listadas, além das despesas não conciliadas, também as que foram conciliadas em períodos posteriores ao período do relatório financeiro;

- [X] No Bloco 7 - Despesas não demonstradas de períodos anteriores, devem ser listadas, além das despesas não conciliadas de períodos anteriores, também as despesas de períodos anteriores que foram conciliadas em períodos posteriores ao período do relatório financeiro;

História: [AB#58639](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58639)