### PR TITLE
feat(58642): Altera na ata o cálculo de despesas demonstradas/não demonstradas - Parte 2

### DIFF
--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -177,7 +177,13 @@ def valida_rateios_quanto_aos_saldos(rateios, associacao, data_documento=None, e
     return result
 
 
-def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=None, conta=None):
+def info_acao_associacao_no_periodo(
+    acao_associacao,
+    periodo,
+    exclude_despesa=None,
+    conta=None,
+    apenas_transacoes_do_periodo=False
+):
     def resultado_vazio():
         return {
             'saldo_anterior_custeio': 0,
@@ -303,7 +309,7 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
         acao_associacao,
         info,
         exclude_despesa=exclude_despesa,
-        conta=None
+        conta=None,
     ):
         rateios = RateioDespesa.rateios_da_acao_entre_periodos(
             acao_associacao=acao_associacao,
@@ -319,7 +325,7 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
                 info['despesas_no_periodo_custeio'] += rateio.valor_rateio
                 info['saldo_atual_custeio'] -= rateio.valor_rateio
 
-                if not rateio.conferido or rateio.conferido and rateio.periodo_conciliacao.referencia > periodo_final.referencia:
+                if (not rateio.conferido) or (rateio.periodo_conciliacao and rateio.periodo_conciliacao.referencia > periodo_final.referencia):
                     info['despesas_nao_conciliadas_custeio'] += rateio.valor_rateio
                 else:
                     info['despesas_conciliadas_custeio'] += rateio.valor_rateio
@@ -328,14 +334,19 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
                 info['despesas_no_periodo_capital'] += rateio.valor_rateio
                 info['saldo_atual_capital'] -= rateio.valor_rateio
 
-                if not rateio.conferido or rateio.conferido and rateio.periodo_conciliacao.referencia > periodo_final.referencia:
+                if (not rateio.conferido) or (rateio.periodo_conciliacao and rateio.periodo_conciliacao.referencia > periodo_final.referencia):
                     info['despesas_nao_conciliadas_capital'] += rateio.valor_rateio
                 else:
                     info['despesas_conciliadas_capital'] += rateio.valor_rateio
 
         return info
 
-    def periodo_aberto_sumarizado_por_acao(periodo, acao_associacao, conta=None):
+    def periodo_aberto_sumarizado_por_acao(
+        periodo,
+        acao_associacao,
+        conta=None,
+        apenas_transacoes_do_periodo=False,
+    ):
         info = resultado_vazio()
 
         if not periodo:
@@ -358,7 +369,7 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
 
         periodo_do_saldo = fechamentos_periodo_anterior.first().periodo if fechamentos_periodo_anterior else periodo
 
-        if periodo_do_saldo and periodo_do_saldo.proximo_periodo:
+        if (not apenas_transacoes_do_periodo) and periodo_do_saldo and periodo_do_saldo.proximo_periodo:
             periodo_inicial_transacoes = periodo_do_saldo.proximo_periodo
         else:
             periodo_inicial_transacoes = periodo
@@ -368,7 +379,7 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
             periodo_final=periodo,
             acao_associacao=acao_associacao,
             info=info,
-            conta=conta
+            conta=conta,
         )
 
         info = sumariza_despesas_acao_entre_periodos(
@@ -376,7 +387,7 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
             periodo_final=periodo,
             acao_associacao=acao_associacao,
             info=info,
-            conta=conta
+            conta=conta,
         )
 
         if info['saldo_atual_custeio'] < 0:
@@ -408,11 +419,15 @@ def info_acao_associacao_no_periodo(acao_associacao, periodo, exclude_despesa=No
     fechamentos_periodo = FechamentoPeriodo.fechamentos_da_acao_no_periodo(acao_associacao=acao_associacao,
                                                                            periodo=periodo)
     if fechamentos_periodo:
-        logger.debug(f'Get fechamentos sumarizados por ação. Conta:{conta}')
+        logger.info(f'Get fechamentos sumarizados por ação. Conta:{conta}')
         return fechamento_sumarizado_por_acao(fechamentos_periodo, conta=conta)
     else:
-        logger.debug(f'Get periodo aberto sumarizado por ação. Período:{periodo} Ação:{acao_associacao} Conta:{conta}')
-        return periodo_aberto_sumarizado_por_acao(periodo, acao_associacao, conta=conta)
+        logger.info(f'Get periodo aberto sumarizado por ação. Período:{periodo} Ação:{acao_associacao} Conta:{conta}')
+        return periodo_aberto_sumarizado_por_acao(periodo,
+                                                  acao_associacao,
+                                                  conta=conta,
+                                                  apenas_transacoes_do_periodo=apenas_transacoes_do_periodo
+                                                  )
 
 
 def info_repasses_pendentes_acao_associacao_no_periodo(acao_associacao, periodo, conta=None):
@@ -433,12 +448,17 @@ def info_repasses_pendentes_acao_associacao_no_periodo(acao_associacao, periodo,
     return total_repasses
 
 
-def info_acoes_associacao_no_periodo(associacao_uuid, periodo, conta=None):
+def info_acoes_associacao_no_periodo(associacao_uuid, periodo, conta=None, apenas_transacoes_do_periodo=False):
     acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=associacao_uuid)
     result = []
     for acao_associacao in acoes_associacao:
         logger.debug(f'Get info ação no período. Ação:{acao_associacao} Período:{periodo} Conta:{conta}')
-        info_acao = info_acao_associacao_no_periodo(acao_associacao=acao_associacao, periodo=periodo, conta=conta)
+        info_acao = info_acao_associacao_no_periodo(
+            acao_associacao=acao_associacao,
+            periodo=periodo,
+            conta=conta,
+            apenas_transacoes_do_periodo=apenas_transacoes_do_periodo,
+        )
         especificacoes_despesas = especificacoes_despesas_acao_associacao_no_periodo(acao_associacao=acao_associacao,
                                                                                      periodo=periodo, conta=conta)
 

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -1011,7 +1011,9 @@ def previa_informacoes_financeiras_para_atas(associacao, periodo):
             f'Get prévia info financeiras por conta para a ata. Associacao:{associacao.uuid} Conta:{conta_associacao}')
         info_acoes = info_acoes_associacao_no_periodo(associacao_uuid=associacao.uuid,
                                                       periodo=periodo,
-                                                      conta=conta_associacao)
+                                                      conta=conta_associacao,
+                                                      apenas_transacoes_do_periodo=True,
+                                                      )
 
         info_acoes = [info for info in info_acoes if
                       info['saldo_reprogramado'] or info['receitas_no_periodo'] or info['despesas_no_periodo']]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_ata_dados_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_ata_dados_service/conftest.py
@@ -1,0 +1,379 @@
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from sme_ptrf_apps.core.models.fechamento_periodo import STATUS_FECHADO
+from sme_ptrf_apps.receitas.tipos_aplicacao_recurso_receitas import (APLICACAO_CAPITAL, APLICACAO_CUSTEIO,
+                                                                     APLICACAO_LIVRE)
+
+
+@pytest.fixture
+def ata_periodo_2019_2():
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=datetime.date(2019, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2019, 12, 31),
+        periodo_anterior=None
+    )
+
+
+@pytest.fixture
+def ata_periodo_2020_1(ata_periodo_2019_2):
+    return baker.make(
+        'Periodo',
+        referencia='2020.1',
+        data_inicio_realizacao_despesas=datetime.date(2020, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 6, 30),
+        periodo_anterior=ata_periodo_2019_2
+    )
+
+
+@pytest.fixture
+def ata_periodo_2020_2(ata_periodo_2020_1):
+    return baker.make(
+        'Periodo',
+        referencia='2020.2',
+        data_inicio_realizacao_despesas=datetime.date(2020, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 12, 31),
+        periodo_anterior=ata_periodo_2020_1
+    )
+
+
+@pytest.fixture
+def ata_periodo_2021_1(ata_periodo_2020_2):
+    return baker.make(
+        'Periodo',
+        referencia='2021.1',
+        data_inicio_realizacao_despesas=datetime.date(2021, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2021, 6, 30),
+        periodo_anterior=ata_periodo_2020_2
+    )
+
+
+@pytest.fixture
+def ata_tipo_conta_cartao():
+    return baker.make('TipoConta', nome='Cartão')
+
+
+@pytest.fixture
+def ata_acao_ptrf():
+    return baker.make('Acao', nome='PTRF')
+
+
+@pytest.fixture
+def ata_acao_associacao_ptrf(associacao, ata_acao_ptrf):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=associacao,
+        acao=ata_acao_ptrf
+    )
+
+
+@pytest.fixture
+def ata_conta_associacao_cartao(associacao, ata_tipo_conta_cartao):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=ata_tipo_conta_cartao
+    )
+
+
+@pytest.fixture
+def ata_tipo_receita_repasse():
+    return baker.make('TipoReceita', nome='Repasse', e_repasse=True)
+
+
+@pytest.fixture
+def ata_receita_2020_1_cartao_ptrf_repasse_capital_conferida_em_2020_1(
+    associacao,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    ata_tipo_receita_repasse,
+    ata_periodo_2020_1,
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        tipo_receita=ata_tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_1,
+        categoria_receita=APLICACAO_CAPITAL,
+    )
+
+
+@pytest.fixture
+def ata_receita_2020_1_cartao_ptrf_repasse_custeio_conferida_em_2020_1(
+    associacao,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_receita_repasse,
+    ata_periodo_2020_1
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        tipo_receita=tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_1,
+        categoria_receita=APLICACAO_CUSTEIO,
+    )
+
+
+@pytest.fixture
+def ata_receita_2020_1_cartao_ptrf_repasse_livre_conferida_em_2020_1(
+    associacao,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_receita_repasse,
+    ata_periodo_2020_1
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2020, 3, 26),
+        valor=100.00,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        tipo_receita=tipo_receita_repasse,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_1,
+        categoria_receita=APLICACAO_LIVRE,
+    )
+
+
+@pytest.fixture
+def ata_tipo_custeio_servico():
+    return baker.make('TipoCusteio', nome='Servico')
+
+
+@pytest.fixture
+def ata_especificacao_instalacao_eletrica(
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico
+):
+    return baker.make(
+        'EspecificacaoMaterialServico',
+        descricao='Instalação elétrica',
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+    )
+
+
+@pytest.fixture
+def ata_despesa_2020_1(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    ata_periodo_2020_1
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+    )
+
+
+@pytest.fixture
+def ata_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_1(
+    associacao,
+    ata_despesa_2020_1,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico,
+    ata_especificacao_instalacao_eletrica,
+    ata_periodo_2020_1
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=ata_despesa_2020_1,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+        especificacao_material_servico=ata_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_1,
+    )
+
+
+@pytest.fixture
+def ata_rateio_despesa_2020_1_cartao_ptrf_custeio_conferido_em_2020_2(
+    associacao,
+    ata_despesa_2020_1,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico,
+    ata_especificacao_instalacao_eletrica,
+    ata_periodo_2020_2
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=ata_despesa_2020_1,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+        especificacao_material_servico=ata_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_2,
+    )
+
+
+@pytest.fixture
+def ata_despesa_2019_2(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    ata_periodo_2019_2
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2019, 12, 1),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2019, 12, 1),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+    )
+
+
+@pytest.fixture
+def ata_rateio_despesa_2019_2_cartao_ptrf_custeio_nao_conferido(
+    associacao,
+    ata_despesa_2019_2,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico,
+    ata_especificacao_instalacao_eletrica,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=ata_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+        especificacao_material_servico=ata_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=False,
+    )
+
+@pytest.fixture
+def ata_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2020_2(
+    associacao,
+    ata_despesa_2019_2,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico,
+    ata_especificacao_instalacao_eletrica,
+    ata_periodo_2020_2,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=ata_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+        especificacao_material_servico=ata_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2020_2,
+    )
+
+
+@pytest.fixture
+def ata_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2021_1(
+    associacao,
+    ata_despesa_2019_2,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    tipo_aplicacao_recurso_custeio,
+    ata_tipo_custeio_servico,
+    ata_especificacao_instalacao_eletrica,
+    ata_periodo_2021_1,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=ata_despesa_2019_2,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=ata_tipo_custeio_servico,
+        especificacao_material_servico=ata_especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=ata_periodo_2021_1,
+    )
+
+@pytest.fixture
+def ata_prestacao_conta_2020_1(ata_periodo_2020_1, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=ata_periodo_2020_1,
+        associacao=associacao,
+    )
+
+
+@pytest.fixture
+def ata_fechamento_periodo_2020_1(
+    ata_periodo_2020_1,
+    associacao,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    ata_prestacao_conta_2020_1
+):
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=ata_periodo_2020_1,
+        associacao=associacao,
+        conta_associacao=ata_conta_associacao_cartao,
+        acao_associacao=ata_acao_associacao_ptrf,
+        fechamento_anterior=None,
+        total_receitas_custeio=100,
+        total_repasses_custeio=100,
+        total_despesas_custeio=100,
+        status=STATUS_FECHADO,
+        prestacao_conta=ata_prestacao_conta_2020_1
+    )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_ata_dados_service/test_informacoes_financeiras_para_atas_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_ata_dados_service/test_informacoes_financeiras_para_atas_service.py
@@ -1,0 +1,157 @@
+import pytest
+from decimal import Decimal
+
+from sme_ptrf_apps.core.services.ata_dados_service import informacoes_financeiras_para_atas
+
+pytestmark = pytest.mark.django_db
+
+
+def test_info_financeira_estrutura_resultado(
+    ata_prestacao_conta_2020_1,
+    ata_fechamento_periodo_2020_1,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+):
+    esperado = {
+        'contas': [
+            {
+                'acoes': [
+                    {
+                        'acao_associacao_nome': 'PTRF',
+                        'acao_associacao_uuid': f'{ata_acao_associacao_ptrf.uuid}',
+                        'despesas_conciliadas': Decimal('100.00'),
+                        'despesas_conciliadas_capital': Decimal('0.00'),
+                        'despesas_conciliadas_custeio': Decimal('100.00'),
+                        'despesas_nao_conciliadas': Decimal('0.00'),
+                        'despesas_nao_conciliadas_anteriores': 0,
+                        'despesas_nao_conciliadas_anteriores_capital': 0,
+                        'despesas_nao_conciliadas_anteriores_custeio': 0,
+                        'despesas_nao_conciliadas_capital': Decimal('0.00'),
+                        'despesas_nao_conciliadas_custeio': Decimal('0.00'),
+                        'despesas_no_periodo': Decimal('100.00'),
+                        'despesas_no_periodo_capital': Decimal('0.00'),
+                        'despesas_no_periodo_custeio': Decimal('100.00'),
+                        'especificacoes_despesas_capital': [],
+                        'especificacoes_despesas_custeio': [],
+                        'outras_receitas_no_periodo': Decimal('0.00'),
+                        'outras_receitas_no_periodo_capital': Decimal('0.00'),
+                        'outras_receitas_no_periodo_custeio': Decimal('0.00'),
+                        'outras_receitas_no_periodo_livre': Decimal('0.00'),
+                        'receitas_devolucao_no_periodo': Decimal('0.00'),
+                        'receitas_devolucao_no_periodo_capital': Decimal('0.00'),
+                        'receitas_devolucao_no_periodo_custeio': Decimal('0.00'),
+                        'receitas_devolucao_no_periodo_livre': Decimal('0.00'),
+                        'receitas_nao_conciliadas': Decimal('0.00'),
+                        'receitas_nao_conciliadas_capital': Decimal('0.00'),
+                        'receitas_nao_conciliadas_custeio': Decimal('0.00'),
+                        'receitas_nao_conciliadas_livre': Decimal('0.00'),
+                        'receitas_no_periodo': Decimal('100.00'),
+                        'repasses_nao_realizados_capital': 0,
+                        'repasses_nao_realizados_custeio': 0,
+                        'repasses_nao_realizados_livre': 0,
+                        'repasses_no_periodo': Decimal('100.00'),
+                        'repasses_no_periodo_capital': Decimal('0.00'),
+                        'repasses_no_periodo_custeio': Decimal('100.00'),
+                        'repasses_no_periodo_livre': Decimal('0.00'),
+                        'saldo_atual_capital': Decimal('0.00'),
+                        'saldo_atual_custeio': Decimal('0.00'),
+                        'saldo_atual_livre': Decimal('0.00'),
+                        'saldo_atual_total': Decimal('0.00'),
+                        'saldo_bancario_capital': Decimal('0.00'),
+                        'saldo_bancario_custeio': Decimal('0.00'),
+                        'saldo_bancario_livre': Decimal('0.00'),
+                        'saldo_bancario_total': Decimal('0.00'),
+                        'saldo_reprogramado': 0,
+                        'saldo_reprogramado_capital': 0,
+                        'saldo_reprogramado_custeio': 0,
+                        'saldo_reprogramado_livre': 0
+                    }
+                ],
+                'conta_associacao': {
+                    'agencia': '',
+                    'banco_nome': '',
+                    'nome': 'Cartão',
+                    'numero_conta': '',
+                    'uuid': f'{ata_conta_associacao_cartao.uuid}'
+                },
+                'totais': {
+                    'despesas_conciliadas': Decimal('100.00'),
+                    'despesas_conciliadas_capital': Decimal('0.00'),
+                    'despesas_conciliadas_custeio': Decimal('100.00'),
+                    'despesas_nao_conciliadas': Decimal('0.00'),
+                    'despesas_nao_conciliadas_anteriores': 0,
+                    'despesas_nao_conciliadas_anteriores_capital': 0,
+                    'despesas_nao_conciliadas_anteriores_custeio': 0,
+                    'despesas_nao_conciliadas_capital': Decimal('0.00'),
+                    'despesas_nao_conciliadas_custeio': Decimal('0.00'),
+                    'despesas_no_periodo': Decimal('100.00'),
+                    'despesas_no_periodo_capital': Decimal('0.00'),
+                    'despesas_no_periodo_custeio': Decimal('100.00'),
+                    'outras_receitas_no_periodo': Decimal('0.00'),
+                    'outras_receitas_no_periodo_capital': Decimal('0.00'),
+                    'outras_receitas_no_periodo_custeio': Decimal('0.00'),
+                    'outras_receitas_no_periodo_livre': Decimal('0.00'),
+                    'receitas_devolucao_no_periodo': Decimal('0.00'),
+                    'receitas_devolucao_no_periodo_capital': Decimal('0.00'),
+                    'receitas_devolucao_no_periodo_custeio': Decimal('0.00'),
+                    'receitas_devolucao_no_periodo_livre': Decimal('0.00'),
+                    'receitas_nao_conciliadas': Decimal('0.00'),
+                    'receitas_nao_conciliadas_capital': Decimal('0.00'),
+                    'receitas_nao_conciliadas_custeio': Decimal('0.00'),
+                    'receitas_nao_conciliadas_livre': Decimal('0.00'),
+                    'receitas_no_periodo': Decimal('100.00'),
+                    'repasses_nao_realizados_capital': 0,
+                    'repasses_nao_realizados_custeio': 0,
+                    'repasses_nao_realizados_livre': 0,
+                    'repasses_no_periodo': Decimal('100.00'),
+                    'repasses_no_periodo_capital': Decimal('0.00'),
+                    'repasses_no_periodo_custeio': Decimal('100.00'),
+                    'repasses_no_periodo_livre': Decimal('0.00'),
+                    'saldo_atual_capital': Decimal('0.00'),
+                    'saldo_atual_custeio': Decimal('0.00'),
+                    'saldo_atual_livre': Decimal('0.00'),
+                    'saldo_atual_total': Decimal('0.00'),
+                    'saldo_bancario_capital': Decimal('0.00'),
+                    'saldo_bancario_custeio': Decimal('0.00'),
+                    'saldo_bancario_livre': Decimal('0.00'),
+                    'saldo_bancario_total': Decimal('0.00'),
+                    'saldo_reprogramado': 0,
+                    'saldo_reprogramado_capital': 0,
+                    'saldo_reprogramado_custeio': 0,
+                    'saldo_reprogramado_livre': 0
+                }
+            }
+        ],
+    }
+
+    resultado = informacoes_financeiras_para_atas(ata_prestacao_conta_2020_1)
+    resultado.pop('uuid')
+    assert resultado == esperado
+
+
+def test_info_financeira_estrutura_despesa_anterior_nao_conferida(
+    ata_prestacao_conta_2020_1,
+    ata_fechamento_periodo_2020_1,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    ata_rateio_despesa_2019_2_cartao_ptrf_custeio_nao_conferido
+):
+    resultado = informacoes_financeiras_para_atas(ata_prestacao_conta_2020_1)
+    assert resultado['contas'][0]['acoes'][0]['despesas_nao_conciliadas_anteriores'] == Decimal('100.00')
+    assert resultado['contas'][0]['acoes'][0]['despesas_nao_conciliadas_anteriores_custeio'] == Decimal('100.00')
+    assert resultado['contas'][0]['totais']['despesas_nao_conciliadas_anteriores'] == Decimal('100.00')
+    assert resultado['contas'][0]['totais']['despesas_nao_conciliadas_anteriores_custeio'] == Decimal('100.00')
+
+
+def test_info_financeira_estrutura_despesa_anterior_conferida_no_futuro(
+    ata_prestacao_conta_2020_1,
+    ata_fechamento_periodo_2020_1,
+    ata_conta_associacao_cartao,
+    ata_acao_associacao_ptrf,
+    ata_rateio_despesa_2019_2_cartao_ptrf_custeio_conferido_em_2020_2
+):
+    resultado = informacoes_financeiras_para_atas(ata_prestacao_conta_2020_1)
+    assert resultado['contas'][0]['acoes'][0]['despesas_nao_conciliadas_anteriores'] == Decimal('100.00')
+    assert resultado['contas'][0]['acoes'][0]['despesas_nao_conciliadas_anteriores_custeio'] == Decimal('100.00')
+    assert resultado['contas'][0]['totais']['despesas_nao_conciliadas_anteriores'] == Decimal('100.00')
+    assert resultado['contas'][0]['totais']['despesas_nao_conciliadas_anteriores_custeio'] == Decimal('100.00')

--- a/sme_ptrf_apps/despesas/models/rateio_despesa.py
+++ b/sme_ptrf_apps/despesas/models/rateio_despesa.py
@@ -379,7 +379,8 @@ class RateioDespesa(ModeloBase):
             else:
                 totais['total_despesas_custeio'] += despesa.valor_rateio
 
-            if not despesa.conferido:
+            # Se não conferida ou conferida em período posterior
+            if (not despesa.conferido) or (despesa.periodo_conciliacao and despesa.periodo_conciliacao.referencia > periodo.referencia):
                 if despesa.aplicacao_recurso == APLICACAO_CAPITAL:
                     totais['total_despesas_nao_conciliadas_capital'] += despesa.valor_rateio
                 else:


### PR DESCRIPTION
## Esse PR:

- Conclui alterações nos cálculos de despesas demonstradas e não demonstradas nas tabelas de valores da ata de apresentação PDF ou Tela.

História: [AB#58642](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58642)

### Na Ata em tela:

- [X] Na linha "Despesas demonstradas", devem ser somadas apenas as despesas conciliadas cujo período de conciliação é o período da ata (tabelas de valores por ação e na tabela de totais);

- [X] Na linha "Despesas não demonstradas no período", devem ser somadas, além das despesas não conciliadas, também as que foram conciliadas em períodos posteriores ao período da ata (tabelas de valores por ação e na tabela de totais);

- [X] Na linha "Despesas não demonstradas de períodos anteriores", devem ser somadas, além das despesas não conciliadas de períodos anteriores, também as despesas de períodos anteriores e que foram conciliadas em períodos posteriores ao período da ata (tabelas de valores por ação e na tabela de totais);

### Na Ata em PDF:

- [X] Na linha "Despesas demonstradas", devem ser somadas apenas as despesas conciliadas cujo período de conciliação é o período da ata (tabelas de valores por ação e na tabela de totais);

- [X] Na linha "Despesas não demonstradas no período", devem ser somadas, além das despesas não conciliadas, também as que foram conciliadas em períodos posteriores ao período da ata (tabelas de valores por ação e na tabela de totais);

- [X] Na linha "Despesas não demonstradas de períodos anteriores", devem ser somadas, além das despesas não conciliadas de períodos anteriores, também as despesas de períodos anteriores e que foram conciliadas em períodos posteriores ao período da ata (tabelas de valores por ação e na tabela de totais);