### PR TITLE
feat(60309): Seleção de cargo na educação do servidor

### DIFF
--- a/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
@@ -142,6 +142,30 @@ class MembroAssociacaoViewSet(mixins.RetrieveModelMixin,
         except SmeIntegracaoApiException as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
+    @action(detail=False, methods=['get'], url_path='lista-cargos',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def lista_cargos(self, request):
+        rf = self.request.query_params.get('rf')
+
+        if not rf:
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': 'É necessário enviar o rf.'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            result = TerceirizadasService.get_informacao_servidor(rf)
+            return Response(result)
+        except SmeIntegracaoApiException as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except TerceirizadasException as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ReadTimeout:
+            return Response({'detail': 'EOL Timeout'}, status=status.HTTP_400_BAD_REQUEST)
+        except ConnectTimeout:
+            return Response({'detail': 'EOL Timeout'}, status=status.HTTP_400_BAD_REQUEST)
+
     def membro_ja_cadastrado(self, **kwargs):
         if MembroAssociacao.objects.filter(**kwargs).exists():
             raise SmeIntegracaoApiException('Membro já cadastrado.')

--- a/sme_ptrf_apps/core/services/membro_associacao_service.py
+++ b/sme_ptrf_apps/core/services/membro_associacao_service.py
@@ -65,7 +65,7 @@ class TerceirizadasService:
             results = response.json()['results']
             logger.info("Dados do servidor: %r", results)
             if len(results) >= 1:
-                return seleciona_cargo_servidor(results)
+                return results
             raise TerceirizadasException(f'Não foram encontrados resultados para o RF: {registro_funcional}.')
         else:
             raise TerceirizadasException(f'API EOL com erro. Status: {response.status_code}')


### PR DESCRIPTION
feat(60309): Seleção de cargo na educação do servidor

Esse PR:

- Altera regra que só permitia retornar 1 cargo para o servidor

História: [AB#60309](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/60309)