### PR TITLE
feat(63005): Demonstrativo: rever a exibição quanto a despesa sem comprovação ou não for reconhecida e não quebrar o bloco de créditos nas linhas relativas ao estorno - Parte 02

### DIFF
--- a/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
@@ -314,7 +314,7 @@
   </article>
 
   <article id="bloco-4" class="mt-4">
-    <table class="table table-bordered tabela-resumo-por-acao tabela-quebra-palavra tabela-bloco-4 nao-quebra-linha">
+    <table class="table table-bordered tabela-resumo-por-acao tabela-quebra-palavra tabela-bloco-4">
       <thead class="thead-light">
       <tr>
         <th colspan="5">


### PR DESCRIPTION
Esse PR:

- Remove classe css nao-quebra-linha

História: [AB#63005](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/63005)