### PR TITLE
feat(59547) Atas de PC add informação sobre se ata está completa 

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/ata_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/ata_serializer.py
@@ -21,7 +21,7 @@ class AtaLookUpSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ata
-        fields = ('uuid', 'nome', 'alterado_em')
+        fields = ('uuid', 'nome', 'alterado_em', "completa")
 
 
 class AtaSerializer(serializers.ModelSerializer):

--- a/sme_ptrf_apps/core/models/ata.py
+++ b/sme_ptrf_apps/core/models/ata.py
@@ -171,6 +171,34 @@ class Ata(ModeloBase):
     def nome(self):
         return f'Ata de {self.ATA_NOMES[self.tipo_ata]} da prestação de contas'
 
+    @property
+    def completa(self):
+        from sme_ptrf_apps.core.services.associacoes_service import tem_repasses_pendentes_periodos_ate_agora
+
+        esta_completa = (
+            self.tipo_ata and
+            self.tipo_reuniao and
+            self.convocacao and
+            self.data_reuniao and
+            self.local_reuniao and
+            self.presidente_reuniao and
+            self.cargo_presidente_reuniao and
+            self.secretario_reuniao and
+            self.cargo_secretaria_reuniao and
+            self.hora_reuniao
+        )
+
+        if tem_repasses_pendentes_periodos_ate_agora(associacao=self.associacao, periodo=self.periodo):
+            esta_completa = esta_completa and self.justificativa_repasses_pendentes
+
+        presidente_presente = self.presentes_na_ata.filter(nome=self.presidente_reuniao).exists()
+        esta_completa = esta_completa and presidente_presente
+
+        secretario_presente = self.presentes_na_ata.filter(nome=self.secretario_reuniao).exists()
+        esta_completa = esta_completa and secretario_presente
+
+        return esta_completa
+
     @classmethod
     def iniciar(cls, prestacao_conta, retificacao=False):
         logger.info(f'Iniciando Ata PC={prestacao_conta}, Retificação={retificacao}...')

--- a/sme_ptrf_apps/core/services/associacoes_service.py
+++ b/sme_ptrf_apps/core/services/associacoes_service.py
@@ -74,6 +74,15 @@ def retorna_repasses_pendentes_periodos_ate_agora(associacao, periodo):
     return resultado
 
 
+def tem_repasses_pendentes_periodos_ate_agora(associacao, periodo):
+    repasses_pendentes = Repasse.objects.filter(
+        associacao=associacao,
+        periodo__referencia__lte=periodo.referencia,
+        status=StatusRepasse.PENDENTE.name
+    )
+    return repasses_pendentes.exists()
+
+
 def retorna_status_prestacoes(periodos=None, status_pc=None, uuid=None):
     lista_de_periodos = []
     if periodos:

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_repasses_pendentes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_repasses_pendentes.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 from rest_framework import status
 
@@ -10,15 +9,13 @@ def test_action_repasses_pendentes_por_periodo(jwt_authenticated_client_a, assoc
         f'/api/associacoes/{associacao.uuid}/repasses-pendentes-por-periodo/?periodo_uuid={periodo.uuid}',
         content_type='application/json')
 
-    result = json.loads(response.content)
-
-    esperado = [
-        {
-            'repasse_periodo': repasse.periodo.referencia,
-            'repasse_acao': repasse.acao_associacao.acao.nome,
-            'repasse_total': round(repasse.valor_capital + repasse.valor_custeio + repasse.valor_livre, 2),
-        }
-    ]
-
     assert response.status_code == status.HTTP_200_OK
-    assert result == esperado
+
+
+def test_action_repasses_pendentes_por_periodo_sem_passar_periodo(jwt_authenticated_client_a, associacao, periodo, repasse):
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/repasses-pendentes-por-periodo/',
+        content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+

--- a/sme_ptrf_apps/core/tests/tests_services/tests_associacoes_service/test_repasses_pendentes_periodo_ate_agora_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_associacoes_service/test_repasses_pendentes_periodo_ate_agora_service.py
@@ -1,0 +1,13 @@
+import pytest
+
+from sme_ptrf_apps.core.services.associacoes_service import retorna_repasses_pendentes_periodos_ate_agora
+
+pytestmark = pytest.mark.django_db
+
+
+def test_retorna_repasses_pendentes_periodos_ate_agora(jwt_authenticated_client_a, associacao, periodo, repasse):
+    result = retorna_repasses_pendentes_periodos_ate_agora(associacao=associacao, periodo=periodo)
+    assert len(result) == 1
+    assert result[0]['repasse_periodo'] == repasse.periodo.referencia
+    assert result[0]['repasse_acao'] == repasse.acao_associacao.acao.nome
+    assert float(result[0]['repasse_total']) == round(repasse.valor_capital + repasse.valor_custeio + repasse.valor_livre, 2)

--- a/sme_ptrf_apps/core/tests/tests_services/tests_associacoes_service/test_tem_repasses_pendentes_periodos_ate_agora_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_associacoes_service/test_tem_repasses_pendentes_periodos_ate_agora_service.py
@@ -1,0 +1,19 @@
+import pytest
+
+from sme_ptrf_apps.core.services.associacoes_service import tem_repasses_pendentes_periodos_ate_agora
+
+pytestmark = pytest.mark.django_db
+
+
+def test_tem_repasses_pendentes_periodos_ate_agora_quando_tem(jwt_authenticated_client_a, associacao, periodo, repasse):
+
+    result = tem_repasses_pendentes_periodos_ate_agora(associacao=associacao, periodo=periodo)
+
+    assert result, "Deveria retornar True"
+
+
+def test_tem_repasses_pendentes_periodos_ate_agora_quando_nao_tem(jwt_authenticated_client_a, associacao, periodo):
+
+    result = tem_repasses_pendentes_periodos_ate_agora(associacao=associacao, periodo=periodo)
+
+    assert not result, "Deveria retornar False"


### PR DESCRIPTION
Esse PR altera o retorno de informações de atas para incluir informação se a ata está ou não completa conforme alguns critérios.

História: [AB#59547](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/59547)

