### PR TITLE
fix(63574): Corrige duplicação das devoluções ao tesouro

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -206,20 +206,22 @@ class PrestacaoConta(ModeloBase):
         from ..models.tipo_devolucao_ao_tesouro import TipoDevolucaoAoTesouro
         from ...despesas.models.despesa import Despesa
 
-        self.devolucoes_ao_tesouro_da_prestacao.all().delete()
         for devolucao in devolucoes_ao_tesouro_da_prestacao:
             tipo_devolucao = TipoDevolucaoAoTesouro.by_uuid(devolucao['tipo'])
             despesa = Despesa.by_uuid(devolucao['despesa'])
-            DevolucaoAoTesouro.objects.create(
-                prestacao_conta=self,
-                tipo=tipo_devolucao,
-                despesa=despesa,
-                data=devolucao['data'],
-                devolucao_total=devolucao['devolucao_total'],
-                motivo=devolucao['motivo'],
-                valor=devolucao['valor'],
-                visao_criacao=devolucao['visao_criacao'],
-            )
+            devolucao_uuid = devolucao['uuid']
+            devolucao_atual = DevolucaoAoTesouro.by_uuid(uuid=devolucao_uuid)
+
+            devolucao_atual.prestacao_conta = self
+            devolucao_atual.tipo = tipo_devolucao
+            devolucao_atual.despesa = despesa
+            devolucao_atual.data = devolucao['data']
+            devolucao_atual.devolucao_total = devolucao['devolucao_total']
+            devolucao_atual.motivo = devolucao['motivo']
+            devolucao_atual.valor = devolucao['valor']
+            devolucao_atual.visao_criacao = devolucao['visao_criacao']
+
+            devolucao_atual.save()
 
         return self
 

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_devolucoes_ao_tesouro.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_salva_devolucoes_ao_tesouro.py
@@ -46,7 +46,7 @@ def tipo_devolucao_ao_tesouro():
 
 @freeze_time('2020-09-01')
 def test_api_salva_devolucoes_ao_tesouro(jwt_authenticated_client_a, prestacao_conta_em_analise, conta_associacao,
-                                         tipo_devolucao_ao_tesouro, despesa):
+                                         tipo_devolucao_ao_tesouro, despesa, devolucao_ao_tesouro):
     payload = {
         'devolucoes_ao_tesouro_da_prestacao': [
             {
@@ -56,7 +56,8 @@ def test_api_salva_devolucoes_ao_tesouro(jwt_authenticated_client_a, prestacao_c
                 'valor': 100.00,
                 'tipo': f'{tipo_devolucao_ao_tesouro.uuid}',
                 'despesa': f'{despesa.uuid}',
-                'visao_criacao': 'UE'
+                'visao_criacao': 'UE',
+                'uuid': f"{devolucao_ao_tesouro.uuid}",
             }
         ]
     }
@@ -87,7 +88,7 @@ def devolucao_ao_tesouro(prestacao_conta_em_analise, tipo_devolucao_ao_tesouro, 
         despesa=despesa,
         devolucao_total=True,
         valor=100.00,
-        motivo='teste'
+        motivo='teste',
     )
 
 
@@ -99,5 +100,3 @@ def test_api_salvar_devolucoes_ao_tesouro_sem_devolucao_tesouro(jwt_authenticate
 
     assert response.status_code == status.HTTP_200_OK
 
-    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_em_analise.uuid)
-    assert not prestacao_atualizada.devolucoes_ao_tesouro_da_prestacao.exists(), 'Não apagou as devoluções ao tesouro'


### PR DESCRIPTION
Corrige: [AB#63574](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/63574)