### PR TITLE
fix(65643): O saldo das PCs 2022.1 e 2021.3 da DRE Ipiranga exibe os dados da PC 2021.2

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -201,7 +201,8 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
             result.append({
                 'conta_uuid': f'{conciliacao.conta_associacao.uuid}',
                 'data_extrato': conciliacao.data_extrato,
-                'saldo_extrato': conciliacao.saldo_extrato
+                'saldo_extrato': conciliacao.saldo_extrato,
+                'periodo_uuid': conciliacao.periodo.uuid,
             })
 
         return result

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -330,9 +330,14 @@ def test_api_retrieve_prestacao_conta_por_uuid(
             'erro': '',
             'mensagem': 'O período atual da PC é igual ao periodo_inicial.proximo_periodo da associacao'
         },
-        'informacoes_conciliacao_ue': [{'conta_uuid': f'{prestacao_conta.associacao.observacoes_conciliacao_da_associacao.first().conta_associacao.uuid}',
-                                        'data_extrato': '2019-11-30',
-                                        'saldo_extrato': 1000.0}],
+        'informacoes_conciliacao_ue': [
+            {
+                'conta_uuid': f'{prestacao_conta.associacao.observacoes_conciliacao_da_associacao.first().conta_associacao.uuid}',
+                'data_extrato': '2019-11-30',
+                'saldo_extrato': 1000.0,
+                'periodo_uuid': f'{prestacao_conta.associacao.observacoes_conciliacao_da_associacao.first().periodo.uuid}'
+            }
+        ],
         'motivos_aprovacao_ressalva': [
             {
                 'uuid': f'{motivo_aprovacao_ressalva_x.uuid}',


### PR DESCRIPTION
Corrige: [AB#65643](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/65643)