### PR TITLE
feat(64261) Configura audit log em arquivos de análises de PC

### DIFF
--- a/sme_ptrf_apps/core/models/analise_conta_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_conta_prestacao_conta.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class AnaliseContaPrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     prestacao_conta = models.ForeignKey('PrestacaoConta', on_delete=models.CASCADE,
                                         related_name='analises_de_conta_da_prestacao')
 
@@ -23,3 +28,6 @@ class AnaliseContaPrestacaoConta(ModeloBase):
     class Meta:
         verbose_name = "Análise de conta de prestação de contas"
         verbose_name_plural = "09.8) Análises de contas de prestações de contas"
+
+
+auditlog.register(AnaliseContaPrestacaoConta)

--- a/sme_ptrf_apps/core/models/analise_documento_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_documento_prestacao_conta.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class AnaliseDocumentoPrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     # Status Choice
     RESULTADO_CORRETO = 'CORRETO'
     RESULTADO_AJUSTE = 'AJUSTE'
@@ -40,3 +45,6 @@ class AnaliseDocumentoPrestacaoConta(ModeloBase):
     class Meta:
         verbose_name = "Análise de documentos de PC"
         verbose_name_plural = "16.6) Análises de documentos de PC"
+
+
+auditlog.register(AnaliseDocumentoPrestacaoConta)

--- a/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class AnaliseLancamentoPrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     # Status Choice
     RESULTADO_CORRETO = 'CORRETO'
     RESULTADO_AJUSTE = 'AJUSTE'
@@ -61,3 +66,6 @@ class AnaliseLancamentoPrestacaoConta(ModeloBase):
     class Meta:
         verbose_name = "Análise de lançamento"
         verbose_name_plural = "16.1) Análises de lançamentos"
+
+
+auditlog.register(AnaliseLancamentoPrestacaoConta)

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -1,10 +1,15 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from datetime import datetime
 
 
 class AnalisePrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     # Status Choice
     STATUS_EM_ANALISE = 'EM_ANALISE'
     STATUS_DEVOLVIDA = 'DEVOLVIDA'
@@ -151,3 +156,4 @@ class AnalisePrestacaoConta(ModeloBase):
         verbose_name_plural = "16.0) Análises de prestações de contas"
 
 
+auditlog.register(AnalisePrestacaoConta)

--- a/sme_ptrf_apps/core/models/analise_valor_reprogramado_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_valor_reprogramado_prestacao_conta.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class AnaliseValorReprogramadoPrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     analise_prestacao_conta = models.ForeignKey('AnalisePrestacaoConta', on_delete=models.CASCADE,
                                                 related_name='analises_de_valores_reprogramados')
 
@@ -32,3 +37,6 @@ class AnaliseValorReprogramadoPrestacaoConta(ModeloBase):
         verbose_name = "Análise de valor reprogramado de PC"
         verbose_name_plural = "16.8) Análises de valores reprogramados de PC"
         unique_together = ['analise_prestacao_conta', 'conta_associacao', 'acao_associacao', ]
+
+
+auditlog.register(AnaliseValorReprogramadoPrestacaoConta)

--- a/sme_ptrf_apps/core/models/censo.py
+++ b/sme_ptrf_apps/core/models/censo.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class Censo(ModeloBase):
+    history = AuditlogHistoryField()
+
     unidade = models.ForeignKey('Unidade', on_delete=models.PROTECT, related_name="censos", to_field="codigo_eol",
                                 null=True)
     quantidade_alunos = models.IntegerField("Quantidade Alunos", blank=True, default=0)
@@ -15,3 +20,6 @@ class Censo(ModeloBase):
     class Meta:
         verbose_name = "Censo"
         verbose_name_plural = '13.0) Censos'
+
+
+auditlog.register(Censo)

--- a/sme_ptrf_apps/core/models/comentario_analise_prestacao.py
+++ b/sme_ptrf_apps/core/models/comentario_analise_prestacao.py
@@ -2,10 +2,15 @@ from django.db import models
 from django.db import transaction
 from datetime import date
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class ComentarioAnalisePrestacao(ModeloBase):
+    history = AuditlogHistoryField()
+
     prestacao_conta = models.ForeignKey('PrestacaoConta', on_delete=models.CASCADE,
                                         related_name='comentarios_de_analise_da_prestacao')
 
@@ -38,3 +43,6 @@ class ComentarioAnalisePrestacao(ModeloBase):
     class Meta:
         verbose_name = "Observação de análise de prestação de contas"
         verbose_name_plural = "09.9) Observações de análise de prestações de contas"
+
+
+auditlog.register(ComentarioAnalisePrestacao)

--- a/sme_ptrf_apps/core/models/devolucao_ao_tesouro.py
+++ b/sme_ptrf_apps/core/models/devolucao_ao_tesouro.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class DevolucaoAoTesouro(ModeloBase):
+    history = AuditlogHistoryField()
+
     # visao_criacao Choice
     VISAO_DRE = 'DRE'
     VISAO_UE = 'UE'
@@ -48,3 +53,6 @@ class DevolucaoAoTesouro(ModeloBase):
     class Meta:
         verbose_name = "Devolução ao tesouro prestação de contas"
         verbose_name_plural = "09.9) Devoluções ao tesouro prestações de contas"
+
+
+auditlog.register(DevolucaoAoTesouro)

--- a/sme_ptrf_apps/core/models/devolucao_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/devolucao_prestacao_conta.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class DevolucaoPrestacaoConta(ModeloBase):
+    history = AuditlogHistoryField()
+
     prestacao_conta = models.ForeignKey('PrestacaoConta', on_delete=models.CASCADE,
                                         related_name='devolucoes_da_prestacao')
 
@@ -19,3 +24,6 @@ class DevolucaoPrestacaoConta(ModeloBase):
     class Meta:
         verbose_name = "Devolução de prestação de contas"
         verbose_name_plural = "09.7) Devoluções de prestações de contas"
+
+
+auditlog.register(DevolucaoPrestacaoConta)

--- a/sme_ptrf_apps/core/models/previsao_repasse_sme.py
+++ b/sme_ptrf_apps/core/models/previsao_repasse_sme.py
@@ -1,9 +1,16 @@
 from django.db import models
+
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
-#TODO Adicionar divisão livre, custeio e capital e conta
+# TODO Adicionar divisão livre, custeio e capital e conta
+
 
 class PrevisaoRepasseSme(ModeloBase):
+    history = AuditlogHistoryField()
+
     periodo = models.ForeignKey('Periodo', on_delete=models.PROTECT, related_name='previsoes_repasse_sme')
 
     associacao = models.ForeignKey('Associacao', on_delete=models.PROTECT,
@@ -26,8 +33,10 @@ class PrevisaoRepasseSme(ModeloBase):
     def __str__(self):
         return f"{self.periodo.referencia} - {self.associacao}"
 
-
     class Meta:
         verbose_name = "Previsão repasse SME"
         verbose_name_plural = "12.0) Previsões de repasse"
         unique_together = ['associacao', 'periodo', 'conta_associacao']
+
+
+auditlog.register(PrevisaoRepasseSme)

--- a/sme_ptrf_apps/core/models/solicitacao_acerto_documento.py
+++ b/sme_ptrf_apps/core/models/solicitacao_acerto_documento.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class SolicitacaoAcertoDocumento(ModeloBase):
+    history = AuditlogHistoryField()
+
     analise_documento = models.ForeignKey('AnaliseDocumentoPrestacaoConta', on_delete=models.CASCADE,
                                           related_name='solicitacoes_de_ajuste_da_analise')
 
@@ -18,3 +23,6 @@ class SolicitacaoAcertoDocumento(ModeloBase):
     class Meta:
         verbose_name = "Solicitação de acerto em documento"
         verbose_name_plural = "16.7) Solicitações de acertos em documentos"
+
+
+auditlog.register(SolicitacaoAcertoDocumento)

--- a/sme_ptrf_apps/core/models/solicitacao_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/models/solicitacao_acerto_lancamento.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class SolicitacaoAcertoLancamento(ModeloBase):
+    history = AuditlogHistoryField()
+
     analise_lancamento = models.ForeignKey('AnaliseLancamentoPrestacaoConta', on_delete=models.CASCADE,
                                            related_name='solicitacoes_de_ajuste_da_analise')
 
@@ -22,3 +27,6 @@ class SolicitacaoAcertoLancamento(ModeloBase):
     class Meta:
         verbose_name = "Solicitação de acerto em lançamento"
         verbose_name_plural = "16.3) Solicitações de acertos em lançamentos"
+
+
+auditlog.register(SolicitacaoAcertoLancamento)

--- a/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
@@ -1,9 +1,14 @@
 from django.db import models
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloIdNome
 
 
 class TipoAcertoLancamento(ModeloIdNome):
+    history = AuditlogHistoryField()
+
     # Categoria Choices
     CATEGORIA_BASICO = 'BASICO'
     CATEGORIA_DEVOLUCAO = 'DEVOLUCAO'
@@ -28,3 +33,6 @@ class TipoAcertoLancamento(ModeloIdNome):
     class Meta:
         verbose_name = "Tipo de acerto em lançamentos"
         verbose_name_plural = "16.2) Tipos de acerto em lançamentos"
+
+
+auditlog.register(TipoAcertoLancamento)

--- a/sme_ptrf_apps/core/tests/tests_analise_conta_prestacao_conta/test_analise_conta_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_conta_prestacao_conta/test_analise_conta_prestacao_conta_model.py
@@ -22,3 +22,14 @@ def test_srt_model(analise_conta_prestacao_conta_2020_1):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[AnaliseContaPrestacaoConta]
+
+
+def test_audit_log(analise_conta_prestacao_conta_2020_1):
+    assert analise_conta_prestacao_conta_2020_1.history.count() == 1  # Um log de inclusão
+    assert analise_conta_prestacao_conta_2020_1.history.latest().action == 0  # 0-Inclusão
+
+    analise_conta_prestacao_conta_2020_1.saldo_extrato = 100.00
+    analise_conta_prestacao_conta_2020_1.save()
+    assert analise_conta_prestacao_conta_2020_1.history.count() == 2  # Um log de inclusão e outro de edição
+    assert analise_conta_prestacao_conta_2020_1.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_analise_documento_prestacao_conta/test_analise_documento_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_documento_prestacao_conta/test_analise_documento_prestacao_conta_model.py
@@ -23,3 +23,14 @@ def test_srt_model(analise_documento_prestacao_conta_2020_1_ata_correta):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[AnaliseDocumentoPrestacaoConta]
+
+
+def test_audit_log(analise_documento_prestacao_conta_2020_1_ata_correta):
+    assert analise_documento_prestacao_conta_2020_1_ata_correta.history.count() == 1  # Um log de inclusão
+    assert analise_documento_prestacao_conta_2020_1_ata_correta.history.latest().action == 0  # 0-Inclusão
+
+    analise_documento_prestacao_conta_2020_1_ata_correta.resultado = "AJUSTE"
+    analise_documento_prestacao_conta_2020_1_ata_correta.save()
+    assert analise_documento_prestacao_conta_2020_1_ata_correta.history.count() == 2  # Um log de inclusão e outro de edição
+    assert analise_documento_prestacao_conta_2020_1_ata_correta.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_analise_lancamento_prestacao_conta/test_analise_lancamento_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_lancamento_prestacao_conta/test_analise_lancamento_prestacao_conta_model.py
@@ -23,3 +23,14 @@ def test_srt_model(analise_lancamento_receita_prestacao_conta_2020_1):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[AnaliseLancamentoPrestacaoConta]
+
+
+def test_audit_log(analise_lancamento_receita_prestacao_conta_2020_1):
+    assert analise_lancamento_receita_prestacao_conta_2020_1.history.count() == 1  # Um log de inclusão
+    assert analise_lancamento_receita_prestacao_conta_2020_1.history.latest().action == 0  # 0-Inclusão
+
+    analise_lancamento_receita_prestacao_conta_2020_1.resultado = "AJUSTE"
+    analise_lancamento_receita_prestacao_conta_2020_1.save()
+    assert analise_lancamento_receita_prestacao_conta_2020_1.history.count() == 2  # Um log de inclusão e outro de edição
+    assert analise_lancamento_receita_prestacao_conta_2020_1.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
@@ -21,3 +21,14 @@ def test_srt_model(analise_prestacao_conta_2020_1):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[AnalisePrestacaoConta]
+
+
+def test_audit_log(analise_prestacao_conta_2020_1):
+    assert analise_prestacao_conta_2020_1.history.count() == 1  # Um log de inclusão
+    assert analise_prestacao_conta_2020_1.history.latest().action == 0  # 0-Inclusão
+
+    analise_prestacao_conta_2020_1.versao = "RASCUNHO"
+    analise_prestacao_conta_2020_1.save()
+    assert analise_prestacao_conta_2020_1.history.count() == 2  # Um log de inclusão e outro de edição
+    assert analise_prestacao_conta_2020_1.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_analise_valor_reprogramado_prestacao_conta/test_analise_valor_reprogramado_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_valor_reprogramado_prestacao_conta/test_analise_valor_reprogramado_prestacao_conta_model.py
@@ -28,3 +28,14 @@ def test_srt_model(analise_valor_reprogramado_por_acao, conta_associacao, acao_a
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[AnaliseValorReprogramadoPrestacaoConta]
+
+
+def test_audit_log(analise_valor_reprogramado_por_acao):
+    assert analise_valor_reprogramado_por_acao.history.count() == 1  # Um log de inclusão
+    assert analise_valor_reprogramado_por_acao.history.latest().action == 0  # 0-Inclusão
+
+    analise_valor_reprogramado_por_acao.novo_saldo_reprogramado_custeio = 100.00
+    analise_valor_reprogramado_por_acao.save()
+    assert analise_valor_reprogramado_por_acao.history.count() == 2  # Um log de inclusão e outro de edição
+    assert analise_valor_reprogramado_por_acao.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_censo/test_model.py
+++ b/sme_ptrf_apps/core/tests/tests_censo/test_model.py
@@ -27,3 +27,13 @@ def test_model_censo(censo):
 def test_censo_admin():
     # pylint: disable=W0212
     assert admin.site._registry[Censo]
+
+
+def test_audit_log(censo):
+    assert censo.history.count() == 1  # Um log de inclusão
+    assert censo.history.latest().action == 0  # 0-Inclusão
+
+    censo.ano = "2022"
+    censo.save()
+    assert censo.history.count() == 2  # Um log de inclusão e outro de edição
+    assert censo.history.latest().action == 1  # 1-Edição

--- a/sme_ptrf_apps/core/tests/tests_comentario_analise_pestacao/test_comentario_analise_prestacao_model.py
+++ b/sme_ptrf_apps/core/tests/tests_comentario_analise_pestacao/test_comentario_analise_prestacao_model.py
@@ -32,3 +32,14 @@ def test_srt_model(comentario_analise_prestacao):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[ComentarioAnalisePrestacao]
+
+
+def test_audit_log(comentario_analise_prestacao):
+    assert comentario_analise_prestacao.history.count() == 1  # Um log de inclusão
+    assert comentario_analise_prestacao.history.latest().action == 0  # 0-Inclusão
+
+    comentario_analise_prestacao.comentario = "TESTE"
+    comentario_analise_prestacao.save()
+    assert comentario_analise_prestacao.history.count() == 2  # Um log de inclusão e outro de edição
+    assert comentario_analise_prestacao.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_devolucao_ao_tesouro/test_devolucao_ao_tesouro_model.py
+++ b/sme_ptrf_apps/core/tests/tests_devolucao_ao_tesouro/test_devolucao_ao_tesouro_model.py
@@ -63,3 +63,13 @@ def test_srt_model(devolucao_ao_tesouro):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[DevolucaoAoTesouro]
+
+
+def test_audit_log(devolucao_ao_tesouro):
+    assert devolucao_ao_tesouro.history.count() == 1  # Um log de inclusão
+    assert devolucao_ao_tesouro.history.latest().action == 0  # 0-Inclusão
+
+    devolucao_ao_tesouro.valor = 100.00
+    devolucao_ao_tesouro.save()
+    assert devolucao_ao_tesouro.history.count() == 2  # Um log de inclusão e outro de edição
+    assert devolucao_ao_tesouro.history.latest().action == 1  # 1-Edição

--- a/sme_ptrf_apps/core/tests/tests_devolucao_pestacao_conta/test_devolucao_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_devolucao_pestacao_conta/test_devolucao_prestacao_conta_model.py
@@ -22,3 +22,14 @@ def test_srt_model(devolucao_prestacao_conta_2020_1):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[DevolucaoPrestacaoConta]
+
+
+def test_audit_log(devolucao_prestacao_conta_2020_1):
+    assert devolucao_prestacao_conta_2020_1.history.count() == 1  # Um log de inclusão
+    assert devolucao_prestacao_conta_2020_1.history.latest().action == 0  # 0-Inclusão
+
+    devolucao_prestacao_conta_2020_1.data_limite_ue = "2022-06-03"
+    devolucao_prestacao_conta_2020_1.save()
+    assert devolucao_prestacao_conta_2020_1.history.count() == 2  # Um log de inclusão e outro de edição
+    assert devolucao_prestacao_conta_2020_1.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_previsao_repasse_sme/test_previsao_repasse_sme_model.py
+++ b/sme_ptrf_apps/core/tests/tests_previsao_repasse_sme/test_previsao_repasse_sme_model.py
@@ -20,6 +20,7 @@ def test_instance_model(previsao_repasse_sme):
     assert model.valor_custeio
     assert model.valor_livre
 
+
 def test_srt_model(previsao_repasse_sme):
     assert previsao_repasse_sme.__str__() == '2019.2 - Escola Teste'
 
@@ -27,3 +28,13 @@ def test_srt_model(previsao_repasse_sme):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[PrevisaoRepasseSme]
+
+
+def test_audit_log(previsao_repasse_sme):
+    assert previsao_repasse_sme.history.count() == 1  # Um log de inclusão
+    assert previsao_repasse_sme.history.latest().action == 0  # 0-Inclusão
+
+    previsao_repasse_sme.valor_capital = 100.00
+    previsao_repasse_sme.save()
+    assert previsao_repasse_sme.history.count() == 2  # Um log de inclusão e outro de edição
+    assert previsao_repasse_sme.history.latest().action == 1  # 1-Edição

--- a/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_documento/test_solicitacao_acerto_documento_model.py
+++ b/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_documento/test_solicitacao_acerto_documento_model.py
@@ -25,3 +25,13 @@ def test_srt_model(solicitacao_acerto_documento_ata):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[SolicitacaoAcertoDocumento]
+
+
+def test_audit_log(solicitacao_acerto_documento_ata):
+    assert solicitacao_acerto_documento_ata.history.count() == 1  # Um log de inclusão
+    assert solicitacao_acerto_documento_ata.history.latest().action == 0  # 0-Inclusão
+
+    solicitacao_acerto_documento_ata.detalhamento = "TESTE"
+    solicitacao_acerto_documento_ata.save()
+    assert solicitacao_acerto_documento_ata.history.count() == 2  # Um log de inclusão e outro de edição
+    assert solicitacao_acerto_documento_ata.history.latest().action == 1  # 1-Edição

--- a/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_lancamento/test_solicitacao_acerto_lancamento_model.py
+++ b/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_lancamento/test_solicitacao_acerto_lancamento_model.py
@@ -27,3 +27,14 @@ def test_srt_model(solicitacao_acerto_lancamento_devolucao):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[SolicitacaoAcertoLancamento]
+
+
+def test_audit_log(solicitacao_acerto_lancamento_devolucao):
+    assert solicitacao_acerto_lancamento_devolucao.history.count() == 1  # Um log de inclusão
+    assert solicitacao_acerto_lancamento_devolucao.history.latest().action == 0  # 0-Inclusão
+
+    solicitacao_acerto_lancamento_devolucao.detalhamento = "TESTE"
+    solicitacao_acerto_lancamento_devolucao.save()
+    assert solicitacao_acerto_lancamento_devolucao.history.count() == 2  # Um log de inclusão e outro de edição
+    assert solicitacao_acerto_lancamento_devolucao.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/core/tests/tests_tipo_acerto_lancamento/test_model.py
+++ b/sme_ptrf_apps/core/tests/tests_tipo_acerto_lancamento/test_model.py
@@ -31,3 +31,14 @@ def test_srt_model(tipo_acerto_lancamento):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[TipoAcertoLancamento]
+
+
+def test_audit_log(tipo_acerto_lancamento):
+    assert tipo_acerto_lancamento.history.count() == 1  # Um log de inclusão
+    assert tipo_acerto_lancamento.history.latest().action == 0  # 0-Inclusão
+
+    tipo_acerto_lancamento.nome = "TESTE"
+    tipo_acerto_lancamento.save()
+    assert tipo_acerto_lancamento.history.count() == 2  # Um log de inclusão e outro de edição
+    assert tipo_acerto_lancamento.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/despesas/models/motivo_pagamento_antecipado.py
+++ b/sme_ptrf_apps/despesas/models/motivo_pagamento_antecipado.py
@@ -1,8 +1,14 @@
 from django.db import models
+
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class MotivoPagamentoAntecipado(ModeloBase):
+    history = AuditlogHistoryField()
+
     lookup_field = 'uuid'
     motivo = models.CharField(max_length=200)
 
@@ -12,3 +18,6 @@ class MotivoPagamentoAntecipado(ModeloBase):
 
     def __str__(self):
         return self.motivo
+
+
+auditlog.register(MotivoPagamentoAntecipado)

--- a/sme_ptrf_apps/despesas/tests/tests_motivos_pagamentos_antecipados/test_motivo_pagamento_antecipado_model.py
+++ b/sme_ptrf_apps/despesas/tests/tests_motivos_pagamentos_antecipados/test_motivo_pagamento_antecipado_model.py
@@ -24,3 +24,12 @@ def test_meta_modelo(motivo_pagamento_adiantado_01):
     assert motivo_pagamento_adiantado_01._meta.verbose_name == 'Motivo de pagamento antecipado'
     assert motivo_pagamento_adiantado_01._meta.verbose_name_plural == 'Motivos de pagamento antecipado'
 
+
+def test_audit_log(motivo_pagamento_adiantado_01):
+    assert motivo_pagamento_adiantado_01.history.count() == 1  # Um log de inclusão
+    assert motivo_pagamento_adiantado_01.history.latest().action == 0  # 0-Inclusão
+
+    motivo_pagamento_adiantado_01.motivo = "TESTE"
+    motivo_pagamento_adiantado_01.save()
+    assert motivo_pagamento_adiantado_01.history.count() == 2  # Um log de inclusão e outro de edição
+    assert motivo_pagamento_adiantado_01.history.latest().action == 1  # 1-Edição

--- a/sme_ptrf_apps/dre/models/motivo_reprovacao.py
+++ b/sme_ptrf_apps/dre/models/motivo_reprovacao.py
@@ -1,8 +1,14 @@
 from django.db import models
+
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 
 
 class MotivoReprovacao(ModeloBase):
+    history = AuditlogHistoryField()
+
     lookup_field = 'uuid'
     motivo = models.CharField(max_length=200)
 
@@ -12,3 +18,6 @@ class MotivoReprovacao(ModeloBase):
 
     def __str__(self):
         return self.motivo
+
+
+auditlog.register(MotivoReprovacao)

--- a/sme_ptrf_apps/dre/models/parametro_fique_de_olho_rel_dre.py
+++ b/sme_ptrf_apps/dre/models/parametro_fique_de_olho_rel_dre.py
@@ -1,9 +1,14 @@
 from ckeditor.fields import RichTextField
 
+from auditlog.models import AuditlogHistoryField
+from auditlog.registry import auditlog
+
 from sme_ptrf_apps.core.models_abstracts import ModeloBase, SingletonModel
 
 
 class ParametroFiqueDeOlhoRelDre(SingletonModel, ModeloBase):
+    history = AuditlogHistoryField()
+
     fique_de_olho = RichTextField(null=True, verbose_name='Texto do fique de olho')
 
     def __str__(self):
@@ -12,3 +17,6 @@ class ParametroFiqueDeOlhoRelDre(SingletonModel, ModeloBase):
     class Meta:
         verbose_name = "Fique de olho (Relatório Consolidado)"
         verbose_name_plural = "Fique de olho (Relatório Consolidado)"
+
+
+auditlog.register(ParametroFiqueDeOlhoRelDre)

--- a/sme_ptrf_apps/dre/tests/tests_motivos_reprovacao/test_motivo_reprovacao_model.py
+++ b/sme_ptrf_apps/dre/tests/tests_motivos_reprovacao/test_motivo_reprovacao_model.py
@@ -25,3 +25,14 @@ def test_meta_model(motivo_reprovacao_x):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[MotivoReprovacao]
+
+
+def test_audit_log(motivo_reprovacao_x):
+    assert motivo_reprovacao_x.history.count() == 1  # Um log de inclusão
+    assert motivo_reprovacao_x.history.latest().action == 0  # 0-Inclusão
+
+    motivo_reprovacao_x.motivo = "TESTE"
+    motivo_reprovacao_x.save()
+    assert motivo_reprovacao_x.history.count() == 2  # Um log de inclusão e outro de edição
+    assert motivo_reprovacao_x.history.latest().action == 1  # 1-Edição
+

--- a/sme_ptrf_apps/dre/tests/tests_parametro_fique_de_olho_rel_dre/test_model.py
+++ b/sme_ptrf_apps/dre/tests/tests_parametro_fique_de_olho_rel_dre/test_model.py
@@ -18,3 +18,13 @@ def test_parametro_fique_de_olho_rel_dre_model(parametro_fique_de_olho_rel_dre_a
     assert isinstance(parametro_fique_de_olho_rel_dre_abc, ParametroFiqueDeOlhoRelDre)
     assert parametro_fique_de_olho_rel_dre_abc.fique_de_olho == 'abc'
 
+
+def test_audit_log(parametro_fique_de_olho_rel_dre_abc):
+    assert parametro_fique_de_olho_rel_dre_abc.history.count() == 1  # Um log de inclusão
+    assert parametro_fique_de_olho_rel_dre_abc.history.latest().action == 0  # 0-Inclusão
+
+    parametro_fique_de_olho_rel_dre_abc.fique_de_olho = "teste"
+    parametro_fique_de_olho_rel_dre_abc.save()
+    assert parametro_fique_de_olho_rel_dre_abc.history.count() == 2  # Um log de inclusão e outro de edição
+    assert parametro_fique_de_olho_rel_dre_abc.history.latest().action == 1  # 1-Edição
+


### PR DESCRIPTION
Esse PR configura o AuditLog nas seguintes entidades:

[X] AnaliseContaPrestacaoConta
[X] AnaliseDocumentoPrestacaoConta
[X] AnaliseLancamentoPrestacaoConta
[X] AnalisePrestacaoConta
[X] AnaliseValorReprogramadoPrestacaoConta
[X] ComentarioAnalisePrestacao
[X] DevolucaoAoTesouro
[X] MotivoReprovacao
[X] TipoAcertoLancamento
[X] SolicitacaoAcertoLancamento
[X] SolicitacaoAcertoDocumento
[X] DevolucaoPrestacaoConta
[X] MotivoPagamentoAntecipado
[X] ParametroFiqueDeOlhoRelDre
[X] Censo
[X] PrevisaoRepasseSme

História: [AB#64261](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/64261)