### PR TITLE
feat(62837): Suporte às Unidades: Encerrar acesso de suporte 

### DIFF
--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -369,16 +369,16 @@ class UserViewSet(ModelViewSet):
     def encerrar_acesso_suporte_usuario_unidade(self, request, id):
         """ (post) /usuarios/{usuario.username}/encerrar-acesso-suporte/  """
         usuario = User.objects.get(username=id)
-        codigo_eol = request.data.get('codigo_eol')
-        if not codigo_eol:
-            return Response("Campo 'codigo_eol' não encontrado no payload.", status=status.HTTP_400_BAD_REQUEST)
+        unidade_suporte_uuid = request.data.get('unidade_suporte_uuid')
+        if not unidade_suporte_uuid:
+            return Response("Campo 'unidade_suporte_uuid' não encontrado no payload.", status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            unidade = Unidade.objects.get(codigo_eol=codigo_eol)
+            unidade = Unidade.objects.get(uuid=unidade_suporte_uuid)
         except Unidade.DoesNotExist:
             erro = {
                 'erro': 'Objeto não encontrado.',
-                'mensagem': f"O objeto Unidade para o código EOL {codigo_eol} não foi encontrado na base."
+                'mensagem': f"O objeto Unidade para o UUID {unidade_suporte_uuid} não foi encontrado na base."
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)

--- a/sme_ptrf_apps/users/api/views/user.py
+++ b/sme_ptrf_apps/users/api/views/user.py
@@ -18,7 +18,12 @@ from sme_ptrf_apps.users.api.serializers import (
     UserRetrieveSerializer
 )
 from sme_ptrf_apps.users.models import Grupo, Visao
-from sme_ptrf_apps.users.services import SmeIntegracaoException, SmeIntegracaoService, criar_acesso_de_suporte
+from sme_ptrf_apps.users.services import (
+    SmeIntegracaoException,
+    SmeIntegracaoService,
+    criar_acesso_de_suporte,
+    encerrar_acesso_de_suporte
+)
 from sme_ptrf_apps.users.services.unidades_e_permissoes_service import unidades_do_usuario_e_permissoes_na_visao
 from sme_ptrf_apps.users.services.validacao_username_service import validar_username
 from sme_ptrf_apps.core.models import Unidade
@@ -359,3 +364,25 @@ class UserViewSet(ModelViewSet):
         criar_acesso_de_suporte(unidade_do_suporte=unidade, usuario_do_suporte=usuario)
 
         return Response({"mensagem": "Acesso de suporte viabilizado."}, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'], url_path='encerrar-acesso-suporte')
+    def encerrar_acesso_suporte_usuario_unidade(self, request, id):
+        """ (post) /usuarios/{usuario.username}/encerrar-acesso-suporte/  """
+        usuario = User.objects.get(username=id)
+        codigo_eol = request.data.get('codigo_eol')
+        if not codigo_eol:
+            return Response("Campo 'codigo_eol' não encontrado no payload.", status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            unidade = Unidade.objects.get(codigo_eol=codigo_eol)
+        except Unidade.DoesNotExist:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': f"O objeto Unidade para o código EOL {codigo_eol} não foi encontrado na base."
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        encerrar_acesso_de_suporte(unidade_do_suporte=unidade, usuario_do_suporte=usuario)
+
+        return Response({"mensagem": "Acesso de suporte encerrado."}, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/users/models.py
+++ b/sme_ptrf_apps/users/models.py
@@ -95,6 +95,13 @@ class User(AbstractUser):
                 self.save()
                 logger.info(f'Visão {visao_obj} adicionada para o usuário {self}.')
 
+    def remove_visao_se_existir(self, visao):
+        if self.visoes.filter(nome=visao).exists():
+            visao_obj = Visao.objects.get(nome=visao)
+            self.visoes.remove(visao_obj)
+            self.save()
+            logger.info(f'Visão {visao} removida do usuário {self}.')
+
     def add_unidade_se_nao_existir(self, codigo_eol):
         if not self.unidades.filter(codigo_eol=codigo_eol).exists():
             unidade = Unidade.objects.get(codigo_eol=codigo_eol)
@@ -107,6 +114,7 @@ class User(AbstractUser):
             unidade = Unidade.objects.get(codigo_eol=codigo_eol)
             self.unidades.remove(unidade)
             self.save()
+            logger.info(f'Unidade {codigo_eol} removida do usuário {self}.')
 
     @classmethod
     def criar_usuario(cls, dados):

--- a/sme_ptrf_apps/users/services/__init__.py
+++ b/sme_ptrf_apps/users/services/__init__.py
@@ -3,3 +3,4 @@ from .usuario_core_sso_service import cria_ou_atualiza_usuario_core_sso
 from .validacao_username_service import validar_username
 from .criar_acesso_de_suporte_service import criar_acesso_de_suporte, CriaAcessoSuporteException
 from .get_unidades_usuario_service import get_unidades_do_usuario
+from .encerrar_acesso_de_suporte_service import encerrar_acesso_de_suporte, EncerraAcessoSuporteException

--- a/sme_ptrf_apps/users/services/encerrar_acesso_de_suporte_service.py
+++ b/sme_ptrf_apps/users/services/encerrar_acesso_de_suporte_service.py
@@ -1,0 +1,41 @@
+import logging
+
+from ..models import UnidadeEmSuporte
+
+logger = logging.getLogger(__name__)
+
+
+class EncerraAcessoSuporteException(Exception):
+    pass
+
+
+def encerrar_acesso_de_suporte(unidade_do_suporte, usuario_do_suporte):
+    from sme_ptrf_apps.core.models import Unidade
+    from django.contrib.auth import get_user_model
+
+    logger.info('Encerramento de acesso de suporte.')
+
+    if not unidade_do_suporte or not isinstance(unidade_do_suporte, Unidade):
+        logger.error('Não informado a unidade para encerramento de acesso de suporte.')
+        raise EncerraAcessoSuporteException('É necessário informar uma unidade pelo parâmetro unidade_do_suporte')
+
+    if not usuario_do_suporte or not isinstance(usuario_do_suporte, get_user_model()):
+        logger.error('Não informado o usuário para encerramento de acesso de suporte.')
+        raise EncerraAcessoSuporteException('É necessário informar um usuário do suporte pelo parâmetro usuário_do_suporte')
+
+    logger.info(f'Encerramento de acesso de suporte solicitado por {usuario_do_suporte.username} para a unidade {unidade_do_suporte.codigo_eol}')
+
+    usuario_do_suporte.remove_unidade_se_existir(codigo_eol=unidade_do_suporte.codigo_eol)
+
+    if unidade_do_suporte.tipo_unidade == 'DRE' and not usuario_do_suporte.unidades.filter(tipo_unidade='DRE').exists():
+        usuario_do_suporte.remove_visao_se_existir(visao='DRE')
+
+    if unidade_do_suporte.tipo_unidade == 'UE' and not usuario_do_suporte.unidades.exclude(tipo_unidade='DRE').exists():
+        usuario_do_suporte.remove_visao_se_existir(visao='UE')
+
+    unidade_em_suporte = UnidadeEmSuporte.objects.filter(unidade=unidade_do_suporte, user=usuario_do_suporte).first()
+    if unidade_em_suporte:
+        unidade_em_suporte.delete()
+        logger.info(f'Apagado acesso de suporte usuário {usuario_do_suporte.username} unidade {unidade_do_suporte.codigo_eol}')
+
+    return

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_encerrar_acesso_suporte_unidade.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_encerrar_acesso_suporte_unidade.py
@@ -1,0 +1,44 @@
+import json
+import pytest
+
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+def test_encerrar_acesso_usuario_unidade(
+        jwt_authenticated_client_u,
+        usuario_3,
+        dre,
+):
+    payload = {
+        'codigo_eol': dre.codigo_eol
+    }
+
+    response = jwt_authenticated_client_u.post(
+        f"/api/usuarios/{usuario_3.username}/encerrar-acesso-suporte/",
+        data=json.dumps(payload),
+        content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_encerrar_acesso_usuario_unidade_sem_passar_codigo_eol(
+        jwt_authenticated_client_u,
+        usuario_3,
+):
+    payload = {
+    }
+
+    response = jwt_authenticated_client_u.post(
+        f"/api/usuarios/{usuario_3.username}/encerrar-acesso-suporte/",
+        data=json.dumps(payload),
+        content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    result = json.loads(response.content)
+    assert result == "Campo 'codigo_eol' não encontrado no payload."
+

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_encerrar_acesso_suporte_unidade.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_encerrar_acesso_suporte_unidade.py
@@ -12,7 +12,7 @@ def test_encerrar_acesso_usuario_unidade(
         dre,
 ):
     payload = {
-        'codigo_eol': dre.codigo_eol
+        'unidade_suporte_uuid': f'{dre.uuid}'
     }
 
     response = jwt_authenticated_client_u.post(

--- a/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/conftest.py
+++ b/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/conftest.py
@@ -61,10 +61,30 @@ def usuario_do_suporte(
     email = 'sme@amcom.com.br'
     User = get_user_model()
     user = User.objects.create_user(username=login, password=senha, email=email)
-    user.unidades.add(dre)
+    # user.unidades.add(dre)
     user.visoes.add(visao_sme)
     user.save()
     return user
+
+
+@pytest.fixture
+def usuario_do_suporte_com_acesso_dre(
+        dre,
+        visao_dre,
+        visao_sme
+):
+
+    senha = 'Sgp0418'
+    login = '2711702'
+    email = 'sme2@amcom.com.br'
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email)
+    user.unidades.add(dre)
+    user.visoes.add(visao_sme)
+    user.visoes.add(visao_dre)
+    user.save()
+    return user
+
 
 
 @pytest.fixture
@@ -73,4 +93,13 @@ def unidade_em_suporte(unidade_do_suporte, usuario_do_suporte):
         'UnidadeEmSuporte',
         unidade=unidade_do_suporte,
         user=usuario_do_suporte,
+    )
+
+
+@pytest.fixture
+def unidade_dre_em_suporte(dre, usuario_do_suporte_com_acesso_dre):
+    return baker.make(
+        'UnidadeEmSuporte',
+        unidade=dre,
+        user=usuario_do_suporte_com_acesso_dre,
     )

--- a/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/test_encerrar_acesso_suporte_service.py
+++ b/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/test_encerrar_acesso_suporte_service.py
@@ -1,0 +1,62 @@
+import pytest
+
+from ...models import UnidadeEmSuporte
+from ...services import encerrar_acesso_de_suporte, EncerraAcessoSuporteException
+
+pytestmark = pytest.mark.django_db
+
+
+def test_encerra_acesso_suporte_dre(
+    unidade_dre_em_suporte,
+    usuario_do_suporte_com_acesso_dre,
+    dre,
+    visao_ue, visao_dre, visao_sme,
+):
+    assert usuario_do_suporte_com_acesso_dre.unidades.filter(codigo_eol=dre.codigo_eol).exists(), "Deveria haver um acesso à DRE."
+    assert usuario_do_suporte_com_acesso_dre.visoes.filter(nome='DRE').exists(), "Deveria haver a visão DRE para o usuário."
+    assert UnidadeEmSuporte.objects.filter(unidade=dre, user=usuario_do_suporte_com_acesso_dre).exists(), "Deveria haver unidade em suporte."
+
+    encerrar_acesso_de_suporte(
+        unidade_do_suporte=dre,
+        usuario_do_suporte=usuario_do_suporte_com_acesso_dre
+    )
+
+    assert not usuario_do_suporte_com_acesso_dre.unidades.filter(codigo_eol=dre.codigo_eol).exists(), "Não deveria haver um acesso do usuário à DRE."
+    assert not usuario_do_suporte_com_acesso_dre.visoes.filter(nome='DRE').exists(), "Deveria ter sido desvinculada a visão DRE para usuário."
+    assert not UnidadeEmSuporte.objects.filter(unidade=dre, user=usuario_do_suporte_com_acesso_dre).exists(), "Não deveria haver unidade em suporte."
+
+
+def test_encerrar_acesso_suporte_sem_informar_unidade_do_suporte(
+    unidade_do_suporte_tipo_dre,
+    usuario_do_suporte,
+    visao_ue, visao_dre, visao_sme
+):
+    with pytest.raises(EncerraAcessoSuporteException):
+        encerrar_acesso_de_suporte(
+            unidade_do_suporte=None,
+            usuario_do_suporte=usuario_do_suporte
+        )
+
+    with pytest.raises(EncerraAcessoSuporteException):
+        encerrar_acesso_de_suporte(
+            unidade_do_suporte="Não objeto unidade",
+            usuario_do_suporte=usuario_do_suporte
+        )
+
+
+def test_encerrar_acesso_suporte_sem_informar_usuario_do_suporte(
+    unidade_do_suporte_tipo_dre,
+    usuario_do_suporte,
+    visao_ue, visao_dre, visao_sme
+):
+    with pytest.raises(EncerraAcessoSuporteException):
+        encerrar_acesso_de_suporte(
+            unidade_do_suporte=unidade_do_suporte_tipo_dre,
+            usuario_do_suporte=None
+        )
+
+    with pytest.raises(EncerraAcessoSuporteException):
+        encerrar_acesso_de_suporte(
+            unidade_do_suporte=unidade_do_suporte_tipo_dre,
+            usuario_do_suporte="Não objeto User"
+        )


### PR DESCRIPTION
Esse PR:

- [X] Altera list de unidades do usuário para retornar flag representando se está ou não em suporte(true/false)
- [X] Cria o serviço que encerra o acesso de suporte
- [X] Cria Endpoint "encerrar suporte" que desfaz a vinculação da unidade ao usuário.

História: [AB#62837](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/62837)