### PR TITLE
feat(66363): Suporte às Unidades: Exibir ícone de acesso suporte

### DIFF
--- a/sme_ptrf_apps/users/api/serializers/user.py
+++ b/sme_ptrf_apps/users/api/serializers/user.py
@@ -50,12 +50,13 @@ class UnidadeSerializer(serializers.ModelSerializer):
         fields = ['uuid', 'nome', 'codigo_eol', 'tipo_unidade', 'acesso_de_suporte']
 
     def get_acesso_de_suporte(self, instance):
-        return UnidadeEmSuporte.objects.filter(unidade=instance).exists()
+        user = self.context["user"]
+        return UnidadeEmSuporte.objects.filter(unidade=instance, user=user).exists()
 
 
 class UserSerializer(serializers.ModelSerializer):
     groups = SerializerMethodField()
-    unidades = UnidadeSerializer(many=True)
+    unidades = SerializerMethodField()
 
     class Meta:
         model = User
@@ -73,11 +74,14 @@ class UserSerializer(serializers.ModelSerializer):
         groups_extendido = Grupo.objects.filter(id__in=groups_padrao).order_by('id')
         return GrupoSerializer(groups_extendido, many=True).data
 
+    def get_unidades(selfself, instance):
+        return UnidadeSerializer(instance.unidades, many=True, context={'user': instance}).data
+
 
 class UserRetrieveSerializer(serializers.ModelSerializer):
     visoes = VisaoSerializer(many=True)
     groups = SerializerMethodField()
-    unidades = UnidadeSerializer(many=True)
+    unidades = SerializerMethodField()
 
     def get_groups(self, instance):
         """
@@ -86,6 +90,9 @@ class UserRetrieveSerializer(serializers.ModelSerializer):
         groups_padrao = instance.groups.values_list("id", flat=True)
         groups_extendido = Grupo.objects.filter(id__in=groups_padrao).order_by('id')
         return GrupoComVisaoSerializer(groups_extendido, many=True).data
+
+    def get_unidades(selfself, instance):
+        return UnidadeSerializer(instance.unidades, many=True, context={'user': instance}).data
 
     class Meta:
         model = User

--- a/sme_ptrf_apps/users/services/get_unidades_usuario_service.py
+++ b/sme_ptrf_apps/users/services/get_unidades_usuario_service.py
@@ -50,7 +50,7 @@ def get_unidades_do_usuario(user):
             'notificar_devolucao_referencia': notificar_devolucao_referencia,
             'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
             'notificacao_uuid': notificacao_uuid,
-            'acesso_de_suporte': UnidadeEmSuporte.objects.filter(unidade=unidade).exists()
+            'acesso_de_suporte': UnidadeEmSuporte.objects.filter(unidade=unidade, user=user).exists()
         })
 
     # Como a visão SME não tem uma Unidade real, cria a unidade caso o usuário tenha essa visão

--- a/sme_ptrf_apps/users/tests/test_api_user/conftest.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/conftest.py
@@ -305,3 +305,12 @@ def jwt_authenticated_client_u2(client, usuario_2):
         resp_data = resp.json()
         api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
     return api_client
+
+
+@pytest.fixture
+def unidade_em_suporte_usuario_3(unidade, usuario_3):
+    return baker.make(
+        'UnidadeEmSuporte',
+        unidade=unidade,
+        user=usuario_3,
+    )

--- a/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
+++ b/sme_ptrf_apps/users/tests/test_api_user/test_api_list_user.py
@@ -16,6 +16,7 @@ def test_lista_usuarios_filtro_por_visao(
     grupo_2,
     unidade,
     dre,
+    unidade_em_suporte_usuario_3,
 ):
 
     response = jwt_authenticated_client_u.get(f"/api/usuarios/?visao=DRE&unidade_uuid={dre.uuid}", content_type='application/json')
@@ -41,7 +42,7 @@ def test_lista_usuarios_filtro_por_visao(
                     'nome': unidade.nome,
                     'codigo_eol': unidade.codigo_eol,
                     'tipo_unidade': unidade.tipo_unidade,
-                    'acesso_de_suporte': False
+                    'acesso_de_suporte': True
                 }
             ]
         },


### PR DESCRIPTION
Esse PR:
- [X] Alterar a API de usuários para retorna nas unidades um indicador de acesso de suporte

História: [AB#66363](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/66363)