### PR TITLE
feat(66366): Ata de apresentação: Exibir mensagem com os campos que faltam

### DIFF
--- a/sme_ptrf_apps/core/api/views/atas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/atas_viewset.py
@@ -102,7 +102,7 @@ class AtasViewSet(mixins.RetrieveModelMixin,
         ata_valida = validar_campos_ata(ata)
         if not ata_valida['is_valid']:
             return Response({
-                'campos': ata_valida['campos']},
+                'campos_invalidos': ata_valida['campos']},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY
             )
 

--- a/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
+++ b/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
@@ -194,4 +194,3 @@ class PresentesAtaViewSet(mixins.CreateModelMixin,
             result = PresenteAta.get_informacao_servidor(identificador)
 
         return Response(result)
-

--- a/sme_ptrf_apps/core/models/ata.py
+++ b/sme_ptrf_apps/core/models/ata.py
@@ -11,7 +11,6 @@ from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
 
-from .presentes_ata import PresenteAta
 
 logger = logging.getLogger(__name__)
 

--- a/sme_ptrf_apps/core/services/ata_service.py
+++ b/sme_ptrf_apps/core/services/ata_service.py
@@ -25,7 +25,7 @@ def gerar_arquivo_ata(prestacao_de_contas=None, ata=None, usuario=None):
         return None
 
 
-def validar_campos_ata(ata: Ata = None):
+def validar_campos_ata(ata: Ata = None) -> dict:
     campos_invalidos, campos_nao_required = list(), [
         'arquivo_pdf',
         'comentarios',

--- a/sme_ptrf_apps/core/services/ata_service.py
+++ b/sme_ptrf_apps/core/services/ata_service.py
@@ -51,7 +51,6 @@ def validar_campos_ata(ata: Ata = None) -> dict:
 
         if valor in [None, ''] and campo not in campos_nao_required:
             campos_invalidos.append(campo)
-
     if repasse_pendentes and ata.justificativa_repasses_pendentes == '':
         campos_invalidos.append('justificativa_repasses_pendentes')
 
@@ -63,18 +62,22 @@ def validar_campos_ata(ata: Ata = None) -> dict:
         nome=ata.secretario_reuniao
     ).exists()
 
+    campos_invalidos_traduzidos = list()
+    for campo, valor in campos_traduzidos.items():
+        if campo in campos_invalidos:
+            campos_invalidos_traduzidos.append(valor)
     msg = ''
     if ata.presidente_reuniao and not presidente_presente:
-        msg = 'informe um presidente presente.'
+        msg = 'informe um presidente presente'
 
     if ata.secretario_reuniao and not secretario_presente:
-        msg = 'informe um secretario presente.'
+        msg = 'informe um secretario presente'
 
     if (ata.presidente_reuniao and ata.secretario_reuniao) and (not presidente_presente and not secretario_presente):
-        msg = 'informe um presidente presente, informe um secretário presente.'
+        msg = 'informe um presidente presente, informe um secretário presente'
 
-    campos_invalidos.append({'msg_presente': msg}) if msg else None
+    campos_invalidos_traduzidos.append({'msg_presente': msg}) if msg else None
 
-    if campos_invalidos:
-        return {'is_valid': False, 'campos': campos_invalidos}
+    if campos_invalidos_traduzidos:
+        return {'is_valid': False, 'campos': campos_invalidos_traduzidos}
     return {'is_valid': True}

--- a/sme_ptrf_apps/core/services/ata_service.py
+++ b/sme_ptrf_apps/core/services/ata_service.py
@@ -26,6 +26,16 @@ def gerar_arquivo_ata(prestacao_de_contas=None, ata=None, usuario=None):
 
 
 def validar_campos_ata(ata: Ata = None) -> dict:
+    campos_traduzidos = {
+        'cargo_presidente_reuniao': 'Cargo Presidente',
+        'cargo_secretaria_reuniao': 'Cargo Secretário',
+        'data_reuniao': 'Data',
+        'hora_reuniao': 'Hora',
+        'justificativa_repasses_pendentes': 'Justificativa',
+        'local_reuniao': 'Local da reunião',
+        'presidente_reuniao': 'Presidente da reunião',
+        'secretario_reuniao': 'Secretário da reunião',
+    }
     campos_invalidos, campos_nao_required = list(), [
         'arquivo_pdf',
         'comentarios',
@@ -44,6 +54,26 @@ def validar_campos_ata(ata: Ata = None) -> dict:
 
     if repasse_pendentes and ata.justificativa_repasses_pendentes == '':
         campos_invalidos.append('justificativa_repasses_pendentes')
+
+    presidente_presente = ata.presentes_na_ata.filter(
+        nome=ata.presidente_reuniao
+    ).exists()
+
+    secretario_presente = ata.presentes_na_ata.filter(
+        nome=ata.secretario_reuniao
+    ).exists()
+
+    msg = ''
+    if ata.presidente_reuniao and not presidente_presente:
+        msg = 'informe um presidente presente.'
+
+    if ata.secretario_reuniao and not secretario_presente:
+        msg = 'informe um secretario presente.'
+
+    if (ata.presidente_reuniao and ata.secretario_reuniao) and (not presidente_presente and not secretario_presente):
+        msg = 'informe um presidente presente, informe um secretário presente.'
+
+    campos_invalidos.append({'msg_presente': msg}) if msg else None
 
     if campos_invalidos:
         return {'is_valid': False, 'campos': campos_invalidos}

--- a/sme_ptrf_apps/core/tests/tests_services/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/conftest.py
@@ -35,6 +35,19 @@ def periodo_2020_1(periodo_2019_2):
         periodo_anterior=periodo_2019_2
     )
 
+@pytest.fixture
+def periodo_2022_1(periodo_2019_2):
+    return baker.make(
+        'Periodo',
+        referencia='2020.1',
+        data_inicio_realizacao_despesas=datetime.date(2020, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2020, 6, 30),
+        data_prevista_repasse=datetime.date(2020, 1, 1),
+        data_inicio_prestacao_contas=datetime.date(2020, 7, 1),
+        data_fim_prestacao_contas=datetime.date(2020, 7, 10),
+        periodo_anterior=periodo_2019_2
+    )
+
 
 @pytest.fixture
 def tipo_receita_repasse():
@@ -422,4 +435,100 @@ def prestacao_conta_2020_1_nao_conciliada(periodo_2020_1, associacao):
         'PrestacaoConta',
         periodo=periodo_2020_1,
         associacao=associacao,
+    )
+
+
+@pytest.fixture
+def ata_2020_1_teste(prestacao_conta_2020_1_conciliada):
+    return baker.make(
+        'Ata',
+        arquivo_pdf=None,
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        periodo=prestacao_conta_2020_1_conciliada.periodo,
+        associacao=prestacao_conta_2020_1_conciliada.associacao,
+        tipo_ata='APRESENTACAO',
+        tipo_reuniao='ORDINARIA',
+        convocacao='PRIMEIRA',
+        status_geracao_pdf='NAO_GERADO',
+        data_reuniao=datetime.date(2020, 7, 1),
+        local_reuniao='Escola Teste',
+        presidente_reuniao='José',
+        cargo_presidente_reuniao='Presidente',
+        secretario_reuniao='Ana',
+        cargo_secretaria_reuniao='Secretária',
+        comentarios='Teste',
+        parecer_conselho='APROVADA',
+    )
+
+
+@pytest.fixture
+def ata_2022_2_teste_valido(prestacao_conta_2020_1_conciliada):
+    return baker.make(
+        'Ata',
+        arquivo_pdf=None,
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        periodo=prestacao_conta_2020_1_conciliada.periodo,
+        associacao=prestacao_conta_2020_1_conciliada.associacao,
+        tipo_ata='APRESENTACAO',
+        tipo_reuniao='ORDINARIA',
+        convocacao='PRIMEIRA',
+        status_geracao_pdf='NAO_GERADO',
+        data_reuniao=datetime.date(2022, 7, 2),
+        local_reuniao='Escola Teste',
+        presidente_reuniao='Arnaldo',
+        cargo_presidente_reuniao='Presidente',
+        secretario_reuniao='Falcao',
+        cargo_secretaria_reuniao='Secretária',
+        comentarios='Teste',
+        justificativa_repasses_pendentes='teste justificativa',
+        parecer_conselho='APROVADA',
+    )
+
+
+@pytest.fixture
+def presente_ata_membro_arnaldo(ata_2022_2_teste_valido):
+    return baker.make(
+        'PresenteAta',
+        ata=ata_2022_2_teste_valido,
+        identificacao="0001",
+        nome="Arnaldo",
+        cargo="Presidente",
+        membro=True,
+        conselho_fiscal=False
+    )
+
+
+@pytest.fixture
+def presente_ata_membro_falcao(ata_2022_2_teste_valido):
+    return baker.make(
+        'PresenteAta',
+        ata=ata_2022_2_teste_valido,
+        identificacao="0001",
+        nome="Falcao",
+        cargo="Secretario",
+        membro=True,
+        conselho_fiscal=False
+    )
+
+
+@pytest.fixture
+def ata_2022_test_campos_invalidos(prestacao_conta_2020_1_conciliada):
+    return baker.make(
+        'Ata',
+        arquivo_pdf=None,
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        periodo=prestacao_conta_2020_1_conciliada.periodo,
+        associacao=prestacao_conta_2020_1_conciliada.associacao,
+        tipo_ata='APRESENTACAO',
+        tipo_reuniao='ORDINARIA',
+        convocacao='PRIMEIRA',
+        status_geracao_pdf='NAO_GERADO',
+        data_reuniao=datetime.date(2022, 7, 2),
+        local_reuniao='',
+        presidente_reuniao='',
+        cargo_presidente_reuniao='',
+        secretario_reuniao='',
+        cargo_secretaria_reuniao='',
+        comentarios='Teste',
+        parecer_conselho='APROVADA',
     )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_ata_service/test_ata_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_ata_service/test_ata_service.py
@@ -1,0 +1,6 @@
+
+
+@pytest.mark.django_db(transaction=False)
+def test_validar_campos_ata(){
+    
+}

--- a/sme_ptrf_apps/core/tests/tests_services/tests_ata_service/test_ata_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_ata_service/test_ata_service.py
@@ -1,6 +1,36 @@
+import pytest
+from sme_ptrf_apps.core.services.ata_service import validar_campos_ata
 
 
 @pytest.mark.django_db(transaction=False)
-def test_validar_campos_ata(){
-    
-}
+def test_validar_campos_ata_completa(ata_2022_2_teste_valido, presente_ata_membro_arnaldo, presente_ata_membro_falcao):
+    result = validar_campos_ata(ata_2022_2_teste_valido)
+    expected_result = {'is_valid': True}
+    assert result == expected_result
+
+@pytest.mark.django_db(transaction=False)
+def test_validar_campos_invalidos(ata_2022_test_campos_invalidos, presente_ata_membro_arnaldo, presente_ata_membro_falcao):
+    ata_2022_test_campos_invalidos.justificativa_repasses_pendentes = ''
+    ata_2022_test_campos_invalidos.data_reuniao = ''
+    result = validar_campos_ata(ata_2022_test_campos_invalidos)
+    expected_result = {
+        'is_valid': False,
+        'campos': [
+            'Cargo Presidente',
+            'Cargo Secretário',
+            'Data',
+            'Local da reunião',
+            'Presidente da reunião',
+            'Secretário da reunião'
+        ]}
+    assert result == expected_result
+
+
+@pytest.mark.django_db(transaction=False)
+def test_validar_campos_ata_sem_presidente_e_secretario(ata_2020_1_teste):
+    result = validar_campos_ata(ata_2020_1_teste)
+    expected_result = {
+        'is_valid': False,
+        'campos': [{'msg_presente': 'informe um presidente presente, informe um secretário presente'}]
+        }
+    assert result == expected_result


### PR DESCRIPTION
Esse PR:

- [x] Altera endpoint que retorna o status para incluir mensagem incluindo os campos que faltam.
- [x] Cria teste unitário para serviço de validação de campos requiridos.
- [x] Cria serviços para lidar com a validação dos campos.

História: [AB#66366](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/66366)