### PR TITLE
feat(66784) Acompanhamento PC: Conferência de lançamentos: Etiquetas informativas e legendas

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -722,6 +722,7 @@ def lancamentos_da_prestacao(
                                                                         many=False).data if despesa_geradora_do_imposto else None,
                 'despesas_impostos': DespesaImpostoSerializer(despesas_impostos, many=True,
                                                               required=False).data if despesas_impostos else None,
+                'informacoes': despesa.tags_de_informacao,
             }
 
             if com_ajustes:

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
@@ -377,7 +377,7 @@ def despesa_2020_1_fornecedor_antonio_jose(associacao, tipo_documento, tipo_tran
         cpf_cnpj_fornecedor='11.478.276/0001-04',
         nome_fornecedor='Antônio José SA',
         tipo_transacao=tipo_transacao_pix,
-        data_transacao=datetime.date(2020, 3, 9),
+        data_transacao=datetime.date(2020, 3, 10),
         valor_total=100.00,
         valor_recursos_proprios=10.00,
     )
@@ -405,6 +405,29 @@ def rateio_despesa_2020_antonio_jose(associacao, despesa_2020_1_fornecedor_anton
         tag=tag_teste,
 
     )
+
+
+@pytest.fixture
+def tipo_receita_e_estorno():
+    return baker.make('TipoReceita', nome='Estorno', e_estorno=True)
+
+
+@pytest.fixture
+def receita_estorno_do_rateio_despesa_2020_antonio_jose(tipo_receita_e_estorno, rateio_despesa_2020_antonio_jose):
+    rateio = rateio_despesa_2020_antonio_jose
+    return baker.make(
+        'Receita',
+        associacao=rateio.despesa.associacao,
+        data=rateio.despesa.data_transacao,
+        valor=rateio.valor_rateio,
+        conta_associacao=rateio.conta_associacao,
+        acao_associacao=rateio.acao_associacao,
+        tipo_receita=tipo_receita_e_estorno,
+        conferido=True,
+        categoria_receita=rateio.aplicacao_recurso,
+        rateio_estornado=rateio
+    )
+
 
 @pytest.fixture
 def despesa_2019_2(associacao, tipo_documento, tipo_transacao):

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
@@ -377,7 +377,7 @@ def despesa_2020_1_fornecedor_antonio_jose(associacao, tipo_documento, tipo_tran
         cpf_cnpj_fornecedor='11.478.276/0001-04',
         nome_fornecedor='Antônio José SA',
         tipo_transacao=tipo_transacao_pix,
-        data_transacao=datetime.date(2020, 3, 10),
+        data_transacao=datetime.date(2020, 3, 9),
         valor_total=100.00,
         valor_recursos_proprios=10.00,
     )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
@@ -711,3 +711,169 @@ def solicitacao_acerto_lancamento_devolucao(
         devolucao_ao_tesouro=devolucao_ao_tesouro_parcial_ajuste,
         detalhamento="teste"
     )
+
+
+# Despesas com retenção de impostos
+@pytest.fixture
+def despesa_imposto_retido(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    tipo_custeio,
+    especificacao_instalacao_eletrica,
+    acao_associacao_role_cultural,
+    conta_associacao_cartao,
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='12331501',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Prefeitura',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=10.00,
+    )
+
+@pytest.fixture
+def rateio_despesa_imposto_retido(associacao, tipo_custeio, especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                   conta_associacao_cartao, despesa_imposto_retido):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_imposto_retido,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso="CUSTEIO",
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        valor_original=10,
+        valor_rateio=10
+    )
+
+
+@pytest.fixture
+def despesa_com_retencao_imposto(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    tipo_custeio,
+    especificacao_instalacao_eletrica,
+    acao_associacao_role_cultural,
+    conta_associacao_cartao,
+    despesa_imposto_retido
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123315',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Antônio José SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=110.00,
+        despesas_impostos=[despesa_imposto_retido,],
+    )
+
+
+@pytest.fixture
+def rateio_despesa_com_retencao_imposto(associacao, despesa_com_retencao_imposto, acao_associacao_role_cultural, conta_associacao_cartao, tipo_custeio, especificacao_instalacao_eletrica):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_com_retencao_imposto,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        acao_associacao=acao_associacao_role_cultural,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=100,
+        valor_original=10,
+    )
+
+
+@pytest.fixture
+def despesa_imposto_retido_2(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    tipo_custeio,
+    especificacao_instalacao_eletrica,
+    acao_associacao_role_cultural,
+    conta_associacao_cartao,
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='12331502',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Prefeitura',
+        tipo_transacao=tipo_transacao,
+        data_transacao=None,
+        valor_total=10.00,
+    )
+
+
+@pytest.fixture
+def rateio_despesa_imposto_retido_2(associacao, tipo_custeio, especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                   conta_associacao_cartao, despesa_imposto_retido_2):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_imposto_retido_2,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso="CUSTEIO",
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        valor_original=10,
+        valor_rateio=10
+    )
+
+@pytest.fixture
+def despesa_com_retencao_imposto_2(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    tipo_custeio,
+    especificacao_instalacao_eletrica,
+    acao_associacao_role_cultural,
+    conta_associacao_cartao,
+    despesa_imposto_retido,
+    despesa_imposto_retido_2
+):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123315',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Antônio José SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=120.00,
+        despesas_impostos=[despesa_imposto_retido, despesa_imposto_retido_2],
+    )
+
+
+@pytest.fixture
+def rateio_despesa_com_retencao_imposto_2(associacao, despesa_com_retencao_imposto_2, acao_associacao_role_cultural, conta_associacao_cartao, tipo_custeio, especificacao_instalacao_eletrica):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_com_retencao_imposto_2,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        acao_associacao=acao_associacao_role_cultural,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=120,
+        valor_original=120,
+    )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/conftest.py
@@ -379,7 +379,6 @@ def despesa_2020_1_fornecedor_antonio_jose(associacao, tipo_documento, tipo_tran
         tipo_transacao=tipo_transacao_pix,
         data_transacao=datetime.date(2020, 3, 10),
         valor_total=100.00,
-        valor_recursos_proprios=10.00,
     )
 
 
@@ -876,4 +875,110 @@ def rateio_despesa_com_retencao_imposto_2(associacao, despesa_com_retencao_impos
         aplicacao_recurso="CUSTEIO",
         valor_rateio=120,
         valor_original=120,
+    )
+
+
+@pytest.fixture
+def despesa_2020_1_recurso_proprio(associacao, tipo_documento, tipo_transacao_pix):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='José Recurso próprio',
+        tipo_transacao=tipo_transacao_pix,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=110.00,
+        valor_recursos_proprios=10.00,
+    )
+
+
+@pytest.fixture
+def rateio_despesa_2020_recurso_proprio(associacao, despesa_2020_1_recurso_proprio, conta_associacao_cartao, acao,
+                                        tipo_aplicacao_recurso_custeio,
+                                        tipo_custeio_servico,
+                                        especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                        periodo_2020_1, tag_teste):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_2020_1_recurso_proprio,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=periodo_2020_1,
+        tag=tag_teste,
+    )
+
+
+
+@pytest.fixture
+def despesa_2020_1_multiplas_contas(associacao, tipo_documento, tipo_transacao_pix):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='José Multiplas Contas',
+        tipo_transacao=tipo_transacao_pix,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=200.00,
+        valor_recursos_proprios=0.00,
+    )
+
+
+@pytest.fixture
+def rateio_despesa_2020_multiplas_contas_cartao(associacao, despesa_2020_1_multiplas_contas, conta_associacao_cartao,
+                                                acao,
+                                                tipo_aplicacao_recurso_custeio,
+                                                tipo_custeio_servico,
+                                                especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                                periodo_2020_1, tag_teste):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_2020_1_multiplas_contas,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=periodo_2020_1,
+        tag=tag_teste,
+    )
+
+
+@pytest.fixture
+def rateio_despesa_2020_multiplas_contas_cheque(associacao, despesa_2020_1_multiplas_contas, conta_associacao_cheque,
+                                                acao,
+                                                tipo_aplicacao_recurso_custeio,
+                                                tipo_custeio_servico,
+                                                especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                                periodo_2020_1, tag_teste):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_2020_1_multiplas_contas,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cheque,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=100.00,
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=periodo_2020_1,
+        tag=tag_teste,
     )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_get_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_get_lancamentos.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sme_ptrf_apps.core.services import lancamentos_da_prestacao
 
 pytestmark = pytest.mark.django_db
@@ -112,35 +113,3 @@ def test_get_lancamentos_da_analise_da_prestacao_filtro_por_forma_pagamento(
 
     assert len(lancamentos) == 1
     assert lancamentos[0]['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
-
-
-def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_antecipado(
-    jwt_authenticated_client_a,
-    despesa_2020_1_fornecedor_antonio_jose,
-    rateio_despesa_2020_antonio_jose,
-    periodo_2020_1,
-    conta_associacao_cartao,
-    acao_associacao_ptrf,
-    prestacao_conta_2020_1_em_analise,
-    analise_prestacao_conta_2020_1_em_analise,
-    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
-    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
-    tipo_transacao_pix
-):
-
-    lancamentos = lancamentos_da_prestacao(
-        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
-        conta_associacao=conta_associacao_cartao,
-        tipo_transacao='GASTOS',
-        tipo_de_pagamento=tipo_transacao_pix,
-    )
-
-    assert len(lancamentos) == 1
-
-    lancamento = lancamentos[0]
-    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
-    assert lancamento['informacoes'] == [{
-        'tag_id': '1',
-        'tag_nome': 'Antecipado',
-        'tag_hint': 'Data do pagamento (09/03/2020) anterior à data do documento (10/03/2020).'
-    }, ]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_get_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_get_lancamentos.py
@@ -112,3 +112,35 @@ def test_get_lancamentos_da_analise_da_prestacao_filtro_por_forma_pagamento(
 
     assert len(lancamentos) == 1
     assert lancamentos[0]['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_antecipado(
+    jwt_authenticated_client_a,
+    despesa_2020_1_fornecedor_antonio_jose,
+    rateio_despesa_2020_antonio_jose,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        tipo_de_pagamento=tipo_transacao_pix,
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '1',
+        'tag_nome': 'Antecipado',
+        'tag_hint': 'Data do pagamento (09/03/2020) anterior à data do documento (10/03/2020).'
+    }, ]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
@@ -1,0 +1,74 @@
+import pytest
+from datetime import date
+
+from sme_ptrf_apps.core.services import lancamentos_da_prestacao
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_antecipado(
+    jwt_authenticated_client_a,
+    despesa_2020_1_fornecedor_antonio_jose,
+    rateio_despesa_2020_antonio_jose,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix
+):
+
+    despesa_2020_1_fornecedor_antonio_jose.data_transacao = date(2020, 3, 9)
+    despesa_2020_1_fornecedor_antonio_jose.save()
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        tipo_de_pagamento=tipo_transacao_pix,
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '1',
+        'tag_nome': 'Antecipado',
+        'tag_hint': 'Data do pagamento (09/03/2020) anterior à data do documento (10/03/2020).'
+    }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_estornado(
+    jwt_authenticated_client_a,
+    despesa_2020_1_fornecedor_antonio_jose,
+    rateio_despesa_2020_antonio_jose,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+    receita_estorno_do_rateio_despesa_2020_antonio_jose
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        tipo_de_pagamento=tipo_transacao_pix,
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_fornecedor_antonio_jose.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '2',
+        'tag_nome': 'Estornado',
+        'tag_hint': 'Esse gasto possui estornos.'
+    }, ]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
@@ -72,3 +72,77 @@ def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_estornado
         'tag_nome': 'Estornado',
         'tag_hint': 'Esse gasto possui estornos.'
     }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_imposto_apenas_um_imposto_retido(
+    jwt_authenticated_client_a,
+    despesa_com_retencao_imposto,
+    rateio_despesa_com_retencao_imposto,
+    despesa_imposto_retido,
+    rateio_despesa_imposto_retido,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        filtrar_por_nome_fornecedor="Antônio José"
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_com_retencao_imposto.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '4',
+        'tag_nome': 'Imposto',
+        'tag_hint': ['Essa despesa teve retenção de imposto:', 'R$ 10,00, pago em 10/03/2020.']
+    }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_imposto_apenas_dois_impostos_retidos(
+    jwt_authenticated_client_a,
+    despesa_com_retencao_imposto_2,
+    rateio_despesa_com_retencao_imposto_2,
+    despesa_imposto_retido,
+    rateio_despesa_imposto_retido,
+    despesa_imposto_retido_2,
+    rateio_despesa_imposto_retido_2,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        filtrar_por_nome_fornecedor="Antônio José"
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_com_retencao_imposto_2.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '4',
+        'tag_nome': 'Imposto',
+        'tag_hint': [
+            'Essa despesa teve retenções de impostos:',
+            'R$ 10,00, pago em 10/03/2020.',
+            'R$ 10,00, pagamento ainda não realizado.'
+        ]
+    }, ]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
@@ -180,3 +180,68 @@ def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_imposto_p
         'tag_nome': 'Imposto Pago',
         'tag_hint': 'Esse imposto está relacionado à despesa 123315 / Antônio José SA.',
     }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_parcial_recurso_proprio(
+    jwt_authenticated_client_a,
+    despesa_2020_1_recurso_proprio,
+    rateio_despesa_2020_recurso_proprio,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        filtrar_por_nome_fornecedor="Recurso próprio"
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_recurso_proprio.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '3',
+        'tag_nome': 'Parcial',
+        'tag_hint': 'Parte da despesa foi paga com recursos próprios ou por mais de uma conta.',
+    }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_parcial_multiplas_contas(
+    jwt_authenticated_client_a,
+    despesa_2020_1_multiplas_contas,
+    rateio_despesa_2020_multiplas_contas_cartao,
+    rateio_despesa_2020_multiplas_contas_cheque,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        filtrar_por_nome_fornecedor="Multiplas"
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_2020_1_multiplas_contas.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '3',
+        'tag_nome': 'Parcial',
+        'tag_hint': 'Parte da despesa foi paga com recursos próprios ou por mais de uma conta.',
+    }, ]

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/tests_lancamento_da_prestacao_service/test_lancamentos_tags_informacoes.py
@@ -146,3 +146,37 @@ def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_imposto_a
             'R$ 10,00, pagamento ainda não realizado.'
         ]
     }, ]
+
+
+def test_get_lancamentos_da_analise_da_prestacao_com_tag_de_informacao_imposto_pago(
+    jwt_authenticated_client_a,
+    despesa_com_retencao_imposto,
+    rateio_despesa_com_retencao_imposto,
+    despesa_imposto_retido,
+    rateio_despesa_imposto_retido,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    acao_associacao_ptrf,
+    prestacao_conta_2020_1_em_analise,
+    analise_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_receita_prestacao_conta_2020_1_em_analise,
+    analise_lancamento_despesa_prestacao_conta_2020_1_em_analise,
+    tipo_transacao_pix,
+):
+
+    lancamentos = lancamentos_da_prestacao(
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_em_analise,
+        conta_associacao=conta_associacao_cartao,
+        tipo_transacao='GASTOS',
+        filtrar_por_nome_fornecedor="Prefeitura"
+    )
+
+    assert len(lancamentos) == 1
+
+    lancamento = lancamentos[0]
+    assert lancamento['documento_mestre']['uuid'] == f'{despesa_imposto_retido.uuid}'
+    assert lancamento['informacoes'] == [{
+        'tag_id': '5',
+        'tag_nome': 'Imposto Pago',
+        'tag_hint': 'Esse imposto está relacionado à despesa 123315 / Antônio José SA.',
+    }, ]

--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -288,3 +288,11 @@ class DespesasViewSet(mixins.CreateModelMixin,
 
         serializer = DespesaListComRateiosSerializer(queryset, many=True)
         return Response(serializer.data)
+
+    @action(detail=False, url_path='tags-informacoes',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def tags_informacoes_list(self, request):
+
+        result = Despesa.get_tags_informacoes_list()
+
+        return Response(result)

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -234,6 +234,10 @@ class Despesa(ModeloBase):
             cpf_cnpj_fornecedor=cpf_cnpj_fornecedor).filter(tipo_documento=tipo_documento).filter(
             numero_documento=numero_documento).first()
 
+    @classmethod
+    def get_tags_informacoes_list(cls):
+        return [cls.TAG_ANTECIPADO, cls.TAG_ESTORNADO, cls.TAG_PARCIAL, cls.TAG_IMPOSTO, cls.TAG_IMPOSTO_PAGO]
+
     class Meta:
         verbose_name = "Documento comprobatório da despesa"
         verbose_name_plural = "Documentos comprobatórios das despesas"

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_tags_informacoes.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_tags_informacoes.py
@@ -1,0 +1,19 @@
+import json
+
+import pytest
+from rest_framework import status
+
+from sme_ptrf_apps.despesas.models import Despesa
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_get_despesas_tabelas(jwt_authenticated_client_d):
+
+    response = jwt_authenticated_client_d.get(f'/api/despesas/tags-informacoes/', content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = Despesa.get_tags_informacoes_list()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado

--- a/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
+++ b/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ...models import Despesa
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_tags_informacoes_list():
+    tags = Despesa.get_tags_informacoes_list()
+    assert tags == [
+        {"id": "1", "nome": "Antecipado", "descricao": "Data do pagamento anterior à data do documento."},
+        {"id": "2", "nome": "Estornado", "descricao": "Gasto estornado."},
+        {"id": "3", "nome": "Parcial", "descricao": "Parte da despesa paga com recursos próprios ou de mais de uma conta."},
+        {"id": "4", "nome": "Imposto", "descricao": "Despesa com recolhimento de imposto."},
+        {"id": "5", "nome": "Imposto Pago", "descricao": "Imposto recolhido relativo a uma despesa de serviço."},
+    ]


### PR DESCRIPTION
Esse PR:

- [X] Inclui em lançamentos a nova coluna "informações"
- [X] Retorna tag "Antecipado": Data do pagamento anterior à data do documento.
- [X] Retorna tag "Estornada": Despesa estornada.
- [X] Retorna tag "Imposto": Despesa com recolhimento de imposto.
- [X] Retorna tag "Imposto pago": Imposto recolhido relativo a uma despesa de serviço. 
- [X] Retorna tag "Parcial": Parte da despesa paga com recursos próprios ou de mais de uma conta.
- [X] Ajusta comportamento do "parcial" quanto aos valores de recursos próprios
- [X] Altera view de lançamentos para incluir nas etiquetas os textos de hover
- [X] Altera view de lançamentos para incluir legenda de cor nas etiquetas
- [X] Cria método que retorna as legendas
- [X] Cria endpoint que retorna as legendas


História: [AB#66784](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/66784)