### PR TITLE
feat(57620) Agrupar tipos de acerto por categoria

### DIFF
--- a/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
+++ b/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
@@ -6,7 +6,6 @@ from ...models import TipoAcertoLancamento
 from sme_ptrf_apps.users.permissoes import PermissaoApiDre
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from ....utils.choices_to_json import choices_to_json
 
 
 class TiposAcertoLancamentoViewSet(mixins.ListModelMixin,
@@ -58,7 +57,8 @@ class TiposAcertoLancamentoViewSet(mixins.ListModelMixin,
             permission_classes=[IsAuthenticated & PermissaoApiDre])
     def tabelas(self, request):
         result = {
-            "categorias": choices_to_json(TipoAcertoLancamento.CATEGORIA_CHOICES)
+            "categorias": TipoAcertoLancamento.categorias(),
+            "agrupado_por_categorias": TipoAcertoLancamento.agrupado_por_categoria()
         }
 
         return Response(result, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
@@ -40,6 +40,16 @@ class TipoAcertoLancamento(ModeloIdNome):
 
     ativo = models.BooleanField('Ativo', default=True)
 
+    @classmethod
+    def agrupado_por_categoria(cls):
+        from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
+        return TipoAcertoLancamentoService.agrupado_por_categoria(cls.CATEGORIA_CHOICES)
+
+    @classmethod
+    def categorias(cls):
+        from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
+        return TipoAcertoLancamentoService.categorias(cls.CATEGORIA_CHOICES)
+
     class Meta:
         verbose_name = "Tipo de acerto em lançamentos"
         verbose_name_plural = "16.2) Tipos de acerto em lançamentos"

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -56,3 +56,4 @@ from .associacoes_service import (
 from .analise_prestacao_conta_service import get_ajustes_extratos_bancarios
 from .resumo_rescursos_service import ResumoRecursosService
 from .painel_resumo_recursos_service import PainelResumoRecursosService
+from .tipos_acerto_lancamento_service import TipoAcertoLancamentoService

--- a/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
@@ -1,0 +1,86 @@
+from sme_ptrf_apps.core.models import TipoAcertoLancamento
+from ...utils.choices_to_json import choices_to_json
+
+
+class TipoAcertoLancamentoAgrupadoPorCategoria:
+
+    def __init__(self, choices):
+        self.choices = choices
+        self.__set_agrupamento()
+
+    def __set_agrupamento(self):
+        self.agrupamento = []
+
+        for choice in self.choices:
+            categoria_id = choice[0]
+            categoria_nome = choice[1]
+
+            tipos_acertos_lancamentos = TipoAcertoLancamento.objects.filter(
+                categoria=categoria_id).filter(ativo=True).values("nome", "uuid")
+
+            if not tipos_acertos_lancamentos:
+                continue
+
+            info_categoria = self.__texto_e_cor_categoria(self, categoria_id)
+
+            dados_categoria = {
+                "categoria": {
+                    "id": categoria_id,
+                    "nome": categoria_nome,
+                    "texto": info_categoria["texto"],
+                    "cor": info_categoria["cor"],
+                    "tipos_acerto_lancamento": list(tipos_acertos_lancamentos)
+                }
+            }
+
+            self.agrupamento.append(dados_categoria)
+
+    @staticmethod
+    def __texto_e_cor_categoria(self, categoria_id):
+        if TipoAcertoLancamento.CATEGORIA_DEVOLUCAO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto demanda informação da data de pagamento da devolução.",
+                "cor": 1
+            }
+        elif TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto reabre o lançamento para edição.",
+                "cor": 1
+            }
+        elif TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto reabre o lançamento para exclusão.",
+                "cor": 1
+            }
+        elif TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto requer apenas ações externas ao sistema e "
+                         "não reabre lançamentos para alterações.",
+                "cor": 2
+            }
+        elif TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto requer que o usuário digite uma justificativa e "
+                         "não reabre lançamentos para alterações.",
+                "cor": 2
+            }
+
+
+class TipoAcertoLancamentoCategorias:
+
+    def __init__(self, choices):
+        self.choices = choices
+        self.__set_choices_json()
+
+    def __set_choices_json(self):
+        self.choices_json = choices_to_json(self.choices)
+
+
+class TipoAcertoLancamentoService:
+    @classmethod
+    def agrupado_por_categoria(cls, choices):
+        return TipoAcertoLancamentoAgrupadoPorCategoria(choices=choices).agrupamento
+
+    @classmethod
+    def categorias(cls, choices):
+        return TipoAcertoLancamentoCategorias(choices=choices).choices_json

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_endpoint_tabelas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_endpoint_tabelas.py
@@ -1,21 +1,9 @@
-import json
-
 import pytest
 from rest_framework import status
-from sme_ptrf_apps.core.models import TipoAcertoLancamento
-from sme_ptrf_apps.utils.choices_to_json import choices_to_json
 
 pytestmark = pytest.mark.django_db
 
 
-def test_api_list_choices(jwt_authenticated_client_a):
+def test_api_tabelas(jwt_authenticated_client_a):
     response = jwt_authenticated_client_a.get(f'/api/tipos-acerto-lancamento/tabelas/', content_type='application/json')
-    result = json.loads(response.content)
-
-    resultado_esperado = {
-        "categorias": choices_to_json(TipoAcertoLancamento.CATEGORIA_CHOICES)
-    }
-
-    assert result == resultado_esperado
     assert response.status_code == status.HTTP_200_OK
-

--- a/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+from model_bakery import baker
+
+
+@pytest.fixture
+def tipo_acerto_lancamento_agrupa_categoria_01():
+    return baker.make('TipoAcertoLancamento', nome='Teste', categoria='DEVOLUCAO')
+
+
+@pytest.fixture
+def tipo_acerto_lancamento_agrupa_categoria_02():
+    return baker.make('TipoAcertoLancamento', nome='Teste 2', categoria='DEVOLUCAO')
+
+
+@pytest.fixture
+def tipo_acerto_lancamento_agrupa_categoria_03():
+    return baker.make('TipoAcertoLancamento', nome='Teste 3', categoria='DEVOLUCAO')
+
+
+@pytest.fixture
+def tipo_acerto_lancamento_agrupa_categoria_04():
+    return baker.make('TipoAcertoLancamento', nome='Teste 4', categoria='EDICAO_LANCAMENTO')
+
+@pytest.fixture
+def tipo_acerto_lancamento_agrupa_categoria_05():
+    return baker.make('TipoAcertoLancamento', nome='Teste 4', categoria='EDICAO_LANCAMENTO', ativo=False)

--- a/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/test_tipos_acertos_lancamentos_agrupa_por_categoria.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/test_tipos_acertos_lancamentos_agrupa_por_categoria.py
@@ -1,0 +1,86 @@
+import pytest
+from sme_ptrf_apps.core.models import TipoAcertoLancamento
+from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_service_tabelas_categorias():
+    resultado_esperado = [
+        {
+            "id": "DEVOLUCAO",
+            "nome": "Devolução ao tesouro"
+        },
+        {
+            "id": "EDICAO_LANCAMENTO",
+            "nome": "Edição do lançamento"
+        },
+        {
+            "id": "EXCLUSAO_LANCAMENTO",
+            "nome": "Exclusão do lançamento"
+        },
+        {
+            "id": "AJUSTES_EXTERNOS",
+            "nome": "Ajustes externos"
+        },
+        {
+            "id": "SOLICITACAO_ESCLARECIMENTO",
+            "nome": "Solicitação de esclarecimento"
+        }
+    ]
+
+    assert resultado_esperado == TipoAcertoLancamentoService.categorias(TipoAcertoLancamento.CATEGORIA_CHOICES)
+
+
+def test_service_tabelas_agrupado_por_categorias(
+    tipo_acerto_lancamento_agrupa_categoria_01,
+    tipo_acerto_lancamento_agrupa_categoria_02,
+    tipo_acerto_lancamento_agrupa_categoria_03,
+    tipo_acerto_lancamento_agrupa_categoria_04,
+    tipo_acerto_lancamento_agrupa_categoria_05  # Nao deve entrar na listagem
+):
+
+    resultado_esperado = [
+        {
+            "categoria": {
+                "id": "DEVOLUCAO",
+                "nome": "Devolução ao tesouro",
+                "texto": "Esse tipo de acerto demanda informação da data de pagamento da devolução.",
+                "cor": 1,
+                "tipos_acerto_lancamento": [
+                    {
+                        "nome": "Teste",
+                        "uuid": tipo_acerto_lancamento_agrupa_categoria_01.uuid
+                    },
+                    {
+                        "nome": "Teste 2",
+                        "uuid": tipo_acerto_lancamento_agrupa_categoria_02.uuid
+                    },
+                    {
+                        "nome": "Teste 3",
+                        "uuid": tipo_acerto_lancamento_agrupa_categoria_03.uuid
+                    }
+                ]
+            }
+        },
+        {
+            "categoria": {
+                "id": "EDICAO_LANCAMENTO",
+                "nome": "Edição do lançamento",
+                "texto": "Esse tipo de acerto reabre o lançamento para edição.",
+                "cor": 1,
+                "tipos_acerto_lancamento": [
+                    {
+                        "nome": "Teste 4",
+                        "uuid": tipo_acerto_lancamento_agrupa_categoria_04.uuid
+                    }
+                ]
+            }
+        }
+    ]
+
+    resultado = TipoAcertoLancamentoService.agrupado_por_categoria(TipoAcertoLancamento.CATEGORIA_CHOICES)
+
+    assert resultado_esperado == resultado
+
+


### PR DESCRIPTION
feat(57620) Agrupar tipos de acerto por categoria

Esse PR:

- [x] Cria serviço para agrupar tipos de acerto por categoria
- [x] Altera testes relacionados 
- [x] Adiciona testes relacionados
- [x] Adiciona campo "agrupado_por_categoria" ao endpoint tabelas

História: [AB#57620](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/57620)