### PR TITLE
feat(70107): Inclui uuid tipo conta em info_execucao_financeira

### DIFF
--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -115,6 +115,7 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
             'valores': totais,
             'justificativa_texto': justificativa.texto if justificativa else '',
             'justificativa_uuid': justificativa.uuid if justificativa else None,
+            'tipo_conta_uuid': justificativa.tipo_conta.uuid if justificativa and justificativa.tipo_conta else None,
         })
 
     dados['por_tipo_de_conta'] = objeto_tipo_de_conta


### PR DESCRIPTION
Esse PR:
- Altera a view /relatorios-consolidados-dre/info-execucao-financeira/ para retornar também o uuid do tipo de conta da justificativa de diferença.

[AB#70107](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/70107)