### PR TITLE
fix(71868)-comissoes: Sistema permite cadastro duplicado

### DIFF
--- a/sme_ptrf_apps/dre/api/serializers/membro_comissao_serializer.py
+++ b/sme_ptrf_apps/dre/api/serializers/membro_comissao_serializer.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from sme_ptrf_apps.core.models import Unidade
 from sme_ptrf_apps.dre.api.serializers.comissao_serializer import ComissaoSerializer
+from sme_ptrf_apps.utils.update_instance_from_dict import update_instance_from_dict
 
 from ...models import MembroComissao
 
@@ -25,6 +26,55 @@ class MembroComissaoCreateSerializer(serializers.ModelSerializer):
         required=False,
         queryset=Unidade.dres.all()
     )
+
+    def create(self, validated_data):
+        rf = validated_data['rf']
+        dre = validated_data['dre']
+
+        rf_ja_cadastrado = MembroComissao.objects.filter(rf=rf).filter(dre=dre).all()
+
+        if rf_ja_cadastrado:
+            raise serializers.ValidationError(
+                {"detail": "Já existe um membro de comissão com esse Registro Funcional."}
+            )
+
+        try:
+            comissoes = validated_data.pop("comissoes")
+        except KeyError:
+            comissoes = []
+
+        membro_comissao_criado = MembroComissao.objects.create(**validated_data)
+
+        if not comissoes:
+            raise serializers.ValidationError({
+                "detail": "Para salvar um membro de comissão, é necessário informar pelo menos uma comissão"
+            })
+
+        membro_comissao_criado.adiciona_comissoes(comissoes)
+
+        return membro_comissao_criado
+
+    def update(self, instance, validated_data):
+        rf = validated_data.get("rf", None)
+        dre = validated_data.get("dre", None)
+
+        if rf and instance.rf != rf:
+            if dre:
+                rf_ja_cadastrado = MembroComissao.objects.filter(rf=rf).filter(dre=dre).all()
+
+                if rf_ja_cadastrado:
+                    raise serializers.ValidationError(
+                        {"detail": "Já existe um membro de comissão com esse Registro Funcional."}
+                    )
+
+        possui_comissoes = validated_data.get("comissoes", None)
+        if possui_comissoes:
+            comissoes = validated_data.pop("comissoes")
+            instance.adiciona_comissoes(comissoes)
+
+        update_instance_from_dict(instance, validated_data, save=True)
+
+        return instance
 
     class Meta:
         model = MembroComissao

--- a/sme_ptrf_apps/dre/models/membro_comissao.py
+++ b/sme_ptrf_apps/dre/models/membro_comissao.py
@@ -41,6 +41,10 @@ class MembroComissao(ModeloBase):
                     return ""
         return ""
 
+    def adiciona_comissoes(self, comissoes):
+        self.comissoes.set(comissoes)
+        self.save()
+
     class Meta:
         verbose_name = "Membro de Comissão"
         verbose_name_plural = "Membros de Comissões"

--- a/sme_ptrf_apps/dre/tests/tests_api_membros_comissoes/test_membro_comissao_create.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_membros_comissoes/test_membro_comissao_create.py
@@ -30,3 +30,28 @@ pytestmark = pytest.mark.django_db
 #     assert MembroComissao.objects.filter(uuid=result['uuid']).exists()
 #
 #     assert Comissao.objects.get(id=comissao_b.id).membros.filter(uuid=result['uuid']).exists()
+
+def test_create_membro_comissao_nome_igual(
+    jwt_authenticated_client_dre, dre_x, dre_y, comissao_a, comissao_b, membro_jose_comissao_a_b_dre_y
+):
+    payload = {
+        'rf': '123458',
+        'nome': 'Pedro Antunes',
+        'email': 'tecnico.sobrenome@sme.prefeitura.sp.gov.br',
+        'dre': f'{dre_y.uuid}',
+        'telefone': '1259275127',
+        'comissoes': [f'{comissao_a.id}', f'{comissao_b.id}']
+    }
+
+    response = jwt_authenticated_client_dre.post(
+            '/api/membros-comissoes/', data=json.dumps(payload), content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'detail': 'Já existe um membro de comissão com esse Registro Funcional.'
+    }
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert len(MembroComissao.objects.filter(rf='123458').all()) == 1
+    assert resultado_esperado == result
+

--- a/sme_ptrf_apps/dre/tests/tests_api_membros_comissoes/test_membro_comissao_update.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_membros_comissoes/test_membro_comissao_update.py
@@ -37,3 +37,33 @@ def test_update_membro_comissao(
     assert membro_comissao.email == 'pedro@teste.com'
     assert membro_comissao.dre == dre_y
     assert membro_comissao.comissoes.filter(uuid=comissao_b.uuid)
+
+
+def test_update_membro_comissao_nome_igual(
+    jwt_authenticated_client_dre,
+    dre_x, dre_y,
+    comissao_a, comissao_b,
+    membro_alex_comissao_a_dre_x,
+    membro_jose_comissao_a_b_dre_y
+):
+    payload = {
+        'rf': '123458',
+        'nome': 'José',
+        'email': 'jose@teste.com',
+        'dre': f'{dre_y.uuid}',
+        'comissoes': [comissao_b.id]
+    }
+
+    response = jwt_authenticated_client_dre.put(
+        f'/api/membros-comissoes/{membro_alex_comissao_a_dre_x.uuid}/',
+        data=json.dumps(payload),
+        content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'detail': 'Já existe um membro de comissão com esse Registro Funcional.'
+    }
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert len(MembroComissao.objects.filter(rf='123458').all()) == 1
+    assert resultado_esperado == result


### PR DESCRIPTION
Esse PR:

- Adiciona regra para não permitir cadastrar um membro duplicado

História: [AB#71868](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/71868)