### PR TITLE
feat(58005) Acompanhamento de PC: Devolução de PC: Apagar fechamentos e docs apenas se necessário 

### DIFF
--- a/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
+++ b/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
@@ -302,7 +302,7 @@ class DemonstrativoFinanceiroViewSet(GenericViewSet):
         conta_associacao = ContaAssociacao.by_uuid(conta_associacao_uuid)
         prestacao_conta = PrestacaoConta.objects.filter(associacao=conta_associacao.associacao,
                                                         periodo__uuid=periodo_uuid
-                                                        ).exclude(status=PrestacaoConta.STATUS_DEVOLVIDA).first()
+                                                        ).first()
 
         demonstrativo_financeiro = DemonstrativoFinanceiro.objects.filter(conta_associacao__uuid=conta_associacao_uuid,
                                                                           prestacao_conta=prestacao_conta).first()

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -205,7 +205,8 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                 periodo.uuid,
                 associacao.uuid,
                 usuario=request.user.username,
-                e_retorno_devolucao=dados["e_retorno_devolucao"]
+                e_retorno_devolucao=dados["e_retorno_devolucao"],
+                requer_geracao_documentos=dados["requer_geracao_documentos"],
             )
         except(IntegrityError):
             erro = {

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -121,6 +121,14 @@ class AnalisePrestacaoConta(ModeloBase):
 
         return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
 
+    @property
+    def requer_informacao_devolucao_ao_tesouro(self):
+        from sme_ptrf_apps.core.models import TipoAcertoLancamento
+
+        return self.analises_de_lancamentos.filter(
+            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_DEVOLUCAO
+        ).exists()
+
     def __str__(self):
         return f"{self.prestacao_conta.periodo} - Análise #{self.pk}"
 

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -102,6 +102,25 @@ class AnalisePrestacaoConta(ModeloBase):
 
     arquivo_pdf_criado_em = models.DateTimeField("Arquivo pdf gerado em", null=True)
 
+    @property
+    def requer_alteracao_em_lancamentos(self):
+        from sme_ptrf_apps.core.models import TipoAcertoDocumento, TipoAcertoLancamento
+        categorias_que_requerem_alteracoes = [
+            TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
+            TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
+            TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO,
+            TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO
+        ]
+        analises_de_lancamentos_requerem_alteracoes = self.analises_de_lancamentos.filter(
+            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
+        ).exists()
+
+        analises_de_documentos_requerem_alteracoes = self.analises_de_documento.filter(
+            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
+        ).exists()
+
+        return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
+
     def __str__(self):
         return f"{self.prestacao_conta.periodo} - Análise #{self.pk}"
 

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -284,16 +284,23 @@ class PrestacaoConta(ModeloBase):
             data=date.today(),
             data_limite_ue=data_limite_ue
         )
+        devolucao_requer_alteracoes = False
+
         if self.analise_atual:
+            devolucao_requer_alteracoes = self.analise_atual.requer_alteracao_em_lancamentos
             self.analise_atual.devolucao_prestacao_conta = devolucao
             self.analise_atual.save()
 
         self.analise_atual = None
         self.save()
 
-        self.apaga_fechamentos()
-        self.apaga_relacao_bens()
-        self.apaga_demonstrativos_financeiros()
+        if devolucao_requer_alteracoes:
+            logging.info('Solicitações de ajustes requerem apagar fechamentos e documentos.')
+            self.apaga_fechamentos()
+            self.apaga_relacao_bens()
+            self.apaga_demonstrativos_financeiros()
+        else:
+            logging.info('Solicitações de ajustes NÃO requerem apagar fechamentos e documentos.')
 
         notificar_prestacao_de_contas_devolvida_para_acertos(self, data_limite_ue)
         return self

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
-    '''
+    """
     Status Período	Status Documentos PC	Status PC na DRE	Parte Período	        Parte Prestação de Contas	                    Exibe Cadeado	Cor
     Em andamento	Não gerados	            N/A	                Período em andamento.	 		                                                        1
     Em andamento	Gerados	                N/A	                Período em andamento.	Documentos gerados para prestação de contas.	            X	2
@@ -16,7 +16,16 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
     Encerrado	    Gerados	                Devolvida Recebida  Período finalizado.	    Prestação de Contas recebida após acertos.		            X   4
     Encerrado	    Gerados	                Aprovada	        Período finalizado.	    Prestação de Contas aprovada pela DRE.	                    X	5
     Encerrado	    Gerados	                Reprovada	        Período finalizado.	    Prestação de Contas reprovada pela DRE.	                    X	3
-    '''
+    """
+
+    def pc_requer_ata_retificacao(prestacao_conta):
+        if not prestacao_conta or prestacao_conta.status not in (PrestacaoConta.STATUS_DEVOLVIDA, PrestacaoConta.STATUS_DEVOLVIDA_RETORNADA):
+            return False
+
+        ultima_analise = prestacao_conta.analises_da_prestacao.last()
+
+        return ultima_analise is not None and (ultima_analise.requer_alteracao_em_lancamentos or ultima_analise.requer_informacao_devolucao_ao_tesouro)
+
     periodo = Periodo.by_uuid(periodo_uuid)
     associacao = Associacao.by_uuid(associacao_uuid)
     prestacao = PrestacaoConta.by_periodo(associacao=associacao, periodo=periodo)
@@ -78,7 +87,8 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
         'texto_status': mensagem_periodo + ' ' + mensagem_prestacao,
         'periodo_bloqueado': periodo_bloqueado,
         'legenda_cor': cor,
-        'prestacao_de_contas_uuid': prestacao.uuid if prestacao and prestacao.uuid else None
+        'prestacao_de_contas_uuid': prestacao.uuid if prestacao and prestacao.uuid else None,
+        'requer_retificacao': pc_requer_ata_retificacao(prestacao),
     }
 
     return status

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -68,7 +68,7 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
             mensagem_prestacao = ''
             cor = LEGENDA_COR[STATUS_PERIODO_EM_ANDAMENTO]
 
-    periodo_bloqueado = True if prestacao and prestacao.status != PrestacaoConta.STATUS_DEVOLVIDA else False
+    periodo_bloqueado = True if prestacao else False
 
     status = {
         'periodo_encerrado': periodo.encerrado,

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -37,19 +37,40 @@ from ..api.serializers.associacao_serializer import AssociacaoCompletoSerializer
 logger = logging.getLogger(__name__)
 
 
+def pc_requer_geracao_documentos(prestacao):
+    if prestacao.status in (
+        PrestacaoConta.STATUS_NAO_RECEBIDA,
+        PrestacaoConta.STATUS_RECEBIDA,
+        PrestacaoConta.STATUS_EM_ANALISE,
+        PrestacaoConta.STATUS_APROVADA,
+        PrestacaoConta.STATUS_APROVADA_RESSALVA,
+        PrestacaoConta.STATUS_REPROVADA,
+        PrestacaoConta.STATUS_DEVOLVIDA_RETORNADA,
+    ):
+        return False
+
+    if prestacao.status == PrestacaoConta.STATUS_DEVOLVIDA:
+        ultima_analise = prestacao.analises_da_prestacao.last()
+        return ultima_analise is not None and ultima_analise.requer_alteracao_em_lancamentos
+    else:
+        return True
+
+
 @transaction.atomic
 def concluir_prestacao_de_contas(periodo, associacao):
     prestacao = PrestacaoConta.abrir(periodo=periodo, associacao=associacao)
     logger.info(f'Aberta a prestação de contas {prestacao}.')
 
     e_retorno_devolucao = prestacao.status == PrestacaoConta.STATUS_DEVOLVIDA
+    requer_geracao_documentos = pc_requer_geracao_documentos(prestacao)
 
     prestacao.em_processamento()
     logger.info(f'Prestação de contas em processamento {prestacao}.')
 
     return {
         "prestacao": prestacao,
-        "e_retorno_devolucao": e_retorno_devolucao
+        "e_retorno_devolucao": e_retorno_devolucao,
+        "requer_geracao_documentos": requer_geracao_documentos,
     }
 
 

--- a/sme_ptrf_apps/core/tasks.py
+++ b/sme_ptrf_apps/core/tasks.py
@@ -29,7 +29,8 @@ def concluir_prestacao_de_contas_async(
     associacao_uuid,
     usuario="",
     criar_arquivos=True,
-    e_retorno_devolucao=False
+    e_retorno_devolucao=False,
+    requer_geracao_documentos=True,
 ):
     from sme_ptrf_apps.core.services.prestacao_contas_services import (_criar_documentos, _criar_fechamentos,
                                                                        _apagar_previas_documentos)
@@ -41,14 +42,17 @@ def concluir_prestacao_de_contas_async(
     acoes = associacao.acoes.filter(status=AcaoAssociacao.STATUS_ATIVA)
     contas = associacao.contas.filter(status=ContaAssociacao.STATUS_ATIVA)
 
-    _criar_fechamentos(acoes, contas, periodo, prestacao)
-    logger.info('Fechamentos criados para a prestação de contas %s.', prestacao)
+    if requer_geracao_documentos:
+        _criar_fechamentos(acoes, contas, periodo, prestacao)
+        logger.info('Fechamentos criados para a prestação de contas %s.', prestacao)
 
-    _apagar_previas_documentos(contas=contas, periodo=periodo, prestacao=prestacao)
-    logger.info('Prévias apagadas.')
+        _apagar_previas_documentos(contas=contas, periodo=periodo, prestacao=prestacao)
+        logger.info('Prévias apagadas.')
 
-    _criar_documentos(acoes, contas, periodo, prestacao, usuario=usuario, criar_arquivos=criar_arquivos)
-    logger.info('Documentos gerados para a prestação de contas %s.', prestacao)
+        _criar_documentos(acoes, contas, periodo, prestacao, usuario=usuario, criar_arquivos=criar_arquivos)
+        logger.info('Documentos gerados para a prestação de contas %s.', prestacao)
+    else:
+        logger.info('PC não requer geração de documentos e cálculo de fechamentos.')
 
     prestacao = prestacao.concluir(e_retorno_devolucao=e_retorno_devolucao)
     logger.info('Concluída a prestação de contas %s.', prestacao)

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
@@ -76,6 +76,7 @@ def test_action_painel_acoes(
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
 
         }
     }
@@ -153,6 +154,7 @@ def test_action_painel_acoes_por_periodo(
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
     }
 
@@ -255,6 +257,7 @@ def test_action_painel_acoes_deve_atender_a_ordem_das_acoes(
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
     }
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
@@ -108,6 +108,7 @@ def test_action_painel_acoes_de_uma_conta(
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
     }
 
@@ -217,6 +218,7 @@ def test_action_painel_acoes_de_uma_conta_tendo_outras_contas(
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
     }
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -30,6 +30,7 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período em andamento. ',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
         'prestacao_conta': '',
 
@@ -57,6 +58,7 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
             'status_prestacao': 'NAO_APRESENTADA',
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
+            'requer_retificacao': False,
         },
         'prestacao_conta': '',
 
@@ -117,6 +119,7 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
             'status_prestacao': 'NAO_RECEBIDA',
             'texto_status': 'Período finalizado. Prestação de contas ainda não recebida pela DRE.',
             'prestacao_de_contas_uuid': f'{prestacao_conta_2020_1_conciliada.uuid}',
+            'requer_retificacao': False,
         },
         'prestacao_conta': f'{prestacao_conta_2020_1_conciliada.uuid}',
 
@@ -159,6 +162,7 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
             'status_prestacao': 'DEVOLVIDA',
             'texto_status': 'Período finalizado. Prestação de contas devolvida para ajustes.',
             'prestacao_de_contas_uuid': f'{_prestacao_conta_devolvida.uuid}',
+            'requer_retificacao': False,
         },
         'prestacao_conta': f'{_prestacao_conta_devolvida.uuid}',
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -150,11 +150,11 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
     esperado = {
         'associacao': f'{associacao.uuid}',
         'periodo_referencia': periodo.referencia,
-        'aceita_alteracoes': True,
+        'aceita_alteracoes': False,
         'prestacao_contas_status': {
             'documentos_gerados': False,
             'legenda_cor': 3,
-            'periodo_bloqueado': False,
+            'periodo_bloqueado': True,
             'periodo_encerrado': True,
             'status_prestacao': 'DEVOLVIDA',
             'texto_status': 'Período finalizado. Prestação de contas devolvida para ajustes.',

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
@@ -34,7 +34,8 @@ def test_obtem_painel_resumo_recursos_por_associacao_periodo_conta(
         'periodo_encerrado': False,
         'prestacao_de_contas_uuid': None,
         'status_prestacao': 'NAO_APRESENTADA',
-        'texto_status': 'Período em andamento. '
+        'texto_status': 'Período em andamento. ',
+        'requer_retificacao': False,
     }
 
     assert isinstance(painel, PainelResumoRecursos)

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
@@ -22,7 +22,8 @@ def test_painel_resumo_recursos_retorna_info_conta(
         'periodo_encerrado': False,
         'prestacao_de_contas_uuid': None,
         'status_prestacao': 'NAO_APRESENTADA',
-        'texto_status': 'Período em andamento. '
+        'texto_status': 'Período em andamento. ',
+        'requer_retificacao': False,
     }
 
     info_conta_esperada = {


### PR DESCRIPTION
Esse PR:
- [X] Altera o serviço de devolução para só apagar fechamentos e documentos nos casos previstos
- [X] Altera a verificação de status do período para continuar fechado para alterações mesmo após devolução
- [X] Altera geração de documentos de PC para exibir relatórios gerados mesmo no status de devolução
- [X] Alterar exibição de ata de retificação para que seja exibida caso requeira alterações ou tenha devolução ao tesouro
- [X] Altera serviço de conclusão de PC para não recriar fechamentos e documentos nos casos previstos

História: [AB#58005](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58005)
