### PR TITLE
feat(73236) Alterar Resumo de Recursos para ignorar lançamentos inativos

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
@@ -58,7 +58,6 @@ def prestacao_conta_02(periodo, associacao, motivo_aprovacao_ressalva_x, motivo_
         associacao=associacao,
         data_recebimento=date(2020, 10, 2),
         data_ultima_analise=date(2020, 10, 2),
-        devolucao_tesouro=True,
         motivos_reprovacao=[motivo_reprovacao_x, ],
         outros_motivos_reprovacao="Outros motivos reprovacao",
         motivos_aprovacao_ressalva=[motivo_aprovacao_ressalva_x, ],

--- a/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datetime import date
+from datetime import date, datetime
 
 from model_bakery import baker
 
@@ -229,6 +229,22 @@ def rr_receita_650_2020_2_ptrf_cheque_custeio(rr_associacao, rr_conta_associacao
         categoria_receita='CUSTEIO'
     )
 
+@pytest.fixture
+def rr_receita_110_2020_1_ptrf_cheque_custeio_inativa(rr_associacao, rr_conta_associacao_cheque, rr_acao_associacao_ptrf, tipo_receita, rr_periodo_2020_1):
+    return baker.make(
+        'Receita',
+        associacao=rr_associacao,
+        data=date(2020, 1, 1),
+        valor=110.00,
+        conta_associacao=rr_conta_associacao_cheque,
+        acao_associacao=rr_acao_associacao_ptrf,
+        tipo_receita=tipo_receita,
+        categoria_receita='CUSTEIO',
+        data_e_hora_de_inativacao=datetime(2020, 1, 2, 10, 20, 30),
+        status='INATIVO',
+    )
+
+
 
 @pytest.fixture
 def rr_despesa_2020_1(rr_associacao, tipo_documento, tipo_transacao, rr_periodo_2020_1):
@@ -372,6 +388,48 @@ def rr_rateio_550_2020_2_ptrf_cheque_custeio(
         especificacao_material_servico=especificacao_material_eletrico,
         valor_rateio=550.00
     )
+
+@pytest.fixture
+def rr_despesa_2020_1_inativa(rr_associacao, tipo_documento, tipo_transacao, rr_periodo_2020_1):
+    return baker.make(
+        'Despesa',
+        associacao=rr_associacao,
+        numero_documento='123456',
+        data_documento=date(2020, 1, 1),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=date(2020, 1, 1),
+        valor_total=1000.00,
+        data_e_hora_de_inativacao=datetime(2020, 2, 2, 10, 20, 30),
+        status='INATIVO',
+    )
+
+
+@pytest.fixture
+def rr_rateio_100_2020_1_ptrf_cheque_custeio_inativo(
+    rr_associacao,
+    rr_despesa_2020_1_inativa,
+    rr_conta_associacao_cheque,
+    rr_acao_associacao_ptrf,
+    tipo_custeio_material,
+    especificacao_material_eletrico,
+):
+    return baker.make(
+        'RateioDespesa',
+        despesa=rr_despesa_2020_1_inativa,
+        associacao=rr_associacao,
+        conta_associacao=rr_conta_associacao_cheque,
+        acao_associacao=rr_acao_associacao_ptrf,
+        aplicacao_recurso='CUSTEIO',
+        tipo_custeio=tipo_custeio_material,
+        especificacao_material_servico=especificacao_material_eletrico,
+        valor_rateio=100.00,
+        status='INATIVO',
+    )
+
+
 
 
 # Fechamentos  =========================================

--- a/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/test_resumo_recursos_soma_despesas.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/test_resumo_recursos_soma_despesas.py
@@ -83,3 +83,24 @@ def test_resumo_de_recursos_deve_usar_somatorio_de_despesas_dos_fechamentos_do_p
     assert resumo.despesas.total_custeio == Decimal(400.00), "Deve somar apenas as despesas do tipo custeio dos fechamentos de todas as contas."
     assert resumo.despesas.total_capital == Decimal(400.00), "Deve somar apenas as despesas do tipo capital em todas as contas."
     assert resumo.despesas.total_geral == Decimal(800.00), "O somatório dos totais por categoria deve ser igual ao total geral."
+
+
+def test_resumo_de_recursos_deve_somar_apenas_as_despesas_ativas(
+    rr_periodo_2020_1,
+    rr_acao_associacao_ptrf,
+    rr_conta_associacao_cheque,
+    rr_rateio_100_2020_1_ptrf_cheque_custeio,
+    rr_rateio_200_2020_1_ptrf_cheque_capital,
+    rr_rateio_300_2020_1_ptrf_cartao_custeio,    # Essa não deve ser somado por ser de outra conta.
+    rr_rateio_400_2020_1_role_cheque_custeio,    # Essa não deve ser somado por ser de outra ação.
+    rr_rateio_550_2020_2_ptrf_cheque_custeio,    # Essa não deve ser somado por ser de outro período.
+    rr_rateio_100_2020_1_ptrf_cheque_custeio_inativo,    # Essa não deve ser somado por ser inativo.
+):
+    resumo = ResumoRecursosService.resumo_recursos(
+        rr_periodo_2020_1,
+        rr_acao_associacao_ptrf,
+        rr_conta_associacao_cheque,
+    )
+
+    assert resumo.despesas.total_geral == 300.00, "Deve somar apenas os rateios do período, ação e conta definidos."
+

--- a/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/test_resumo_recursos_soma_receitas.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_resumo_recursos_service/test_resumo_recursos_soma_receitas.py
@@ -124,3 +124,23 @@ def test_resumo_de_recursos_deve_somar_as_receitas_do_periodo_por_categoria_sepa
     assert resumo.receitas.repasses_geral == Decimal(630.00), "Deve ser o total das receitas que são repasses."
 
 
+def test_resumo_de_recursos_deve_somar_apenas_as_receitas_ativas(
+    rr_periodo_2020_1,
+    rr_acao_associacao_ptrf,
+    rr_conta_associacao_cheque,
+    rr_receita_110_2020_1_ptrf_cheque_custeio,
+    rr_receita_220_2020_1_ptrf_cheque_capital,
+    rr_receita_300_2020_1_ptrf_cheque_livre,
+    rr_receita_400_2020_1_ptrf_cartao_custeio,    # Essa não deve ser somada por ser de outra conta.
+    rr_receita_500_2020_1_role_cheque_custeio,    # Essa não deve ser somada por ser de outra ação.
+    rr_receita_650_2020_2_ptrf_cheque_custeio,    # Essa não deve ser somada por ser de outro período.
+    rr_receita_110_2020_1_ptrf_cheque_custeio_inativa, # Essa não deve ser somada por ser inativa.
+):
+    resumo = ResumoRecursosService.resumo_recursos(
+        rr_periodo_2020_1,
+        rr_acao_associacao_ptrf,
+        rr_conta_associacao_cheque,
+    )
+
+    assert resumo.receitas.total_geral == 630.00, "Deve somar apenas as receitas do período, ação e conta definidos."
+

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_ao_tesouro_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_ao_tesouro_relatorio_consolidado_dre.py
@@ -18,7 +18,6 @@ def prestacao_conta(periodo, associacao):
         associacao=associacao,
         data_recebimento=date(2020, 10, 1),
         data_ultima_analise=date(2020, 10, 1),
-        devolucao_tesouro=True,
         status='APROVADA',
     )
 

--- a/sme_ptrf_apps/receitas/models/receita.py
+++ b/sme_ptrf_apps/receitas/models/receita.py
@@ -137,10 +137,10 @@ class Receita(ModeloBase):
     def receitas_da_acao_associacao_no_periodo(cls, acao_associacao, periodo, conferido=None, conta_associacao=None,
                                                categoria_receita=None):
         if periodo.data_fim_realizacao_despesas:
-            dataset = cls.objects.filter(acao_associacao=acao_associacao).filter(
+            dataset = cls.completas.filter(acao_associacao=acao_associacao).filter(
                 data__range=(periodo.data_inicio_realizacao_despesas, periodo.data_fim_realizacao_despesas))
         else:
-            dataset = cls.objects.filter(acao_associacao=acao_associacao).filter(
+            dataset = cls.completas.filter(acao_associacao=acao_associacao).filter(
                 data__gte=periodo.data_inicio_realizacao_despesas)
 
         if conferido is not None:


### PR DESCRIPTION
Esse PR:
- Altera o serviço de resumo de recursos para ignorar receitas inativas
- Cria testes para confirmar que despesas inativas estão sendo ignoradas.

História: [AB#73236](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73236)