### PR TITLE
fix(72442) Ajuste teste devolucao tesouro

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_reabre_prestacao_conta.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from rest_framework import status
 
-from ...models import PrestacaoConta
+from sme_ptrf_apps.core.models import PrestacaoConta
 
 from model_bakery import baker
 
@@ -58,7 +58,6 @@ def prestacao_conta_02(periodo, associacao, motivo_aprovacao_ressalva_x, motivo_
         associacao=associacao,
         data_recebimento=date(2020, 10, 2),
         data_ultima_analise=date(2020, 10, 2),
-        devolucao_tesouro=True,
         motivos_reprovacao=[motivo_reprovacao_x, ],
         outros_motivos_reprovacao="Outros motivos reprovacao",
         motivos_aprovacao_ressalva=[motivo_aprovacao_ressalva_x, ],

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_ao_tesouro_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_devolucoes_ao_tesouro_relatorio_consolidado_dre.py
@@ -18,7 +18,6 @@ def prestacao_conta(periodo, associacao):
         associacao=associacao,
         data_recebimento=date(2020, 10, 1),
         data_ultima_analise=date(2020, 10, 1),
-        devolucao_tesouro=True,
         status='APROVADA',
     )
 


### PR DESCRIPTION
Esse PR:

- [x] Altera dois teste referente a devolução ao tesouro.

História: [AB#72442](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/72442)