### PR TITLE
feat(73238): Alterar relatórios pc para ignorar inativos

### DIFF
--- a/sme_ptrf_apps/receitas/models/receita.py
+++ b/sme_ptrf_apps/receitas/models/receita.py
@@ -165,10 +165,10 @@ class Receita(ModeloBase):
         categoria_receita=None
     ):
         if periodo_final.data_fim_realizacao_despesas:
-            dataset = cls.objects.filter(acao_associacao=acao_associacao).filter(
+            dataset = cls.completas.filter(acao_associacao=acao_associacao).filter(
                 data__range=(periodo_inicial.data_inicio_realizacao_despesas, periodo_final.data_fim_realizacao_despesas))
         else:
-            dataset = cls.objects.filter(acao_associacao=acao_associacao).filter(
+            dataset = cls.completas.filter(acao_associacao=acao_associacao).filter(
                 data__gte=periodo_inicial.data_inicio_realizacao_despesas)
 
         if conferido is not None:
@@ -185,10 +185,10 @@ class Receita(ModeloBase):
     @classmethod
     def receitas_da_conta_associacao_no_periodo(cls, conta_associacao, periodo, conferido=None, acao_associacao=None, filtrar_por_data_inicio=None, filtrar_por_data_fim=None):
         if periodo.data_fim_realizacao_despesas:
-            dataset = cls.objects.filter(conta_associacao=conta_associacao).filter(
+            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
                 data__range=(periodo.data_inicio_realizacao_despesas, periodo.data_fim_realizacao_despesas)).order_by('data')
         else:
-            dataset = cls.objects.filter(conta_associacao=conta_associacao).filter(
+            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
                 data__gte=periodo.data_inicio_realizacao_despesas).order_by('data')
 
         if conferido is not None:
@@ -222,13 +222,13 @@ class Receita(ModeloBase):
         acao_associacao=None
     ):
         if periodo_final.data_fim_realizacao_despesas:
-            dataset = cls.objects.filter(conta_associacao=conta_associacao).filter(
+            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
                 data__range=(
                     periodo_inicial.data_inicio_realizacao_despesas,
                     periodo_final.data_fim_realizacao_despesas
                 )).order_by('data')
         else:
-            dataset = cls.objects.filter(conta_associacao=conta_associacao).filter(
+            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
                 data__gte=periodo_inicial.data_inicio_realizacao_despesas).order_by('data')
 
         if conferido is not None:


### PR DESCRIPTION
Esse PR altera os cálculos dos relatórios de prestação de contas para ignorar os créditos inativos.

Relatórios afetados:

- [X] Demonstrativos financeiros
- [X] Relações de Bens
- [X] Atas de apresentação
- [X] Atas de retificação

História: [AB#73238](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73238)