### PR TITLE
Feat(73291) Exibir lançamento inativos back-end

### DIFF
--- a/sme_ptrf_apps/core/api/views/analises_prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/analises_prestacoes_contas_viewset.py
@@ -152,7 +152,8 @@ class AnalisesPrestacoesContasViewSet(
             acao_associacao=acao_associacao,
             tipo_transacao=tipo_transacao,
             tipo_acerto=tipo_acerto,
-            com_ajustes=True
+            com_ajustes=True,
+            inclui_inativas=True,
         )
 
         return Response(lancamentos, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -637,7 +637,7 @@ def lancamentos_da_prestacao(
         despesas_com_rateios = rateios.values_list('despesa__id', flat=True).distinct()
 
         if inclui_inativas:
-            dataset = Despesa.objects.exclude(status=STATUS_INCOMPLETO)
+            dataset = Despesa.objects.exclude(status=STATUS_INCOMPLETO).filter(id__in=despesas_com_rateios)
         else:
             dataset = Despesa.completas.filter(id__in=despesas_com_rateios)
 

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -25,7 +25,7 @@ from ..services.relacao_bens import gerar_arquivo_relacao_de_bens, apagar_previa
 from ..services.processos_services import get_processo_sei_da_prestacao
 from ...despesas.models import RateioDespesa, Despesa
 from ...receitas.models import Receita
-from ..tasks import concluir_prestacao_de_contas_async, gerar_previa_demonstrativo_financeiro_async
+from ..tasks import gerar_previa_demonstrativo_financeiro_async
 
 from ..services.dados_demo_financeiro_service import gerar_dados_demonstrativo_financeiro
 from .demonstrativo_financeiro_pdf_service import gerar_arquivo_demonstrativo_financeiro_pdf
@@ -626,6 +626,7 @@ def lancamentos_da_prestacao(
         filtrar_por_data_inicio,
         filtrar_por_data_fim,
         filtrar_por_nome_fornecedor=None,
+        inclui_inativas=False,
     ):
         rateios = RateioDespesa.rateios_da_conta_associacao_no_periodo(
             conta_associacao=conta_associacao,
@@ -634,7 +635,10 @@ def lancamentos_da_prestacao(
         )
         despesas_com_rateios = rateios.values_list('despesa__id', flat=True).distinct()
 
-        dataset = Despesa.completas.filter(id__in=despesas_com_rateios)
+        if inclui_inativas:
+            dataset = Despesa.objects.exclude(status='INCOMPLETA')
+        else:
+            dataset = Despesa.completas.filter(id__in=despesas_com_rateios)
 
         if filtrar_por_data_inicio and filtrar_por_data_fim:
             dataset = dataset.filter(data_transacao__range=[filtrar_por_data_inicio, filtrar_por_data_fim])
@@ -679,6 +683,7 @@ def lancamentos_da_prestacao(
             periodo=prestacao_conta.periodo,
             filtrar_por_data_inicio=filtrar_por_data_inicio,
             filtrar_por_data_fim=filtrar_por_data_fim,
+            inclui_inativas=True,
         )
 
         receitas = receitas.order_by("data")
@@ -694,6 +699,7 @@ def lancamentos_da_prestacao(
             filtrar_por_data_inicio=filtrar_por_data_inicio,
             filtrar_por_data_fim=filtrar_por_data_fim,
             filtrar_por_nome_fornecedor=filtrar_por_nome_fornecedor,
+            inclui_inativas=True,
         )
 
         despesas = despesas.order_by("data_transacao")
@@ -1004,7 +1010,7 @@ def solicita_acertos_de_lancamentos(analise_prestacao, lancamentos, solicitacoes
 
 
 def documentos_da_prestacao(analise_prestacao_conta):
-    from ..models import TipoDocumentoPrestacaoConta, ContaAssociacao
+    from ..models import TipoDocumentoPrestacaoConta
 
     associacao = analise_prestacao_conta.prestacao_conta.associacao
 

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
@@ -244,6 +244,24 @@ def despesa_2020_1(associacao, tipo_documento, tipo_transacao):
         valor_recursos_proprios=10.00,
     )
 
+@pytest.fixture
+def despesa_2020_1_inativa(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+        status="INATIVO",
+        data_e_hora_de_inativacao=datetime.datetime(2020, 5, 10, 5, 10, 10),
+    )
+
 
 @pytest.fixture
 def tag_teste():
@@ -273,6 +291,31 @@ def rateio_despesa_2020_role_conferido(associacao, despesa_2020_1, conta_associa
         conferido=True,
         periodo_conciliacao=periodo_2020_1,
         tag=tag_teste,
+
+    )
+
+
+@pytest.fixture
+def rateio_despesa_2020_role_conferido_inativa(associacao, despesa_2020_1_inativa, conta_associacao_cartao, acao,
+                                       tipo_aplicacao_recurso_custeio,
+                                       tipo_custeio_servico,
+                                       especificacao_instalacao_eletrica, acao_associacao_role_cultural,
+                                       periodo_2020_1):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_2020_1_inativa,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=200.00,
+        update_conferido=True,
+        conferido=True,
+        status="INATIVO",
+        periodo_conciliacao=periodo_2020_1,
+        tag=None,
 
     )
 
@@ -315,6 +358,26 @@ def rateio_despesa_2020_role_nao_conferido(associacao, despesa_2020_1, conta_ass
         valor_rateio=100.00,
         conferido=False,
 
+    )
+
+
+@pytest.fixture
+def rateio_despesa_2020_role_nao_conferido_inativa(associacao, despesa_2020_1_inativa, conta_associacao_cartao, acao,
+                                           tipo_aplicacao_recurso_custeio,
+                                           tipo_custeio_servico,
+                                           especificacao_instalacao_eletrica, acao_associacao_role_cultural):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_2020_1_inativa,
+        associacao=associacao,
+        conta_associacao=conta_associacao_cartao,
+        acao_associacao=acao_associacao_role_cultural,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        status="INATIVO",
+        valor_rateio=100.00,
+        conferido=False,
     )
 
 
@@ -564,10 +627,30 @@ def prestacao_conta_2020_1_teste_analises(periodo_2020_1, associacao):
 
 
 @pytest.fixture
+def prestacao_conta_2020_1_teste_inativa_analises(periodo_2020_1, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        data_recebimento=datetime.date(2020, 4, 4),
+        status="EM_ANALISE"
+    )
+
+
+@pytest.fixture
 def devolucao_prestacao_conta_2020_1_teste_analises(prestacao_conta_2020_1_teste_analises):
     return baker.make(
         'DevolucaoPrestacaoConta',
         prestacao_conta=prestacao_conta_2020_1_teste_analises,
+        data=datetime.date(2020, 10, 5),
+        data_limite_ue=datetime.date(2020, 8, 1),
+    )
+
+@pytest.fixture
+def devolucao_prestacao_conta_2020_1_teste_inativa_analises(prestacao_conta_2020_1_teste_inativa_analises):
+    return baker.make(
+        'DevolucaoPrestacaoConta',
+        prestacao_conta=prestacao_conta_2020_1_teste_inativa_analises,
         data=datetime.date(2020, 10, 5),
         data_limite_ue=datetime.date(2020, 8, 1),
     )
@@ -582,6 +665,17 @@ def analise_prestacao_conta_2020_1_teste_analises(
         'AnalisePrestacaoConta',
         prestacao_conta=prestacao_conta_2020_1_teste_analises,
         devolucao_prestacao_conta=devolucao_prestacao_conta_2020_1_teste_analises
+    )
+
+@pytest.fixture
+def analise_prestacao_conta_2020_1_teste_inativa_analises(
+    prestacao_conta_2020_1_teste_inativa_analises,
+    devolucao_prestacao_conta_2020_1_teste_inativa_analises
+):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_2020_1_teste_inativa_analises,
+        devolucao_prestacao_conta=devolucao_prestacao_conta_2020_1_teste_inativa_analises
     )
 
 @pytest.fixture
@@ -640,6 +734,20 @@ def analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises(
 
 
 @pytest.fixture
+def analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises(
+    analise_prestacao_conta_2020_1_teste_inativa_analises,
+    despesa_2020_1_inativa
+):
+    return baker.make(
+        'AnaliseLancamentoPrestacaoConta',
+        analise_prestacao_conta=analise_prestacao_conta_2020_1_teste_inativa_analises,
+        tipo_lancamento='GASTO',
+        despesa=despesa_2020_1_inativa,
+        resultado='AJUSTE'
+    )
+
+
+@pytest.fixture
 def tipo_acerto_lancamento_devolucao():
     return baker.make('TipoAcertoLancamento', nome='Devolução', categoria='DEVOLUCAO')
 
@@ -668,6 +776,19 @@ def devolucao_ao_tesouro_parcial_ajuste(prestacao_conta_2020_1_teste_analises, t
         visao_criacao='DRE'
     )
 
+@pytest.fixture
+def devolucao_ao_tesouro_parcial_ajuste_inativa(prestacao_conta_2020_1_teste_inativa_analises, tipo_devolucao_ao_tesouro_teste, despesa_2020_1_inativa):
+    return baker.make(
+        'DevolucaoAoTesouro',
+        prestacao_conta=prestacao_conta_2020_1_teste_inativa_analises,
+        tipo=tipo_devolucao_ao_tesouro_teste,
+        data=datetime.date(2020, 7, 1),
+        despesa=despesa_2020_1_inativa,
+        devolucao_total=False,
+        valor=100.00,
+        motivo='teste',
+        visao_criacao='DRE'
+    )
 
 @pytest.fixture
 def solicitacao_acerto_lancamento_devolucao_teste_analises(
@@ -680,6 +801,21 @@ def solicitacao_acerto_lancamento_devolucao_teste_analises(
         analise_lancamento=analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
         tipo_acerto=tipo_acerto_lancamento_devolucao,
         devolucao_ao_tesouro=devolucao_ao_tesouro_parcial_ajuste,
+        detalhamento="teste"
+    )
+
+
+@pytest.fixture
+def solicitacao_acerto_lancamento_devolucao_teste_inativa_analises(
+    analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
+    tipo_acerto_lancamento_devolucao,
+    devolucao_ao_tesouro_parcial_ajuste_inativa
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
+        tipo_acerto=tipo_acerto_lancamento_devolucao,
+        devolucao_ao_tesouro=devolucao_ao_tesouro_parcial_ajuste_inativa,
         detalhamento="teste"
     )
 

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -6,10 +6,13 @@ from rest_framework import status
 pytestmark = pytest.mark.django_db
 
 
-def monta_result_esperado(lancamentos_esperados, periodo, conta):
+def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
     result_esperado = []
 
     for lancamento in lancamentos_esperados:
+
+        if inativa:
+            lancamento["mestre"].mensagem_inativa = f'Este gasto foi desativado em {lancamento["mestre"].data_e_hora_de_inativacao.strftime("%d/%m/%Y às %H:%M:%S")}'
 
         mestre_esperado = {
             'associacao': f'{lancamento["mestre"].associacao.uuid}',
@@ -27,6 +30,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta):
             'documento_transacao': f'{lancamento["mestre"].documento_transacao}',
             'data_documento': f'{lancamento["mestre"].data_documento}',
             'data_transacao': f'{lancamento["mestre"].data_transacao}',
+            'mensagem_inativa': lancamento["mestre"].mensagem_inativa if 'mensagem_inativa' in lancamento["mestre"].__dict__ else None,
             'cpf_cnpj_fornecedor': lancamento["mestre"].cpf_cnpj_fornecedor,
             'nome_fornecedor': lancamento["mestre"].nome_fornecedor,
             'valor_ptrf': lancamento["mestre"].valor_ptrf,
@@ -34,7 +38,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta):
             'status': lancamento["mestre"].status,
             'conferido': lancamento["mestre"].conferido,
             'uuid': f'{lancamento["mestre"].uuid}',
-            'data_e_hora_de_inativacao': None,
+            'data_e_hora_de_inativacao': lancamento["mestre"].data_e_hora_de_inativacao.isoformat("T") if lancamento["mestre"].data_e_hora_de_inativacao else None,
 
         } if lancamento["tipo"] == 'Gasto' else {
             'associacao': f'{lancamento["mestre"].associacao.uuid}',
@@ -242,7 +246,7 @@ def test_api_list_lancamentos_todos_da_conta(
     solicitacao_acerto_lancamento_devolucao_teste_analises
 ):
     conta_uuid = conta_associacao_cartao.uuid
-
+    despesa_2020_1.mesagem_inativa = None
     lancamentos_esperados = [
         {
             'mestre': despesa_2020_1,
@@ -281,6 +285,50 @@ def test_api_list_lancamentos_todos_da_conta(
     assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
 
 
+def test_api_list_lancamentos_todos_da_conta_inativa(
+    jwt_authenticated_client_a,
+    despesa_2020_1_inativa,
+    rateio_despesa_2020_role_conferido_inativa,
+    periodo_2020_1,
+    conta_associacao_cartao,
+    conta_associacao_cheque,
+    analise_prestacao_conta_2020_1_teste_inativa_analises,
+    analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
+    solicitacao_acerto_lancamento_devolucao_teste_inativa_analises
+):
+    conta_uuid = conta_associacao_cartao.uuid
+    lancamentos_esperados = [
+        {
+            'mestre': despesa_2020_1_inativa,
+            'rateios': [
+                rateio_despesa_2020_role_conferido_inativa,
+            ],
+            'tipo': 'Gasto',
+            'valor_transacao_na_conta': 200.0,
+            'valor_transacao_total': 100.0,
+            'valores_por_conta': [{
+                'conta_associacao__tipo_conta__nome': 'Cartão',
+                'valor_rateio__sum': 200.0
+            }],
+            'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
+            'solicitacao_ajuste': solicitacao_acerto_lancamento_devolucao_teste_inativa_analises,
+        },
+    ]
+
+    result_esperado = monta_result_esperado(lancamentos_esperados=lancamentos_esperados, periodo=periodo_2020_1,
+                                            conta=conta_associacao_cartao, inativa=True)
+
+    url = f'/api/analises-prestacoes-contas/{analise_prestacao_conta_2020_1_teste_inativa_analises.uuid}/lancamentos-com-ajustes/?conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
+
+
+
 def test_api_list_lancamentos_todos_da_conta_por_tipo_ajuste(
     jwt_authenticated_client_a,
     despesa_2020_1,
@@ -300,7 +348,6 @@ def test_api_list_lancamentos_todos_da_conta_por_tipo_ajuste(
     tipo_acerto_lancamento_devolucao,
 ):
     conta_uuid = conta_associacao_cartao.uuid
-
     lancamentos_esperados = [
         {
             'mestre': despesa_2020_1,

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -262,10 +262,6 @@ def test_api_list_lancamentos_todos_da_conta(
                     'conta_associacao__tipo_conta__nome': 'Cartão',
                     'valor_rateio__sum': 300.0
                 },
-                {
-                    'conta_associacao__tipo_conta__nome': 'Cheque',
-                    'valor_rateio__sum': 100.0
-                }
             ],
             'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
             'solicitacao_ajuste': solicitacao_acerto_lancamento_devolucao_teste_analises,
@@ -278,7 +274,6 @@ def test_api_list_lancamentos_todos_da_conta(
     url = f'/api/analises-prestacoes-contas/{analise_prestacao_conta_2020_1_teste_analises.uuid}/lancamentos-com-ajustes/?conta_associacao={conta_uuid}'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
-
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -363,10 +358,6 @@ def test_api_list_lancamentos_todos_da_conta_por_tipo_ajuste(
                     'conta_associacao__tipo_conta__nome': 'Cartão',
                     'valor_rateio__sum': 300.0
                 },
-                {
-                    'conta_associacao__tipo_conta__nome': 'Cheque',
-                    'valor_rateio__sum': 100.0
-                }
             ],
             'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_teste_analises,
             'solicitacao_ajuste': solicitacao_acerto_lancamento_devolucao_teste_analises,

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -408,7 +408,7 @@ class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
     tipo_transacao = TipoTransacaoSerializer()
 
     receitas_saida_do_recurso = serializers.SerializerMethodField('get_recurso_externo')
-    mensagem_despesa_inativa = serializers.SerializerMethodField('get_mensagem_despesa_inativa')
+    mensagem_inativa = serializers.SerializerMethodField('get_mensagem_despesa_inativa')
 
     def get_recurso_externo(self, despesa):
         return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
@@ -435,5 +435,5 @@ class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
             'uuid',
             'receitas_saida_do_recurso',
             'data_e_hora_de_inativacao',
-            'mensagem_despesa_inativa',
+            'mensagem_inativa',
         )

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -408,9 +408,13 @@ class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
     tipo_transacao = TipoTransacaoSerializer()
 
     receitas_saida_do_recurso = serializers.SerializerMethodField('get_recurso_externo')
+    mensagem_despesa_inativa = serializers.SerializerMethodField('get_mensagem_despesa_inativa')
 
     def get_recurso_externo(self, despesa):
         return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
+
+    def get_mensagem_despesa_inativa(self, despesa):
+        return  f"Este gasto foi desativado em {despesa.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}" if despesa.status == "INATIVO" else None
 
     class Meta:
         model = Despesa
@@ -431,4 +435,5 @@ class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
             'uuid',
             'receitas_saida_do_recurso',
             'data_e_hora_de_inativacao',
+            'mensagem_despesa_inativa',
         )

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -414,7 +414,7 @@ class DespesaDocumentoMestreSerializer(serializers.ModelSerializer):
         return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
 
     def get_mensagem_despesa_inativa(self, despesa):
-        return  f"Este gasto foi desativado em {despesa.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}" if despesa.status == "INATIVO" else None
+        return  f"Este gasto foi desativado em {despesa.data_e_hora_de_inativacao.strftime('%d/%m/%Y às %H:%M:%S')}" if despesa.status == "INATIVO" else None
 
     class Meta:
         model = Despesa

--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -194,7 +194,7 @@ class ReceitaConciliacaoSerializer(serializers.ModelSerializer):
     mensagem_inativa = serializers.SerializerMethodField('get_mensagem_receita_inativa')
 
     def get_mensagem_receita_inativa(self, receita):
-        return f"Este crédito foi desativado em {receita.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}" if receita.status == "INATIVO" else None
+        return f"Este crédito foi desativado em {receita.data_e_hora_de_inativacao.strftime('%d/%m/%Y às %H:%M:%S')}" if receita.status == "INATIVO" else None
 
     class Meta:
         model = Receita

--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -191,7 +191,7 @@ class ReceitaConciliacaoSerializer(serializers.ModelSerializer):
     tipo_receita = TipoReceitaLookUpSerializer()
     acao_associacao = AcaoAssociacaoLookUpSerializer()
     rateio_estornado = RateioDespesaEstornoLookupSerializer()
-    mensagem_receita_inativa = serializers.SerializerMethodField('get_mensagem_receita_inativa')
+    mensagem_inativa = serializers.SerializerMethodField('get_mensagem_receita_inativa')
 
     def get_mensagem_receita_inativa(self, receita):
         return f"Este crédito foi desativado em {receita.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}" if receita.status == "INATIVO" else None
@@ -212,7 +212,7 @@ class ReceitaConciliacaoSerializer(serializers.ModelSerializer):
             'rateio_estornado',
             'status',
             'data_e_hora_de_inativacao',
-            'mensagem_receita_inativa'
+            'mensagem_inativa'
         )
 
 

--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -9,8 +9,7 @@ from sme_ptrf_apps.core.api.serializers.periodo_serializer import PeriodoLookUpS
 from sme_ptrf_apps.core.models import AcaoAssociacao, Associacao, ContaAssociacao, Periodo
 
 from sme_ptrf_apps.despesas.api.serializers.despesa_serializer import DespesaListSerializer
-from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaEstornoLookupSerializer, \
-    RateioDespesaListaSerializer
+from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaEstornoLookupSerializer
 from sme_ptrf_apps.despesas.models import RateioDespesa
 
 from sme_ptrf_apps.receitas.models import Receita, Repasse
@@ -192,6 +191,10 @@ class ReceitaConciliacaoSerializer(serializers.ModelSerializer):
     tipo_receita = TipoReceitaLookUpSerializer()
     acao_associacao = AcaoAssociacaoLookUpSerializer()
     rateio_estornado = RateioDespesaEstornoLookupSerializer()
+    mensagem_receita_inativa = serializers.SerializerMethodField('get_mensagem_receita_inativa')
+
+    def get_mensagem_receita_inativa(self, receita):
+        return f"Este crédito foi desativado em {receita.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}" if receita.status == "INATIVO" else None
 
     class Meta:
         model = Receita
@@ -209,6 +212,7 @@ class ReceitaConciliacaoSerializer(serializers.ModelSerializer):
             'rateio_estornado',
             'status',
             'data_e_hora_de_inativacao',
+            'mensagem_receita_inativa'
         )
 
 

--- a/sme_ptrf_apps/receitas/models/receita.py
+++ b/sme_ptrf_apps/receitas/models/receita.py
@@ -183,12 +183,17 @@ class Receita(ModeloBase):
         return dataset.all()
 
     @classmethod
-    def receitas_da_conta_associacao_no_periodo(cls, conta_associacao, periodo, conferido=None, acao_associacao=None, filtrar_por_data_inicio=None, filtrar_por_data_fim=None):
+    def receitas_da_conta_associacao_no_periodo(cls, conta_associacao, periodo, conferido=None, acao_associacao=None, filtrar_por_data_inicio=None, filtrar_por_data_fim=None, inclui_inativas=False):
+        if inclui_inativas:
+            dataset = cls.objects
+        else:
+            dataset = cls.completas
+
         if periodo.data_fim_realizacao_despesas:
-            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
+            dataset = dataset.filter(conta_associacao=conta_associacao).filter(
                 data__range=(periodo.data_inicio_realizacao_despesas, periodo.data_fim_realizacao_despesas)).order_by('data')
         else:
-            dataset = cls.completas.filter(conta_associacao=conta_associacao).filter(
+            dataset = dataset.filter(conta_associacao=conta_associacao).filter(
                 data__gte=periodo.data_inicio_realizacao_despesas).order_by('data')
 
         if conferido is not None:


### PR DESCRIPTION
Esse PR:

- [x] Exibi todos os créditos com solicitação de ajuste, mesmo que estejam inativos.
- [x] Exibi todos os gastos com solicitação de ajuste mesmo que estejam inativos.
- [x] Inclui no retorno do endpoint usado a data e hora de inativação e o texto informativo "Este crédito/gasto foi desativado em DD/MM/AAAA HH:MM:SS."
- [x] Ajusta testes e inclui novo teste para inativas. 

História: [AB#73291](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73291)