### PR TITLE
feat(67647): Altera inativação de receita estorno

### DIFF
--- a/sme_ptrf_apps/receitas/api/views/receita_viewset.py
+++ b/sme_ptrf_apps/receitas/api/views/receita_viewset.py
@@ -140,13 +140,6 @@ class ReceitaViewSet(mixins.CreateModelMixin,
             }
             return Response(msg, status=status.HTTP_200_OK)
 
-        if instance.tipo_receita.e_estorno:
-            erro = {
-                'erro': 'receita_do_tipo_estorno',
-                'mensagem': 'Não é possivel excluir uma receita do tipo estorno. Deve ser feito a partir da despesa.'
-            }
-            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
-
         if instance.inativar_em_vez_de_excluir:
             instance.inativar_receita()
             msg = {

--- a/sme_ptrf_apps/receitas/models/receita.py
+++ b/sme_ptrf_apps/receitas/models/receita.py
@@ -340,6 +340,10 @@ class Receita(ModeloBase):
     def inativar_receita(self):
         self.status = self.STATUS_INATIVO
         self.data_e_hora_de_inativacao = datetime.now()
+
+        if self.rateio_estornado:
+            self.rateio_estornado = None
+
         self.save()
         return self
 

--- a/sme_ptrf_apps/receitas/tests/conftest.py
+++ b/sme_ptrf_apps/receitas/tests/conftest.py
@@ -737,3 +737,29 @@ def receita_deve_inativar_e_repasse(
         data_e_hora_de_inativacao=None,
         periodo_conciliacao=periodo_inativar_receita,
     )
+
+
+@pytest.fixture
+def receita_deve_inativar_estorno(
+    associacao,
+    conta_associacao_cheque,
+    acao_associacao_ptrf,
+    tipo_receita_e_estorno,
+    rateio_saida_recurso,
+    periodo_inativar_receita
+):
+    return baker.make(
+        'Receita',
+        associacao=associacao,
+        data=datetime.date(2019, 9, 1),
+        valor=100.00,
+        conta_associacao=conta_associacao_cheque,
+        acao_associacao=acao_associacao_ptrf,
+        tipo_receita=tipo_receita_e_estorno,
+        conferido=True,
+        status='COMPLETO',
+        data_e_hora_de_inativacao=None,
+        rateio_estornado=rateio_saida_recurso,
+        periodo_conciliacao=periodo_inativar_receita,
+    )
+


### PR DESCRIPTION
Esse PR: 

- Altera o método de inativação de um estorno para desfazer o vínculo com o rateio estornado. 
- Altera as regras de exclusão de estorno para permitir a exclusão.

História: [AB#67647](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/67647)