### PR TITLE
feat(73291) Adiciona teste para caso de rateios_de_conta_associacao

### DIFF
--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -171,7 +171,6 @@ class Associacao(ModeloIdNome):
             qry_periodos = qry_periodos.filter(
                 data_inicio_realizacao_despesas__gte=self.periodo_inicial.data_fim_realizacao_despesas
             )
-
         return qry_periodos.all()
 
     def membros_por_cargo(self):

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -632,7 +632,8 @@ def lancamentos_da_prestacao(
         rateios = RateioDespesa.rateios_da_conta_associacao_no_periodo(
             conta_associacao=conta_associacao,
             acao_associacao=acao_associacao,
-            periodo=periodo
+            periodo=periodo,
+            incluir_inativas=True,
         )
         despesas_com_rateios = rateios.values_list('despesa__id', flat=True).distinct()
 
@@ -669,7 +670,6 @@ def lancamentos_da_prestacao(
 
         if filtrar_por_nome_fornecedor:
             dataset = dataset.filter(nome_fornecedor__unaccent__icontains=filtrar_por_nome_fornecedor)
-
         return dataset.all()
 
     receitas = []

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -284,6 +284,7 @@ def test_api_list_lancamentos_todos_da_conta_inativa(
     jwt_authenticated_client_a,
     despesa_2020_1_inativa,
     rateio_despesa_2020_role_conferido_inativa,
+    rateio_despesa_2020_role_nao_conferido_inativa,
     periodo_2020_1,
     conta_associacao_cartao,
     conta_associacao_cheque,
@@ -297,13 +298,14 @@ def test_api_list_lancamentos_todos_da_conta_inativa(
             'mestre': despesa_2020_1_inativa,
             'rateios': [
                 rateio_despesa_2020_role_conferido_inativa,
+                rateio_despesa_2020_role_nao_conferido_inativa,
             ],
             'tipo': 'Gasto',
-            'valor_transacao_na_conta': 200.0,
+            'valor_transacao_na_conta': 300.0,
             'valor_transacao_total': 100.0,
             'valores_por_conta': [{
                 'conta_associacao__tipo_conta__nome': 'Cartão',
-                'valor_rateio__sum': 200.0
+                'valor_rateio__sum': 300.0
             }],
             'analise_lancamento': analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
             'solicitacao_ajuste': solicitacao_acerto_lancamento_devolucao_teste_inativa_analises,
@@ -316,9 +318,7 @@ def test_api_list_lancamentos_todos_da_conta_inativa(
     url = f'/api/analises-prestacoes-contas/{analise_prestacao_conta_2020_1_teste_inativa_analises.uuid}/lancamentos-com-ajustes/?conta_associacao={conta_uuid}'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
-
     result = json.loads(response.content)
-
     assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
 

--- a/sme_ptrf_apps/despesas/models/rateio_despesa.py
+++ b/sme_ptrf_apps/despesas/models/rateio_despesa.py
@@ -189,13 +189,14 @@ class RateioDespesa(ModeloBase):
 
     @classmethod
     def rateios_da_conta_associacao_no_periodo(cls, conta_associacao, periodo, conferido=None,
-                                               exclude_despesa=None, aplicacao_recurso=None, acao_associacao=None):
+                                               exclude_despesa=None, aplicacao_recurso=None, acao_associacao=None, incluir_inativas=False):
+        todos_rateios = cls.objects.exclude(status=STATUS_INCOMPLETO) if incluir_inativas else cls.completas
         if periodo.data_fim_realizacao_despesas:
-            dataset = cls.completos.filter(conta_associacao=conta_associacao).filter(
+            dataset = todos_rateios.filter(conta_associacao=conta_associacao).filter(
                 despesa__data_transacao__range=(
                     periodo.data_inicio_realizacao_despesas, periodo.data_fim_realizacao_despesas))
         else:
-            dataset = cls.completos.filter(conta_associacao=conta_associacao).filter(
+            dataset = todos_rateios.filter(conta_associacao=conta_associacao).filter(
                 despesa__data_transacao__gte=periodo.data_inicio_realizacao_despesas)
 
         if conferido is not None:


### PR DESCRIPTION
Esse PR:

- [x] Inclui teste para rateios_da_conta_associacao_no_periodo, que só filtrava por completas.

História [AB#73291](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73291)