### PR TITLE
Feat(73292) dre lancamentos inativos

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -791,7 +791,8 @@ def lancamentos_da_prestacao(
             'rateios': [],
             'notificar_dias_nao_conferido': receita.notificar_dias_nao_conferido,
             'analise_lancamento': {'resultado': analise_lancamento.resultado,
-                                   'uuid': analise_lancamento.uuid} if analise_lancamento else None
+                                   'uuid': analise_lancamento.uuid} if analise_lancamento else None,
+            'informacoes': receita.tags_de_informacao,
         }
 
         if com_ajustes:

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -129,7 +129,6 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
         for rateio in rateios_esperados:
             if rateio['notificar_dias_nao_conferido'] > max_notificar_dias_nao_conferido:
                 max_notificar_dias_nao_conferido = rateio['notificar_dias_nao_conferido']
-
         result_esperado.append(
             {
                 'periodo': f'{periodo.uuid}',
@@ -222,12 +221,23 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
                     'tipo_lancamento': 'GASTO',
                     'uuid': f'{lancamento["analise_lancamento"].uuid}'
                 } if lancamento["analise_lancamento"] else None,
-                'informacoes': [{'tag_hint': 'Parte da despesa foi paga com recursos '
-                                             'próprios ou por mais de uma conta.',
-                                 'tag_id': '3',
-                                 'tag_nome': 'Parcial'}],
+                'informacoes': [
+                                {
+                                    'tag_hint': 'Parte da despesa foi paga com recursos '
+                                                'próprios ou por mais de uma conta.',
+                                    'tag_id': '3',
+                                    'tag_nome': 'Parcial'},
+                               ],
             }
         )
+
+        if lancamento["mestre"].data_e_hora_de_inativacao:
+                result_esperado[0]['informacoes'].append({
+                    'tag_hint': 'Este gasto foi inativado em 10/05/2020 às '
+                                '05:10:10',
+                    'tag_id': '6',
+                    'tag_nome': 'Inativado'
+                })
 
     return result_esperado
 
@@ -276,6 +286,7 @@ def test_api_list_lancamentos_todos_da_conta(
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
     result = json.loads(response.content)
 
+
     assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
 
@@ -319,9 +330,9 @@ def test_api_list_lancamentos_todos_da_conta_inativa(
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
     result = json.loads(response.content)
+
     assert response.status_code == status.HTTP_200_OK
     assert result == result_esperado, "Não retornou a lista de lançamentos esperados."
-
 
 
 def test_api_list_lancamentos_todos_da_conta_por_tipo_ajuste(

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -26,6 +26,7 @@ class Despesa(ModeloBase):
     TAG_PARCIAL = {"id": "3", "nome": "Parcial", "descricao": "Parte da despesa paga com recursos próprios ou de mais de uma conta."}
     TAG_IMPOSTO = {"id": "4", "nome": "Imposto", "descricao": "Despesa com recolhimento de imposto."}
     TAG_IMPOSTO_PAGO = {"id": "5", "nome": "Imposto Pago", "descricao": "Imposto recolhido relativo a uma despesa de serviço."}
+    TAG_INATIVA = {"id": "6", "nome": "Inativado", "descricao": "Lançamento inativado."}
 
     history = AuditlogHistoryField()
 
@@ -133,6 +134,11 @@ class Despesa(ModeloBase):
                 'Parte da despesa foi paga com recursos próprios ou por mais de uma conta.'
             ))
 
+        if self.e_despesa_inativa():
+            tags.append(tag_informacao(
+                self.TAG_INATIVA,
+                f"Este gasto foi inativado em {self.data_e_hora_de_inativacao.strftime('%d/%m/%Y às %H:%M:%S')}"
+            ))
         return tags
 
     @property
@@ -250,6 +256,9 @@ class Despesa(ModeloBase):
 
     def tem_pagamentos_em_multiplas_contas(self):
         return self.rateios.values('conta_associacao').order_by('conta_associacao').annotate(count=Count('conta_associacao')).count() > 1
+
+    def e_despesa_inativa(self):
+        return self.status == STATUS_INATIVO
 
     def inativar_despesa(self):
         self.status = STATUS_INATIVO

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -281,7 +281,7 @@ class Despesa(ModeloBase):
 
     @classmethod
     def get_tags_informacoes_list(cls):
-        return [cls.TAG_ANTECIPADO, cls.TAG_ESTORNADO, cls.TAG_PARCIAL, cls.TAG_IMPOSTO, cls.TAG_IMPOSTO_PAGO]
+        return [cls.TAG_ANTECIPADO, cls.TAG_ESTORNADO, cls.TAG_PARCIAL, cls.TAG_IMPOSTO, cls.TAG_IMPOSTO_PAGO, cls.TAG_INATIVA]
 
     class Meta:
         verbose_name = "Documento comprobatório da despesa"

--- a/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
+++ b/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
@@ -13,4 +13,5 @@ def test_get_tags_informacoes_list():
         {"id": "3", "nome": "Parcial", "descricao": "Parte da despesa paga com recursos próprios ou de mais de uma conta."},
         {"id": "4", "nome": "Imposto", "descricao": "Despesa com recolhimento de imposto."},
         {"id": "5", "nome": "Imposto Pago", "descricao": "Imposto recolhido relativo a uma despesa de serviço."},
+        {"id": "6", "nome": "Inativado", "descricao": "Lançamento inativado."},
     ]

--- a/sme_ptrf_apps/receitas/api/views/receita_viewset.py
+++ b/sme_ptrf_apps/receitas/api/views/receita_viewset.py
@@ -221,3 +221,12 @@ class ReceitaViewSet(mixins.CreateModelMixin,
 
         return Response(ReceitaListaSerializer(receita_atrelada, many=False).data,
                         status=status.HTTP_200_OK)
+
+
+    @action(detail=False, url_path='tags-informacoes',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def tags_informacoes_list(self, request):
+
+        result = Receita.get_tags_informacoes_list()
+
+        return Response(result)

--- a/sme_ptrf_apps/receitas/tests/test_receita/test_receita_tags_informacoes.py
+++ b/sme_ptrf_apps/receitas/tests/test_receita/test_receita_tags_informacoes.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ...models import Receita
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_tags_informacoes_list():
+    tags = Receita.get_tags_informacoes_list()
+    assert tags == [
+        {"id": "6", "nome": "Inativado", "descricao": "Lançamento inativado."},
+    ]

--- a/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_get_receitas_tags_informacoes.py
+++ b/sme_ptrf_apps/receitas/tests/tests_api_receitas/test_get_receitas_tags_informacoes.py
@@ -1,0 +1,19 @@
+import json
+
+import pytest
+from rest_framework import status
+from sme_ptrf_apps.receitas.models import Receita
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_get_receita_tabelas(jwt_authenticated_client_p):
+
+    response = jwt_authenticated_client_p.get(f'/api/receitas/tags-informacoes/', content_type='application/json')
+    result = json.loads(response.content)
+
+    esperado = Receita.get_tags_informacoes_list()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == esperado


### PR DESCRIPTION
esse PR:

- [x] A tabela Conferência de lançamentos deve exibir os créditos do período da PC mesmo que estejam inativos.
- [x] A tabela Conferência de lançamentos deve exibir os gastos do período da PC mesmo que estejam inativos.

- [x] Incluir no retorno do endpoint usado, data e hora de inativação e texto explicativo dos gastos inativados
- [x] Incluir no retorno do endpoint usado, o status dos lançamentos tipo crédito
- [x] Incluir no retorno do endpoint usado, data e hora de inativação e texto explicativo dos créditos inativados

- [x] No modelo de Despesa, alterar propriedade informações para incluir a tag "Inativo"
- [x] No modelo de Receitas, criar propriedade informações com a tag "Inativo"

- [x] Incluir no retorno do endpoint para o quadro de legendas a nova tag "Inativo"

História [AB#73292](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73292)