### PR TITLE
Feat(73239) Desconsidera creditos inativos em conciliação bancária

### DIFF
--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -74,8 +74,8 @@ class ConciliacoesViewSet(GenericViewSet):
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
-
         result = info_resumo_conciliacao(periodo=periodo, conta_associacao=conta_associacao)
+
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=['get'],

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -289,7 +289,6 @@ def info_conciliacao_conta_associacao_no_periodo(periodo, conta_associacao):
 
 def receitas_conciliadas_por_conta_na_conciliacao(conta_associacao, periodo):
     dataset = periodo.receitas_conciliadas_no_periodo.filter(conta_associacao=conta_associacao)
-
     return dataset.all()
 
 

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -4,7 +4,7 @@ from sme_ptrf_apps.core.models import Associacao, FechamentoPeriodo
 from sme_ptrf_apps.despesas.models import RateioDespesa, Despesa
 from sme_ptrf_apps.receitas.models import Receita
 
-from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO
+from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO, STATUS_INATIVO
 
 
 def receitas_conciliadas_por_conta_e_acao_na_conciliacao(conta_associacao, acao_associacao, periodo):
@@ -289,7 +289,7 @@ def info_conciliacao_conta_associacao_no_periodo(periodo, conta_associacao):
 
 def receitas_conciliadas_por_conta_na_conciliacao(conta_associacao, periodo):
     dataset = periodo.receitas_conciliadas_no_periodo.filter(conta_associacao=conta_associacao)
-    return dataset.all()
+    return dataset.exclude(status=STATUS_INATIVO).all()
 
 
 def receitas_nao_conciliadas_por_conta_no_periodo(conta_associacao, periodo):


### PR DESCRIPTION
esse PR:

- [x] Alterar endpoint com os dados da tabela "Quadro Resumo" para desconsiderar créditos inativos

História: [AB#73239](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73239)