### PR TITLE
feat(75777) Registro de devoluções ao tesouro

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -1917,14 +1917,13 @@ def tipo_acerto_lancamento_devolucao():
 def solicitacao_acerto_lancamento_devolucao(
     analise_lancamento_receita_prestacao_conta_2020_1,
     tipo_acerto_lancamento_devolucao,
-    devolucao_ao_tesouro_parcial,
 
 ):
     return baker.make(
         'SolicitacaoAcertoLancamento',
         analise_lancamento=analise_lancamento_receita_prestacao_conta_2020_1,
         tipo_acerto=tipo_acerto_lancamento_devolucao,
-        devolucao_ao_tesouro=devolucao_ao_tesouro_parcial,
+        devolucao_ao_tesouro=None,
         detalhamento="teste"
     )
 

--- a/sme_ptrf_apps/core/api/serializers/solicitacao_devolucao_ao_tesouro_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/solicitacao_devolucao_ao_tesouro_serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from ...models import SolicitacaoDevolucaoAoTesouro
+from ...models import SolicitacaoDevolucaoAoTesouro, DevolucaoAoTesouro
 from ...api.serializers.tipo_devolucao_ao_tesouro_serializer import TipoDevolucaoAoTesouroSerializer
 from ....despesas.api.serializers.despesa_serializer import DespesaListSerializer
 
@@ -24,8 +24,20 @@ class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerialize
             return None
 
     def get_data(self, obj):
-        # Existe apenas por compatibilidade. Sempre retornará uma data nula.
-        return None
+        registro_devolucao = None
+        if (
+            obj.solicitacao_acerto_lancamento and
+            obj.solicitacao_acerto_lancamento.analise_lancamento and
+            obj.solicitacao_acerto_lancamento.analise_lancamento.despesa and
+            obj.solicitacao_acerto_lancamento.analise_lancamento.analise_prestacao_conta and
+            obj.solicitacao_acerto_lancamento.analise_lancamento.analise_prestacao_conta.prestacao_conta
+        ):
+            registro_devolucao = DevolucaoAoTesouro.objects.filter(
+                prestacao_conta=obj.solicitacao_acerto_lancamento.analise_lancamento.analise_prestacao_conta.prestacao_conta,
+                despesa=obj.solicitacao_acerto_lancamento.analise_lancamento.despesa,
+            ).first()
+
+        return registro_devolucao.data if registro_devolucao else None
 
     def get_despesa(self, obj):
         if (

--- a/sme_ptrf_apps/core/api/serializers/solicitacao_devolucao_ao_tesouro_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/solicitacao_devolucao_ao_tesouro_serializer.py
@@ -8,9 +8,10 @@ from ....despesas.api.serializers.despesa_serializer import DespesaListSerialize
 class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerializer):
     prestacao_conta = serializers.SerializerMethodField('get_prestacao_conta')
     tipo = TipoDevolucaoAoTesouroSerializer(many=False)
-    data = serializers.SerializerMethodField('get_data')
     despesa = serializers.SerializerMethodField('get_despesa')
     visao_criacao = serializers.SerializerMethodField('get_visao_criacao')
+    uuid_registro_devolucao = serializers.SerializerMethodField('get_uuid_registro_devolucao')
+    data = serializers.SerializerMethodField('get_data')
 
     def get_prestacao_conta(self, obj):
         if (
@@ -23,7 +24,7 @@ class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerialize
         else:
             return None
 
-    def get_data(self, obj):
+    def get_registro_devolucao_tesouro(self, obj):
         registro_devolucao = None
         if (
             obj.solicitacao_acerto_lancamento and
@@ -36,8 +37,7 @@ class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerialize
                 prestacao_conta=obj.solicitacao_acerto_lancamento.analise_lancamento.analise_prestacao_conta.prestacao_conta,
                 despesa=obj.solicitacao_acerto_lancamento.analise_lancamento.despesa,
             ).first()
-
-        return registro_devolucao.data if registro_devolucao else None
+        return registro_devolucao
 
     def get_despesa(self, obj):
         if (
@@ -54,6 +54,16 @@ class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerialize
         # Existe apenas por compatibilidade. Sempre retornará 'DRE'.
         return "DRE"
 
+    def get_uuid_registro_devolucao(self, obj):
+        registro_devolucao = self.get_registro_devolucao_tesouro(obj)
+
+        return registro_devolucao.uuid if registro_devolucao else None
+
+    def get_data(self, obj):
+        registro_devolucao = self.get_registro_devolucao_tesouro(obj)
+
+        return registro_devolucao.data if registro_devolucao else None
+
     class Meta:
         model = SolicitacaoDevolucaoAoTesouro
         order_by = 'id'
@@ -61,10 +71,11 @@ class SolicitacaoDevolucaoAoTesouroRetrieveSerializer(serializers.ModelSerialize
             'uuid',
             'prestacao_conta',
             'tipo',
-            'data',
             'despesa',
             'devolucao_total',
             'valor',
             'motivo',
-            'visao_criacao'
+            'visao_criacao',
+            'uuid_registro_devolucao',
+            'data',
         )

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -232,18 +232,31 @@ class PrestacaoConta(ModeloBase):
             tipo_devolucao = TipoDevolucaoAoTesouro.by_uuid(devolucao['tipo'])
             despesa = Despesa.by_uuid(devolucao['despesa'])
             devolucao_uuid = devolucao['uuid']
-            devolucao_atual = DevolucaoAoTesouro.by_uuid(uuid=devolucao_uuid)
 
-            devolucao_atual.prestacao_conta = self
-            devolucao_atual.tipo = tipo_devolucao
-            devolucao_atual.despesa = despesa
-            devolucao_atual.data = devolucao['data']
-            devolucao_atual.devolucao_total = devolucao['devolucao_total']
-            devolucao_atual.motivo = devolucao['motivo']
-            devolucao_atual.valor = devolucao['valor']
-            devolucao_atual.visao_criacao = devolucao['visao_criacao']
+            if devolucao_uuid:
+                registro_devolucao = DevolucaoAoTesouro.objects.get(uuid=devolucao_uuid)
 
-            devolucao_atual.save()
+                registro_devolucao.prestacao_conta = self
+                registro_devolucao.tipo = tipo_devolucao
+                registro_devolucao.despesa = despesa
+                registro_devolucao.data = devolucao['data']
+                registro_devolucao.devolucao_total = devolucao['devolucao_total']
+                registro_devolucao.motivo = devolucao['motivo']
+                registro_devolucao.valor = devolucao['valor']
+                registro_devolucao.visao_criacao = devolucao['visao_criacao']
+
+                registro_devolucao.save()
+            else:
+                DevolucaoAoTesouro.objects.create(
+                    prestacao_conta=self,
+                    tipo=tipo_devolucao,
+                    despesa=despesa,
+                    data=devolucao['data'],
+                    devolucao_total=devolucao['devolucao_total'],
+                    motivo=devolucao['motivo'],
+                    valor=devolucao['valor'],
+                    visao_criacao=devolucao['visao_criacao'],
+                )
 
         return self
 

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -260,6 +260,15 @@ class PrestacaoConta(ModeloBase):
 
         return self
 
+    def apagar_devolucoes_ao_tesouro(self, devolucoes_ao_tesouro_a_apagar):
+        from ..models.devolucao_ao_tesouro import DevolucaoAoTesouro
+
+        for devolucao in devolucoes_ao_tesouro_a_apagar:
+            if devolucao['uuid']:
+                DevolucaoAoTesouro.objects.get(uuid=devolucao['uuid']).delete()
+
+        return self
+
     @transaction.atomic
     def salvar_analise(self, analises_de_conta_da_prestacao=None, resultado_analise=None,
                        motivos_aprovacao_ressalva=[], outros_motivos_aprovacao_ressalva='', motivos_reprovacao=[],

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/conftest.py
@@ -821,7 +821,6 @@ def solicitacao_devolucao_ao_tesouro_teste_analises(
 def solicitacao_acerto_lancamento_devolucao_teste_inativa_analises(
     analise_lancamento_despesa_prestacao_conta_2020_1_teste_inativa_analises,
     tipo_acerto_lancamento_devolucao,
-    devolucao_ao_tesouro_parcial_ajuste_inativa
 ):
     return baker.make(
         'SolicitacaoAcertoLancamento',

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -172,7 +172,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
                             'copiado': False,
                             'detalhamento': 'teste',
                             'devolucao_ao_tesouro': {
-                                'data': None,
+                                'data': lancamento["data_devolucao"] if "data_devolucao" in lancamento else None,
                                 'despesa': {
                                     'associacao': f'{lancamento["mestre"].associacao.uuid}',
                                     'cpf_cnpj_fornecedor': '11.478.276/0001-04',
@@ -206,7 +206,8 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
                                 },
                                 'uuid': f'{lancamento["solicitacao_devolucao"].uuid}',
                                 'valor': '100.00',
-                                'visao_criacao': 'DRE'
+                                'visao_criacao': 'DRE',
+                                'uuid_registro_devolucao': None
                             },
                             'id': lancamento["solicitacao_ajuste"].id,
                             'tipo_acerto': {

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_apaga_devolucoes_ao_tesouro.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_apaga_devolucoes_ao_tesouro.py
@@ -1,0 +1,78 @@
+import json
+import pytest
+
+from datetime import date
+from model_bakery import baker
+
+from sme_ptrf_apps.core.models import PrestacaoConta
+
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def despesa(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=date(2020, 3, 10),
+        valor_total=100.00,
+    )
+
+
+@pytest.fixture
+def prestacao_conta_em_analise(periodo, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo,
+        associacao=associacao,
+        data_recebimento=date(2020, 10, 1),
+        status=PrestacaoConta.STATUS_EM_ANALISE
+    )
+
+
+@pytest.fixture
+def tipo_devolucao_ao_tesouro():
+    return baker.make('TipoDevolucaoAoTesouro', nome='Teste')
+
+
+@pytest.fixture
+def devolucao_ao_tesouro(prestacao_conta_em_analise, tipo_devolucao_ao_tesouro, despesa):
+    return baker.make(
+        'DevolucaoAoTesouro',
+        prestacao_conta=prestacao_conta_em_analise,
+        tipo=tipo_devolucao_ao_tesouro,
+        data=date(2020, 7, 1),
+        despesa=despesa,
+        devolucao_total=True,
+        valor=100.00,
+        motivo='teste',
+    )
+
+
+def test_api_apaga_devolucoes_ao_tesouro(
+    jwt_authenticated_client_a,
+    prestacao_conta_em_analise,
+    conta_associacao,
+    devolucao_ao_tesouro
+):
+    payload = {
+        'devolucoes_ao_tesouro_a_apagar': [
+            {
+                'uuid': f"{devolucao_ao_tesouro.uuid}",
+            }
+        ]
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/apagar-devolucoes-ao-tesouro/'
+
+    response = jwt_authenticated_client_a.delete(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_get_lancamentos_solicitacoes_acerto.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_lancamentos/test_get_lancamentos_solicitacoes_acerto.py
@@ -49,7 +49,7 @@ def test_api_get_solicitacoes_acerto_de_um_lancamento(
                 'copiado': False,
                 'detalhamento': 'teste',
                 'devolucao_ao_tesouro': {
-                    'data': None,
+                    'data': '2020-07-01',
                     'despesa': {
                         'associacao': f'{despesa_2020_1.associacao.uuid}',
                         'cpf_cnpj_fornecedor': '11.478.276/0001-04',
@@ -63,7 +63,7 @@ def test_api_get_solicitacoes_acerto_de_um_lancamento(
                         'tipo_transacao': {'id': despesa_2020_1.tipo_transacao.id, 'nome': 'Boleto', 'tem_documento': False},
                         'uuid': f'{despesa_2020_1.uuid}',
                         'valor_ptrf': 90.0,
-                        'valor_total': '100.00'
+                        'valor_total': '100.00',
                     },
                     'devolucao_total': False,
                     'motivo': 'teste',
@@ -74,7 +74,8 @@ def test_api_get_solicitacoes_acerto_de_um_lancamento(
                              'uuid': f'{solicitacao_acerto_lancamento_devolucao.devolucao_ao_tesouro.tipo.uuid}'},
                     'uuid': f'{solicitacao_devolucao_ao_tesouro.uuid}',
                     'valor': '100.00',
-                    'visao_criacao': 'DRE'
+                    'visao_criacao': 'DRE',
+                    'uuid_registro_devolucao': f'{solicitacao_acerto_lancamento_devolucao.devolucao_ao_tesouro.uuid}',
                 },
                 'id': solicitacao_acerto_lancamento_devolucao.id,
                 'tipo_acerto': {'ativo': True,

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_apagar_devolucoes_ao_tesouro.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_apagar_devolucoes_ao_tesouro.py
@@ -1,0 +1,81 @@
+import pytest
+from datetime import date
+from model_bakery import baker
+
+from ...models import DevolucaoAoTesouro
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tpcadat_despesa(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        data_transacao=date(2020, 3, 10),
+        valor_total=100.00,
+    )
+
+
+@pytest.fixture
+def tpcadat_tipo_devolucao_ao_tesouro():
+    return baker.make('TipoDevolucaoAoTesouro', nome='Teste')
+
+@pytest.fixture
+def tpcadat_devolucao_ao_tesouro_1(prestacao_conta_2020_1_conciliada, tpcadat_tipo_devolucao_ao_tesouro, tpcadat_despesa):
+    return baker.make(
+        'DevolucaoAoTesouro',
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        tipo=tpcadat_tipo_devolucao_ao_tesouro,
+        data=date(2020, 7, 1),
+        despesa=tpcadat_despesa,
+        devolucao_total=True,
+        valor=100.00,
+        motivo='teste',
+        visao_criacao='DRE'
+    )
+
+@pytest.fixture
+def tpcadat_devolucao_ao_tesouro_2(prestacao_conta_2020_1_conciliada, tpcadat_tipo_devolucao_ao_tesouro, tpcadat_despesa):
+    return baker.make(
+        'DevolucaoAoTesouro',
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        tipo=tpcadat_tipo_devolucao_ao_tesouro,
+        data=date(2020, 7, 1),
+        despesa=tpcadat_despesa,
+        devolucao_total=True,
+        valor=100.00,
+        motivo='teste',
+        visao_criacao='DRE'
+    )
+
+
+def test_apagar_devolucoes_ao_tesouro_pode_apagar_uma(
+    tpcadat_devolucao_ao_tesouro_1,
+    tpcadat_devolucao_ao_tesouro_2,
+    prestacao_conta_2020_1_conciliada
+):
+    assert DevolucaoAoTesouro.objects.count() == 2
+    prestacao_conta_2020_1_conciliada.apagar_devolucoes_ao_tesouro([{"uuid": tpcadat_devolucao_ao_tesouro_1.uuid}])
+    assert DevolucaoAoTesouro.objects.count() == 1
+
+
+def test_apagar_devolucoes_ao_tesouro_pode_apagar_varias(
+    tpcadat_devolucao_ao_tesouro_1,
+    tpcadat_devolucao_ao_tesouro_2,
+    prestacao_conta_2020_1_conciliada
+):
+    assert DevolucaoAoTesouro.objects.count() == 2
+    prestacao_conta_2020_1_conciliada.apagar_devolucoes_ao_tesouro([
+        {"uuid": tpcadat_devolucao_ao_tesouro_1.uuid},
+        {"uuid": tpcadat_devolucao_ao_tesouro_2.uuid},
+    ])
+    assert DevolucaoAoTesouro.objects.count() == 0
+

--- a/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_lancamento/test_solicitacao_acerto_lancamento_model.py
+++ b/sme_ptrf_apps/core/tests/tests_solicitacao_acerto_lancamento/test_solicitacao_acerto_lancamento_model.py
@@ -16,7 +16,6 @@ def test_instance_model(solicitacao_acerto_lancamento_devolucao):
     assert isinstance(model, SolicitacaoAcertoLancamento)
     assert isinstance(model.analise_lancamento, AnaliseLancamentoPrestacaoConta)
     assert isinstance(model.tipo_acerto, TipoAcertoLancamento)
-    assert isinstance(model.devolucao_ao_tesouro, DevolucaoAoTesouro)
     assert model.detalhamento
 
 


### PR DESCRIPTION
Esse PR:

[X] Altera a API que traz as informações da tabela de devolução ao tesouro para usar o novo modelo. 
[X] Altera o salvamento de devolução ao tesouro parta criar o registro de devolução
[X] Cria endpoint e serviço para desfazer o registro de uma  devolução ao tesouro
[X] Altera retorno da API para o relatório após acertos para usar informações da nova tabela
[X] Altera retorno da API para o relatório de acertos para usar informações da nova tabela

História: [AB#75777](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/75777)
