### PR TITLE
fix(76087): Conciliação bancaria

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -1805,6 +1805,17 @@ def devolucao_prestacao_conta_2020_1(prestacao_conta_2020_1_conciliada):
 
 
 @pytest.fixture
+def devolucao_prestacao_conta_2019_2(prestacao_conta_devolvida):
+    return baker.make(
+        'DevolucaoPrestacaoConta',
+        prestacao_conta=prestacao_conta_devolvida,
+        data=date(2020, 7, 1),
+        data_limite_ue=date(2020, 8, 1),
+        data_retorno_ue=None
+    )
+
+
+@pytest.fixture
 def analise_conta_prestacao_conta_2020_1(prestacao_conta_2020_1_conciliada, conta_associacao_cheque):
     return baker.make(
         'AnaliseContaPrestacaoConta',
@@ -1812,6 +1823,18 @@ def analise_conta_prestacao_conta_2020_1(prestacao_conta_2020_1_conciliada, cont
         conta_associacao=conta_associacao_cheque,
         data_extrato=date(2020, 7, 1),
         saldo_extrato=100.00,
+    )
+
+
+@pytest.fixture
+def analise_conta_prestacao_conta_2019_2(prestacao_conta_devolvida, conta_associacao_cheque, analise_prestacao_conta_2019_2):
+    return baker.make(
+        'AnaliseContaPrestacaoConta',
+        prestacao_conta=prestacao_conta_devolvida,
+        conta_associacao=conta_associacao_cheque,
+        data_extrato=date(2020, 7, 1),
+        saldo_extrato=100.00,
+        analise_prestacao_conta=analise_prestacao_conta_2019_2
     )
 
 
@@ -1834,6 +1857,15 @@ def analise_prestacao_conta_2020_1(prestacao_conta_2020_1_conciliada, devolucao_
         'AnalisePrestacaoConta',
         prestacao_conta=prestacao_conta_2020_1_conciliada,
         devolucao_prestacao_conta=devolucao_prestacao_conta_2020_1
+    )
+
+
+@pytest.fixture
+def analise_prestacao_conta_2019_2(prestacao_conta_devolvida, devolucao_prestacao_conta_2019_2):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_devolvida,
+        devolucao_prestacao_conta=devolucao_prestacao_conta_2019_2
     )
 
 

--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -16,7 +16,7 @@ from sme_ptrf_apps.users.permissoes import (
 
 from ....despesas.api.serializers.rateio_despesa_serializer import RateioDespesaListaSerializer
 from ....receitas.api.serializers.receita_serializer import ReceitaListaSerializer
-from ...models import AcaoAssociacao, ContaAssociacao, ObservacaoConciliacao, Periodo
+from ...models import AcaoAssociacao, ContaAssociacao, ObservacaoConciliacao, Periodo, Associacao
 from ...services import (
     despesas_conciliadas_por_conta_e_acao_na_conciliacao,
     despesas_nao_conciliadas_por_conta_e_acao_no_periodo,
@@ -26,7 +26,8 @@ from ...services import (
     transacoes_para_conciliacao,
     conciliar_transacao,
     desconciliar_transacao,
-    salva_conciliacao_bancaria
+    salva_conciliacao_bancaria,
+    permite_editar_campos_extrato
 )
 from ....despesas.models import Despesa
 from ....receitas.models import Receita
@@ -677,3 +678,80 @@ class ConciliacoesViewSet(GenericViewSet):
                 'mensagem': 'Extrato bancário não encontrado'
             }
             return Response(erro, status=status.HTTP_404_NOT_FOUND)
+
+    @action(detail=False, methods=['get'], url_path='tem_ajuste_bancario',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComGravacao])
+    def tem_ajuste_bancario(self, request):
+
+        # Define a Associacao
+        associacao_uuid = self.request.query_params.get('associacao')
+
+        if not associacao_uuid:
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': 'É necessário enviar o uuid da associação.'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            associacao = Associacao.objects.get(uuid=associacao_uuid)
+        except Associacao.DoesNotExist:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': f"O objeto associacao para o uuid {associacao_uuid} não foi encontrado na base."
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        # Define o período de conciliação
+        periodo_uuid = self.request.query_params.get('periodo')
+
+        if not periodo_uuid:
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': 'É necessário enviar o uuid do período de conciliação.'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            periodo = Periodo.objects.get(uuid=periodo_uuid)
+        except Periodo.DoesNotExist:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': f"O objeto período para o uuid {periodo_uuid} não foi encontrado na base."
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        # Define a conta de conciliação
+        conta_associacao_uuid = self.request.query_params.get('conta_associacao')
+
+        if not conta_associacao_uuid:
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': 'É necessário enviar o uuid da conta da associação.'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            conta_associacao = ContaAssociacao.objects.get(uuid=conta_associacao_uuid)
+        except ContaAssociacao.DoesNotExist:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': f"O objeto conta-associação para o uuid {conta_associacao_uuid} não foi encontrado na base."
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        permite_editar = permite_editar_campos_extrato(
+            associacao,
+            periodo,
+            conta_associacao
+        )
+
+        result = {
+            'permite_editar_campos_extrato': permite_editar,
+        }
+
+        return Response(result, status=status.HTTP_200_OK)
+

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -167,6 +167,11 @@ class AnalisePrestacaoConta(ModeloBase):
 
         return tem_analises_de_lancamentos_pendentes or tem_analises_de_documentos_pendentes
 
+    def tem_acertos_extratos_bancarios(self, conta_associacao):
+        acerto_extrato_bancario = self.analises_de_extratos.filter(conta_associacao=conta_associacao).exists()
+
+        return acerto_extrato_bancario
+
     def __str__(self):
         return f"{self.prestacao_conta.periodo} - Análise #{self.pk}"
 

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -9,6 +9,7 @@ from .conciliacao_services import (
     conciliar_transacao,
     desconciliar_transacao,
     salva_conciliacao_bancaria,
+    permite_editar_campos_extrato
 )
 from .exporta_associacao import gerar_planilha
 from .implantacao_saldos_services import implanta_saldos_da_associacao, implantacoes_de_saldo_da_associacao

--- a/sme_ptrf_apps/core/services/associacoes_service.py
+++ b/sme_ptrf_apps/core/services/associacoes_service.py
@@ -87,6 +87,12 @@ def tem_repasses_pendentes_periodos_ate_agora(associacao, periodo):
 def retorna_se_pode_habilitar_botao_ver_acertos_em_analise_da_dre(periodo, associacao_uuid):
     associacao = Associacao.by_uuid(associacao_uuid)
 
+    tem_solicitacoes_de_ajustes_extratos_bancarios = PrestacaoConta.objects.filter(
+        periodo=periodo,
+        associacao=associacao,
+        analises_da_prestacao__analises_de_extratos__isnull=False
+    ).count()
+
     tem_solicitacoes_de_ajustes_lancamentos = PrestacaoConta.objects.filter(
         periodo=periodo,
         associacao=associacao,
@@ -99,7 +105,8 @@ def retorna_se_pode_habilitar_botao_ver_acertos_em_analise_da_dre(periodo, assoc
         analises_da_prestacao__analises_de_documento__solicitacoes_de_ajuste_da_analise__isnull=False
     ).count()
 
-    total_ajustes = tem_solicitacoes_de_ajustes_lancamentos + tem_solicitacoes_de_ajustes_documentos
+    total_ajustes = tem_solicitacoes_de_ajustes_lancamentos + tem_solicitacoes_de_ajustes_documentos + \
+        tem_solicitacoes_de_ajustes_extratos_bancarios
 
     return total_ajustes > 0
 

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -1,6 +1,6 @@
 from django.db.models import Sum, Q, Count, Max
 
-from sme_ptrf_apps.core.models import Associacao, FechamentoPeriodo
+from sme_ptrf_apps.core.models import Associacao, FechamentoPeriodo, PrestacaoConta
 from sme_ptrf_apps.despesas.models import RateioDespesa, Despesa
 from sme_ptrf_apps.receitas.models import Receita
 
@@ -620,3 +620,23 @@ def salva_conciliacao_bancaria(justificativa_ou_extrato_bancario, texto_observac
             comprovante_extrato=comprovante_extrato,
             data_atualizacao_comprovante_extrato=data_atualizacao_comprovante_extrato,
         )
+
+
+def permite_editar_campos_extrato(associacao, periodo, conta_associacao):
+    prestacao_conta = PrestacaoConta.objects.filter(
+        associacao=associacao,
+        periodo=periodo
+    ).first()
+
+    if not prestacao_conta:
+        return True
+
+    if prestacao_conta.status != PrestacaoConta.STATUS_DEVOLVIDA:
+        return False
+
+    ultima_analise = prestacao_conta.analises_da_prestacao.last()
+
+    tem_acertos_de_extrato = ultima_analise.tem_acertos_extratos_bancarios(conta_associacao) if \
+        ultima_analise is not None else False
+
+    return tem_acertos_de_extrato

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_get_pode_editar_campos_extrato.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_get_pode_editar_campos_extrato.py
@@ -1,0 +1,93 @@
+import json
+
+import pytest
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_get_pode_editar_campos_sem_pc(jwt_authenticated_client_a,
+                                           associacao,
+                                           periodo,
+                                           conta_associacao,
+                                           observacao_conciliacao
+                                           ):
+    conta_uuid = conta_associacao.uuid
+
+    url = f'/api/conciliacoes/tem_ajuste_bancario/?associacao={associacao.uuid}&periodo={periodo.uuid}&conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'permite_editar_campos_extrato': True
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert resultado_esperado == result
+
+
+def test_api_get_pode_editar_campos_com_pc_nao_devolvida(jwt_authenticated_client_a,
+                                                         associacao,
+                                                         periodo_2019_2,
+                                                         conta_associacao,
+                                                         observacao_conciliacao,
+                                                         prestacao_conta_2019_2_conciliada
+                                                         ):
+    conta_uuid = conta_associacao.uuid
+    url = f'/api/conciliacoes/tem_ajuste_bancario/?associacao={associacao.uuid}&periodo={periodo_2019_2.uuid}&conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'permite_editar_campos_extrato': False
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert resultado_esperado == result
+
+
+def test_api_get_pode_editar_campos_com_pc_devolvida_sem_ajuste_bancario(jwt_authenticated_client_a,
+                                                                         associacao,
+                                                                         periodo,
+                                                                         conta_associacao,
+                                                                         observacao_conciliacao,
+                                                                         prestacao_conta_devolvida
+                                                                         ):
+    conta_uuid = conta_associacao.uuid
+    url = f'/api/conciliacoes/tem_ajuste_bancario/?associacao={associacao.uuid}&periodo={periodo.uuid}&conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'permite_editar_campos_extrato': False
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert resultado_esperado == result
+
+
+def test_api_get_pode_editar_campos_com_pc_devolvida_com_ajuste_bancario(jwt_authenticated_client_a,
+                                                                         associacao,
+                                                                         periodo,
+                                                                         conta_associacao_cheque,
+                                                                         observacao_conciliacao,
+                                                                         prestacao_conta_devolvida,
+                                                                         analise_conta_prestacao_conta_2019_2,
+                                                                         analise_prestacao_conta_2019_2
+                                                                         ):
+    conta_uuid = conta_associacao_cheque.uuid
+    url = f'/api/conciliacoes/tem_ajuste_bancario/?associacao={associacao.uuid}&periodo={periodo.uuid}&conta_associacao={conta_uuid}'
+
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+
+    result = json.loads(response.content)
+    resultado_esperado = {
+        'permite_editar_campos_extrato': True
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert resultado_esperado == result
+


### PR DESCRIPTION
fix(76087): Conciliação bancaria

Esse PR:

- Adiciona seviço para verificar se os campos relacionados ao saldo bancario podem ser editados
- Adiciona endpoint para o novo serviço
- Adiciona função  para verificar se há ajustes bancarios ao modelo de AnalisePrestacaoConta
- Adiciona testes relacionados

História: [AB#76087](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/76087)
