### PR TITLE
Feat(76333): Padronização dados relatorio acertos back

### DIFF
--- a/sme_ptrf_apps/core/api/views/analises_prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/analises_prestacoes_contas_viewset.py
@@ -155,7 +155,6 @@ class AnalisesPrestacoesContasViewSet(
             com_ajustes=True,
             inclui_inativas=True,
         )
-
         return Response(lancamentos, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['get'], url_path='documentos-com-ajuste',

--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -1055,7 +1055,6 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
                 elif status_prestacao_conta == "APROVADA_RESSALVA":
                     dado["motivos_aprovada_ressalva"] = get_motivos_aprovacao_ressalva(prestacao_conta)
                     dado["recomendacoes"] = prestacao_conta.recomendacoes
-
         # Verificando se pelo menos um objeto do tipo dado foi criado, se sim existe o index status_prestacao_contas no dict dado
         _status_prestacao_contas = any('status_prestacao_contas' in d for d in dado)
 

--- a/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/pdf.html
@@ -211,11 +211,13 @@
                         <br>
                         <span class="font-12">{{ acerto.devolucao_ao_tesouro.tipo.nome }}</span>
                       </div>
+                      {% if acerto.devolucao_ao_tesouro.data %}
                       <div class="col-6">
                         <span class="font-12"><strong>Realização da devolução em</strong></span>
                         <br>
                         <span class="font-12">{{ acerto.devolucao_ao_tesouro.data|date:'d/m/Y' }}</span>
                       </div>
+                      {% endif %}
                     </div>
 
                     <div class="row mt-2">
@@ -355,7 +357,7 @@
   {% endif %}
 
   {% if dados.dados_documentos %}
-    <article class="mt-4 ml-2">
+    <article class="mt-4">
       <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
         <thead>
           <tr class="">
@@ -378,15 +380,14 @@
 
             {% for acertos in documento.solicitacoes_de_ajuste_da_analise %}
               <tr>
-                <td class="">
+                <td class="sem-borda pb-2">
                   <div class="row">
                     <div class="col-6 mt-2">
-                      <span class="ml-3 font-12"><strong>Item:</strong></span>
-                      <br/>
+                      <span class="ml-3 item font-12"><strong>Item {{ forloop.counter }}:</strong></span>
                       <span class="ml-3 font-12">{{ acertos.tipo_acerto.nome }}</span>
                     </div>
                   {% if acertos.detalhamento %}
-                      <div class="col-6 mt-2">
+                      <div class="col-12 mt-2">
                         <span class="ml-3 font-12"><strong>Detalhamento do acerto:</strong></span>
                         <br>
                         <span class="ml-3 font-12">{{ acertos.detalhamento }}</span>
@@ -399,7 +400,7 @@
             {% endfor %}
 
             <tr>
-              <td>
+              <td class="sem-borda pb-2">
                 <div class="row">
                   <div class="col-12 mt-4 ml-3">
                     <span class="item font-12"><strong>Retorno da Associação:</strong></span>

--- a/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/pdf.html
@@ -206,10 +206,15 @@
                     </div>
 
                     <div class="row mt-2">
-                      <div class="col-12">
+                      <div class="col-6">
                         <span class="font-12"><strong>Tipo de devolução</strong></span>
                         <br>
                         <span class="font-12">{{ acerto.devolucao_ao_tesouro.tipo.nome }}</span>
+                      </div>
+                      <div class="col-6">
+                        <span class="font-12"><strong>Realização da devolução em</strong></span>
+                        <br>
+                        <span class="font-12">{{ acerto.devolucao_ao_tesouro.data|date:'d/m/Y' }}</span>
                       </div>
                     </div>
 
@@ -250,7 +255,7 @@
                     {% if acerto.detalhamento %}
                       <div class="row mt-2">
                         <div class="col-12">
-                          <span class="font-12"><strong>Detalhamento do acerto (opcional):</strong></span>
+                          <span class="font-12"><strong>Detalhamento do acerto:</strong></span>
                           <br>
                           <span class="font-12">{{ acerto.detalhamento }}</span>
                         </div>
@@ -350,7 +355,7 @@
   {% endif %}
 
   {% if dados.dados_documentos %}
-    <article class="mt-4">
+    <article class="mt-4 ml-2">
       <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
         <thead>
           <tr class="">
@@ -375,23 +380,20 @@
               <tr>
                 <td class="">
                   <div class="row">
-                    <div class="col-12 mt-2">
+                    <div class="col-6 mt-2">
                       <span class="ml-3 font-12"><strong>Item:</strong></span>
                       <br/>
                       <span class="ml-3 font-12">{{ acertos.tipo_acerto.nome }}</span>
                     </div>
-                  </div>
-
                   {% if acertos.detalhamento %}
-                    <div class="row mt-2">
-                      <div class="col-12">
+                      <div class="col-6 mt-2">
                         <span class="ml-3 font-12"><strong>Detalhamento do acerto:</strong></span>
                         <br>
                         <span class="ml-3 font-12">{{ acertos.detalhamento }}</span>
                       </div>
-                    </div>
                   {% endif %}
 
+                  </div>
                 </td>
               </tr>
             {% endfor %}
@@ -399,14 +401,14 @@
             <tr>
               <td>
                 <div class="row">
-                  <div class="col-12 mt-2">
-                    <span class="ml-3 font-12"><strong>Retorno da Associação:</strong></span>
+                  <div class="col-12 mt-4 ml-3">
+                    <span class="item font-12"><strong>Retorno da Associação:</strong></span>
                   </div>
                 </div>
 
 
                 {% if documento.status_realizacao == 'PENDENTE' %}
-                  <div class="row mt-2">
+                  <div class="row mt-2 mb-5">
                     <div class="col-3">
                       <span class="ml-3 font-12"><strong>Status</strong></span>
                       <br/>
@@ -416,7 +418,7 @@
                     </div>
 
                     {% if documento.esclarecimentos %}
-                      <div class="col-9">
+                      <div class="col-9 mb-2">
                         <span class="font-12"><strong>Esclarecimento</strong></span>
                         <br/>
                         <span class="mt-2 font-12">{{ documento.esclarecimentos }}</span>
@@ -426,7 +428,7 @@
                   </div>
                 {% elif documento.status_realizacao == 'JUSTIFICADO' %}
 
-                  <div class="row mt-2">
+                  <div class="row mt-2 mb-5">
                     <div class="col-3">
                       <span class="ml-3 font-12"><strong>Status</strong></span>
                       <br/>
@@ -436,20 +438,20 @@
                     </div>
 
                     {% if documento.esclarecimentos %}
-                      <div class="col-5">
+                      <div class="col-5 mb-2">
                         <span class="font-12"><strong>Justificativa</strong></span>
                         <br/>
                         <span class="mt-2 font-12">{{ documento.justificativa }}</span>
                       </div>
 
-                      <div class="col-4">
+                      <div class="col-4 mb-2">
                         <span class="font-12"><strong>Esclarecimento</strong></span>
                         <br/>
                         <span class="mt-2 font-12">{{ documento.esclarecimentos }}</span>
                       </div>
 
                     {% else %}
-                      <div class="col-9">
+                      <div class="col-9 mb-2">
                         <span class="font-12"><strong>Justificativa</strong></span>
                         <br/>
                         <span class="mt-2 font-12">{{ documento.justificativa }}</span>
@@ -458,7 +460,7 @@
                   </div>
 
                 {% elif documento.status_realizacao == 'REALIZADO' %}
-                  <div class="row mt-2">
+                  <div class="row mt-2 mb-5">
                     <div class="col-3">
                       <span class="ml-3 font-12"><strong>Status</strong></span>
                       <br/>
@@ -469,7 +471,7 @@
                     </div>
 
                     {% if documento.esclarecimentos %}
-                      <div class="col-9">
+                      <div class="col-9 mb-2">
                         <span class="font-12"><strong>Esclarecimento</strong></span>
                         <br/>
                         <span class="mt-2 font-12">{{ documento.esclarecimentos }}</span>


### PR DESCRIPTION
Esse PR:

- [x] Ajusta template do relatório (padronizar entre lancto e docs)
- [x] Inclui a data de devolução ao tesouro (nas devoluções ao tesouro)

História: [AB#76333](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/76333)