### PR TITLE
Feat(52178) filtro dre buscar nome associacao

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -344,8 +344,8 @@ class TagAdmin(admin.ModelAdmin):
 @admin.register(ProcessoAssociacao)
 class ProcessoAssociacaoAdmin(admin.ModelAdmin):
     list_display = ('associacao', 'numero_processo', 'ano')
-    search_fields = ('uuid', 'numero_processo')
-    list_filter = ('ano', 'associacao',)
+    search_fields = ('uuid', 'numero_processo', 'associacao__nome')
+    list_filter = ('ano', 'associacao', 'associacao__unidade__tipo_unidade', 'associacao__unidade__dre')
     readonly_fields = ('uuid', 'id')
 
 


### PR DESCRIPTION
Esse PR:

-[x] Aplicar um filtro que exiba todos os registros de determinado tipo de unidade;
-[x] Aplica um filtro que exiba todos os registros de determinada DRE;
-[x] Busca (search) pelo nome da associação.

História: [AB#52178](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/52178)