### PR TITLE
feat(50157): Altera identificação de usuários no AuditLog

### DIFF
--- a/sme_ptrf_apps/sme/services/exporta_dados_creditos_service.py
+++ b/sme_ptrf_apps/sme/services/exporta_dados_creditos_service.py
@@ -136,7 +136,7 @@ class ExportacoesDadosCreditosService:
     def envia_arquivo_central_download(self, tmp) -> None:
         logger.info("Gerando arquivo download...")
         obj_arquivo_download = gerar_arquivo_download(
-            self.user,
+            self.user.username,
             self.nome_arquivo
         )
 

--- a/sme_ptrf_apps/users/models.py
+++ b/sme_ptrf_apps/users/models.py
@@ -17,6 +17,7 @@ from django.db.models.signals import m2m_changed
 
 logger = logging.getLogger(__name__)
 
+
 class Visao(ModeloIdNome):
     history = AuditlogHistoryField()
 
@@ -151,6 +152,8 @@ class User(AbstractUser):
         verbose_name = 'Usuário'
         verbose_name_plural = 'Usuários'
 
+    def __str__(self):
+        return f"Nome: {self.name}, RF: {self.username}"
 
 # signals para gravação de log de campos many to many modelo User
 def m2m_changed_visoes(sender, **kwargs):


### PR DESCRIPTION
Esse PR:

1. Alterar o __str__ de user para exibir RF e nome do usuário. 
2. Altera a exportação de créditos que estava passando o usuário como parâmetro onde era esperado o username.

[AB#50157](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50157)