### PR TITLE
feat(78548): Desfaz alterações anteriores devido a mudança pela PO

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -737,7 +737,6 @@ def lancamentos_da_prestacao(
                 'periodo': f'{prestacao_conta.periodo.uuid}',
                 'conta': f'{conta_associacao.uuid}',
                 'data': despesa.data_documento if despesa.data_documento else '',
-                'data_classificacao': despesa.data_transacao if despesa.data_transacao else despesa.data_documento if despesa.data_documento else '',
                 'tipo_transacao': 'Gasto',
                 'numero_documento': despesa.numero_documento,
                 'descricao': despesa.nome_fornecedor,
@@ -782,7 +781,6 @@ def lancamentos_da_prestacao(
             'periodo': f'{prestacao_conta.periodo.uuid}',
             'conta': f'{conta_associacao.uuid}',
             'data': receita.data,
-            'data_classificacao': receita.data,
             'tipo_transacao': 'Crédito',
             'numero_documento': '',
             'descricao': receita.tipo_receita.nome if receita.tipo_receita else '',
@@ -810,7 +808,7 @@ def lancamentos_da_prestacao(
 
         if lancamentos:
             for idx, lancamento in enumerate(lancamentos):
-                if novo_lancamento['data_classificacao'] <= lancamento['data_classificacao']:
+                if novo_lancamento['data'] <= lancamento['data']:
                     lancamentos.insert(idx, novo_lancamento)
                     lancamento_adicionado = True
                     break

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -134,7 +134,6 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
                 'periodo': f'{periodo.uuid}',
                 'conta': f'{conta.uuid}',
                 'data': f'{lancamento["mestre"].data_transacao if lancamento["tipo"] == "Gasto" else lancamento["mestre"].data}',
-                'data_classificacao': f'{lancamento["mestre"].data_transacao if lancamento["tipo"] == "Gasto" else lancamento["mestre"].data}',
                 'tipo_transacao': lancamento["tipo"],
                 'numero_documento': lancamento["mestre"].numero_documento if lancamento["tipo"] == "Gasto" else "",
                 'descricao': lancamento["mestre"].nome_fornecedor if lancamento["tipo"] == "Gasto" else lancamento[


### PR DESCRIPTION
Em conversa com a PO foi solicitado alterar a classificação de despesas de data_transacao para data de documento. Isso torna essa mudança desnecessária.