### PR TITLE
fix(78926): Corrige exclusão indevida de devolução ao tesouro

### DIFF
--- a/sme_ptrf_apps/core/services/analise_prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/services/analise_prestacao_conta_service.py
@@ -23,6 +23,7 @@ def copia_ajustes_entre_analises(analise_origem, analise_destino):
         nova_solicitacao.pk = None
         nova_solicitacao.uuid = uuid.uuid4()
         nova_solicitacao.analise_lancamento = para
+        nova_solicitacao.devolucao_ao_tesouro = None  # A cópia não deve referenciar a DT
         nova_solicitacao.save()
         return nova_solicitacao
 


### PR DESCRIPTION
Agora quando as solicitações de ajuste em lançamentos são copiadas para uma nova análise, o campo de referência à devolução ao tesouro da solicitação da análise anterior não é copiado.

Corrige [AB#78926](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/78926)