### PR TITLE
fix(79496): Inclui tratamento de erro em prévia de relatório de acertos

### DIFF
--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db import models
 
 from auditlog.models import AuditlogHistoryField
@@ -5,6 +7,8 @@ from auditlog.registry import auditlog
 
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 class AnalisePrestacaoConta(ModeloBase):
@@ -150,6 +154,15 @@ class AnalisePrestacaoConta(ModeloBase):
         self.status_versao = self.STATUS_CONCLUIDO
         self.arquivo_pdf_criado_em = datetime.today()
         self.save()
+
+    def cancela_geracao_arquivo_pdf(self):
+        logging.info(f'Cancelando geração de arquivo pdf da análise {self.pk}')
+        self.arquivo_pdf = None
+        self.versao = self.VERSAO_NAO_GERADO
+        self.status_versao = self.STATUS_NAO_GERADO
+        self.arquivo_pdf_criado_em = None
+        self.save()
+        logging.info(f'Geração de arquivo pdf da análise {self.pk} cancelada')
 
     class Meta:
         verbose_name = "Análise de prestação de contas"

--- a/sme_ptrf_apps/core/services/analise_prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/services/analise_prestacao_conta_service.py
@@ -85,13 +85,23 @@ def _criar_documento_final_relatorio_acertos(analise_prestacao_uuid, usuario="")
 def _gerar_arquivos_relatorio_acertos(analise_prestacao_conta, previa, usuario=""):
     analise_prestacao_conta.inicia_geracao_arquivo_pdf(previa)
 
-    dados_relatorio_acertos = gerar_dados_relatorio_acertos(
-        analise_prestacao_conta=analise_prestacao_conta,
-        previa=previa,
-        usuario=usuario
-    )
+    try:
+        dados_relatorio_acertos = gerar_dados_relatorio_acertos(
+            analise_prestacao_conta=analise_prestacao_conta,
+            previa=previa,
+            usuario=usuario
+        )
+    except Exception as e:
+        analise_prestacao_conta.cancela_geracao_arquivo_pdf()
+        logger.error(f'Erro ao gerar dados do relatorio de acertos: {e}')
+        raise e
 
-    gerar_arquivo_relatorio_acertos_pdf(dados_relatorio_acertos, analise_prestacao_conta)
+    try:
+        gerar_arquivo_relatorio_acertos_pdf(dados_relatorio_acertos, analise_prestacao_conta)
+    except Exception as e:
+        analise_prestacao_conta.cancela_geracao_arquivo_pdf()
+        logger.error(f'Erro ao gerar arquivo pdf do relatorio de acertos: {e}')
+        raise e
 
 
 def get_ajustes_extratos_bancarios(analise_prestacao, conta_associacao=None):


### PR DESCRIPTION
Agora caso ocorra alguma exceção na geração de uma prévia de relatório de acertos, o status volta para "NÃO GERADO" permitindo ao usuário uma nova geração da prévia.

Corrige [AB#79496](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/79496)