### PR TITLE
fix(79496): Configura integração Celery e Sentry

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -3,6 +3,7 @@ from .base import env
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -151,5 +152,8 @@ LOGGING = {
 # SENTRY
 sentry_sdk.init(
     dsn=env('SENTRY_URL'),
-    integrations=[DjangoIntegration()]
+    integrations=[
+        DjangoIntegration(),
+        CeleryIntegration(),
+    ]
 )


### PR DESCRIPTION
Agora erros ocorridos em processos Celery também alimentarão o Sentry.

[AB#79496](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/79496)