### PR TITLE
fix(79315): Corrige layout do consolidado DRE

### DIFF
--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
@@ -171,14 +171,14 @@
 
         {% if valor.justificativa|length > 0 %}
           <tr>
-            <td colSpan="24" class="font-10 py-2"><strong>Justificativa da diferença entre o valor previsto pela SME e o transferido pela DRE no período</strong></td>
+            <td {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %} colSpan="24" {% else %} colSpan="20" {% endif %} class="font-10 py-2"><strong>Justificativa da diferença entre o valor previsto pela SME e o transferido pela DRE no período</strong></td>
           </tr>
         {% endif %}
 
         {% for justificativa in valor.justificativa %}
           {% if justificativa %}
             <tr>
-              <td colSpan="24" class="font-10 py-2">{{ justificativa.justificativa }}</td>
+              <td {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %} colSpan="24" {% else %} colSpan="20" {% endif %} class="font-10 py-2">{{ justificativa.justificativa }}</td>
             </tr>
           {% endif %}
         {% endfor %}
@@ -187,10 +187,10 @@
 
         {% if valor.justificativa %}
           <tr>
-            <td colSpan="24" class="font-10 py-2"><strong>Justificativa da diferença entre o valor previsto pela SME e o transferido pela DRE no período</strong></td>
+            <td {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %} colSpan="24" {% else %} colSpan="20" {% endif %} class="font-10 py-2"><strong>Justificativa da diferença entre o valor previsto pela SME e o transferido pela DRE no período</strong></td>
           </tr>
           <tr>
-            <td colSpan="24" class="font-10 py-2">{{ valor.justificativa }}</td>
+            <td {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %} colSpan="24" {% else %} colSpan="20" {% endif %} class="font-10 py-2">{{ valor.justificativa }}</td>
           </tr>
         {% endif %}
 


### PR DESCRIPTION
Corrige deslocamento na tabela do bloco 2 quando há uma justificativa de diferença de repasses informada.

O problema era causado por uma divergência no colSpan.

Corrige [AB#79315](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/79315)