### PR TITLE
fix(79837): Corrige lista de pcs para acompanhamento de PC

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -52,7 +52,7 @@ class PrestacaoContaListSerializer(serializers.ModelSerializer):
         return obj.tecnico_responsavel.nome if obj.tecnico_responsavel else ''
 
     def get_devolucao_ao_tesouro(self, obj):
-        return _str_devolucao_ao_tesouro(obj)
+        return obj.total_devolucao_ao_tesouro_str
 
     def get_unidade_tipo_unidade(self, obj):
         return obj.associacao.unidade.tipo_unidade if obj.associacao and obj.associacao.unidade else ''
@@ -111,7 +111,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
         return get_processo_sei_da_prestacao(prestacao_contas=obj)
 
     def get_devolucao_ao_tesouro(self, obj):
-        return _str_devolucao_ao_tesouro(obj)
+        return obj.total_devolucao_ao_tesouro_str
 
     def get_arquivos_referencia(self, prestacao_contas):
         result = []
@@ -237,7 +237,3 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
             'publicada',
             'referencia_consolidado_dre',
         )
-
-
-def _str_devolucao_ao_tesouro(obj):
-    return f'{obj.total_devolucao_ao_tesouro:.2f}'.replace('.', ',') if obj.devolucoes_ao_tesouro_da_prestacao.count() > 0 else 'Não'

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -112,6 +112,10 @@ class PrestacaoConta(ModeloBase):
     def total_devolucao_ao_tesouro(self):
         return self.devolucoes_ao_tesouro_da_prestacao.all().aggregate(Sum('valor'))['valor__sum'] or 0.00
 
+    @property
+    def total_devolucao_ao_tesouro_str(self):
+        return f'{self.total_devolucao_ao_tesouro:.2f}'.replace('.', ',') if self.devolucoes_ao_tesouro_da_prestacao.count() > 0 else 'Não'
+
     def __str__(self):
         return f"{self.periodo} - {self.status}"
 

--- a/sme_ptrf_apps/core/services/processos_services.py
+++ b/sme_ptrf_apps/core/services/processos_services.py
@@ -1,5 +1,11 @@
 from ..models import ProcessoAssociacao
 
+
 def get_processo_sei_da_prestacao(prestacao_contas):
     return ProcessoAssociacao.by_associacao_periodo(associacao=prestacao_contas.associacao,
                                                     periodo=prestacao_contas.periodo)
+
+
+def get_processo_sei_da_associacao_no_periodo(associacao, periodo):
+    return ProcessoAssociacao.by_associacao_periodo(associacao=associacao,
+                                                    periodo=periodo)

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_nao_recebidas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_nao_recebidas.py
@@ -176,7 +176,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_sem_filtro_po
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
 
         },
         {
@@ -191,7 +191,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_sem_filtro_po
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
     ]
 
@@ -243,7 +243,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_periodo_e_dre_nao_inclui_ou
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
 
         }
     ]
@@ -281,7 +281,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_nome_unidade(jwt_authentica
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -307,7 +307,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_nome_unidade(jwt_authentica
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -347,7 +347,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_nome_associacao(jwt_authent
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -373,7 +373,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_nome_associacao(jwt_authent
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -411,7 +411,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_tipo_unidade(jwt_authentica
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -437,7 +437,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_tipo_unidade(jwt_authentica
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -479,7 +479,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_status_nao_recebida(jwt_aut
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -520,7 +520,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_status_nao_apresentada(jwt_
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -588,7 +588,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_mais_de_um_status(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
 
         },
         {
@@ -603,7 +603,7 @@ def test_api_list_prestacoes_conta_nao_recebidas_por_mais_de_um_status(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_todos_os_status.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_list_prestacoes_conta_todos_os_status.py
@@ -190,12 +190,12 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
 
         },
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -205,7 +205,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
     ]
 
@@ -245,11 +245,11 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre_inclui_outr
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'EM_ANALISE',
@@ -259,7 +259,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_periodo_e_dre_inclui_outr
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_em_analise.uuid}',
             'associacao_uuid': f'{_associacao_a_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -288,7 +288,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(
     result_esperado = [
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -298,7 +298,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -324,7 +324,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_unidade(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -354,7 +354,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(
     result_esperado = [
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -364,7 +364,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -390,7 +390,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_nome_associacao(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -420,7 +420,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(
     result_esperado = [
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -430,7 +430,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -456,7 +456,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_tipo_unidade(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         }
 
     ]
@@ -496,7 +496,7 @@ def test_api_list_prestacoes_conta_todos_os_status_por_status_nao_apresentada(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -525,7 +525,7 @@ def test_api_list_prestacoes_conta_todos_os_status_nao_recebida(
     result_esperado = [
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -535,7 +535,7 @@ def test_api_list_prestacoes_conta_todos_os_status_nao_recebida(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -574,11 +574,11 @@ def test_api_list_prestacoes_conta_todos_os_status_nao_recebida_nao_apresentada(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -588,7 +588,7 @@ def test_api_list_prestacoes_conta_todos_os_status_nao_recebida_nao_apresentada(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 
@@ -626,11 +626,11 @@ def test_api_list_prestacoes_conta_todos_os_status_sem_filtro_por_status(
             'unidade_tipo_unidade': 'CEU',
             'uuid': '',
             'associacao_uuid': f'{_associacao_c_dre_1_todos_os_status.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
         {
             'periodo_uuid': f'{periodo_2020_1.uuid}',
-            'data_recebimento': None,
+            'data_recebimento': '2020-01-01',
             'data_ultima_analise': None,
             'processo_sei': '',
             'status': 'NAO_RECEBIDA',
@@ -640,7 +640,7 @@ def test_api_list_prestacoes_conta_todos_os_status_sem_filtro_por_status(
             'unidade_tipo_unidade': 'EMEI',
             'uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.uuid}',
             'associacao_uuid': f'{_prestacao_conta_2020_1_unidade_a_dre1_todos_os_status.associacao.uuid}',
-            'devolucao_ao_tesouro': '0,00'
+            'devolucao_ao_tesouro': 'Não'
         },
     ]
 


### PR DESCRIPTION
Informações de técnico, data de recebimento, data de última análise e devolução ao tesouro não eram incluídas nas consultas de alguns status de PC.

Corrige [AB#79837](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/79837)