### PR TITLE
fix(80956): Status realizacao dev. tesouro

### DIFF
--- a/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
@@ -117,7 +117,17 @@ class AnaliseLancamentoPrestacaoConta(ModeloBase):
         return self
 
     def passar_devolucao_tesouro_para_nao_atualizada(self):
+        from ..models import SolicitacaoAcertoLancamento
+        from ..models import TipoAcertoLancamento
+
         self.devolucao_tesouro_atualizada = False
+        devolucoes = self.solicitacoes_de_ajuste_da_analise.filter(
+            tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_DEVOLUCAO)
+
+        for devolucao in devolucoes:
+            if devolucao.status_realizacao == SolicitacaoAcertoLancamento.STATUS_REALIZACAO_REALIZADO:
+                devolucao.altera_status_realizacao(novo_status=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE)
+
         self.save()
         return self
 


### PR DESCRIPTION
fix(80956): Status realizacao dev. tesouro

Esse PR:

- Adiciona regra para alterar status realizacao ao desfazer devolução ao tesouro

História: [AB#80956](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/80956)