### PR TITLE
fix(80937): Remove termo opcional

### DIFF
--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
@@ -293,7 +293,7 @@
                     {% if acerto.detalhamento %}
                       <div class="row mt-2">
                         <div class="col-12">
-                          <span class="font-12"><strong>Detalhamento do acerto (opcional):</strong></span>
+                          <span class="font-12"><strong>Detalhamento do acerto:</strong></span>
                           <br>
                           <span class="font-12">{{ acerto.detalhamento }}</span>
                         </div>
@@ -348,7 +348,7 @@
                     {% if acertos.detalhamento %}
                       <div class="row mt-2">
                         <div class="col-12">
-                          <span class="font-12"><strong>Detalhamento do acerto (opcional)</strong></span>
+                          <span class="font-12"><strong>Detalhamento do acerto:</strong></span>
                           <br>
                           <span class="font-12">{{ acertos.detalhamento }}</span>
                         </div>


### PR DESCRIPTION
fix(80937): Remove termo opcional

Esse PR:

- Remove termo "opcional" do PDF

História: [AB#80937](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/80937)