### PR TITLE
feat(80933) Altera texto no back end e testes

### DIFF
--- a/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
+++ b/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
@@ -12,8 +12,7 @@ class MarcarComoRealizado:
 
     def __set_response(self):
         pode_atualizar_status = True
-        texto_solicitacoes_nao_atendidas = "Não é possível marcar a solicitação como realizada Não foi possível alterar o status da solicitação, "
-        "pois os ajustes solicitados não foram realizados."
+        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados."
         self.response = {
             "mensagem": "Status alterados com sucesso!",
             "status": status.HTTP_200_OK,

--- a/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
+++ b/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
@@ -12,9 +12,8 @@ class MarcarComoRealizado:
 
     def __set_response(self):
         pode_atualizar_status = True
-        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status de algumas solicitações " \
-                                           "pois os ajustes não foram realizados."
-
+        texto_solicitacoes_nao_atendidas = "Não é possível marcar a solicitação como realizada Não foi possível alterar o status da solicitação, "
+        "pois os ajustes solicitados não foram realizados."
         self.response = {
             "mensagem": "Status alterados com sucesso!",
             "status": status.HTTP_200_OK,

--- a/sme_ptrf_apps/core/services/solicitacao_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/solicitacao_acerto_lancamento_service.py
@@ -10,9 +10,7 @@ class MarcarComoRealizado:
 
     def __set_response(self):
         pode_atualizar_status = True
-        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status de algumas solicitações " \
-                                           "pois os ajustes não foram realizados."
-
+        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados."
         self.response = {
             "mensagem": "Status alterados com sucesso!",
             "status": status.HTTP_200_OK,

--- a/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_documento_service/test_service_solicitacao_acerto_documento.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_documento_service/test_service_solicitacao_acerto_documento.py
@@ -117,8 +117,7 @@ def test_service_marcar_realizado_categoria_inclusao_credito_ajuste_nao_realizad
     solicitacao_acerto_documento_pendente_service_02
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }
@@ -168,8 +167,7 @@ def test_service_marcar_realizado_categoria_inclusao_gasto_ajuste_nao_realizado(
     solicitacao_acerto_documento_pendente_service_04
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }
@@ -219,8 +217,7 @@ def test_service_marcar_realizado_categoria_solicitacao_esclarecimento_ajuste_na
     solicitacao_acerto_documento_pendente_service_06
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }

--- a/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_lancamento_service/test_service_solicitacao_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_lancamento_service/test_service_solicitacao_acerto_lancamento.py
@@ -115,8 +115,7 @@ def test_service_marcar_realizado_categoria_edicao_lancamento_ajuste_nao_realiza
     solicitacao_acerto_lancamento_pendente_categoria_edicao_lancamento_service_01
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }
@@ -166,8 +165,7 @@ def test_service_marcar_realizado_categoria_devolucao_ajuste_nao_realizado(
     solicitacao_acerto_lancamento_pendente_categoria_devolucao_service_01
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }
@@ -217,8 +215,7 @@ def test_service_marcar_realizado_categoria_exclusao_lancamento_ajuste_nao_reali
     solicitacao_acerto_lancamento_pendente_categoria_exclusao_lancamento_service_01
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }
@@ -268,8 +265,7 @@ def test_service_marcar_realizado_categoria_solicitacao_esclarecimento_ajuste_na
     solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_01
 ):
     resultado_esperado = {
-        "mensagem": "Não foi possível alterar o status de algumas solicitações pois "
-                    "os ajustes não foram realizados.",
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados.",
         "status": status.HTTP_200_OK,
         "todas_as_solicitacoes_marcadas_como_realizado": False,
     }


### PR DESCRIPTION
-[x] Ajusta texto do back-end para "Não é possível marcar a solicitação como realizada Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados."

História [AB#80933](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/80933)