### PR TITLE
fix(82839): Corrige cores de tags no PDF do relatório após acertos

### DIFF
--- a/sme_ptrf_apps/static/css/pdf-relatorio-apos-acertos.css
+++ b/sme_ptrf_apps/static/css/pdf-relatorio-apos-acertos.css
@@ -266,7 +266,7 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
     border-radius: 5px;
     margin-bottom: 10px;
     color: #fff;
-    background-color: #297805;
+    background-color: #1A8459;
     font-weight: 700;
 }
 
@@ -280,7 +280,7 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
     border-radius: 5px;
     margin-bottom: 10px;
     color: #fff;
-    background-color: #086397;
+    background-color: #5C4EF8;
     font-weight: 700;
 }
 


### PR DESCRIPTION
Corrige as cores das tags de realizado e justificado no PDF do relatório após acertos.

Corrige [AB#82839](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/82839)