### PR TITLE
feat(r6.83304) Alterações em devoluções de PCs

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -357,10 +357,13 @@ class PrestacaoConta(ModeloBase):
             data=date.today(),
             data_limite_ue=data_limite_ue
         )
-        devolucao_requer_alteracoes = False
+
+        # TODO Remover essa linha após validação da história 83304
+        # devolucao_requer_alteracoes = False
 
         if self.analise_atual:
-            devolucao_requer_alteracoes = self.analise_atual.requer_alteracao_em_lancamentos
+            # TODO Remover essa linha após validação da história 83304
+            # devolucao_requer_alteracoes = self.analise_atual.requer_alteracao_em_lancamentos
             self.analise_atual.devolucao_prestacao_conta = devolucao
             self.analise_atual.save()
 
@@ -368,13 +371,14 @@ class PrestacaoConta(ModeloBase):
         self.justificativa_pendencia_realizacao = ""
         self.save()
 
-        if devolucao_requer_alteracoes:
-            logging.info('Solicitações de ajustes requerem apagar fechamentos e documentos.')
-            self.apaga_fechamentos()
-            self.apaga_relacao_bens()
-            self.apaga_demonstrativos_financeiros()
-        else:
-            logging.info('Solicitações de ajustes NÃO requerem apagar fechamentos e documentos.')
+        # TODO Remover esse bloco após validação da história 83304
+        # if devolucao_requer_alteracoes:
+        #     logging.info('Solicitações de ajustes requerem apagar fechamentos e documentos.')
+        #     self.apaga_fechamentos()
+        #     self.apaga_relacao_bens()
+        #     self.apaga_demonstrativos_financeiros()
+        # else:
+        #     logging.info('Solicitações de ajustes NÃO requerem apagar fechamentos e documentos.')
 
         notificar_prestacao_de_contas_devolvida_para_acertos(self, data_limite_ue)
         return self

--- a/sme_ptrf_apps/core/tasks.py
+++ b/sme_ptrf_apps/core/tasks.py
@@ -49,6 +49,15 @@ def concluir_prestacao_de_contas_async(
         ultima_analise_pc = prestacao.analises_da_prestacao.order_by('id').last()
         criar_relatorio_apos_acertos_final(analise_prestacao_conta=ultima_analise_pc, usuario=usuario)
 
+    if e_retorno_devolucao and requer_geracao_documentos:
+        logging.info(f'Solicitações de ajustes requerem apagar fechamentos e documentos da pc {prestacao.uuid}.')
+        prestacao.apaga_fechamentos()
+        prestacao.apaga_relacao_bens()
+        prestacao.apaga_demonstrativos_financeiros()
+        logging.info(f'Fechamentos e documentos da pc {prestacao.uuid} apagados.')
+    else:
+        logging.info(f'Solicitações de ajustes NÃO requerem apagar fechamentos e documentos da pc {prestacao.uuid}.')
+
     if requer_geracao_documentos:
         _criar_fechamentos(acoes, contas, periodo, prestacao)
         logger.info('Fechamentos criados para a prestação de contas %s.', prestacao)


### PR DESCRIPTION
Esse PR:

- Altera a devolução de PC para não mais apagar fechamentos e relatórios no ao da devolução. 
- Altera o fechamento de uma PC devolvida para apagar os fechamentos e relatórios caso haja solicitações de correção que impliquem em mudanças em lançamentos, mas apenas se essas tiverem sido realizadas.

[AB#83304](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/83304)