### PR TITLE
feat(83473): Nao permitir justificar

### DIFF
--- a/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
+++ b/sme_ptrf_apps/core/services/solicitacao_acerto_documento_service.py
@@ -11,7 +11,6 @@ class MarcarComoRealizado:
         self.__set_response()
 
     def __set_response(self):
-        pode_atualizar_status = True
         texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados."
         self.response = {
             "mensagem": "Status alterados com sucesso!",
@@ -20,6 +19,7 @@ class MarcarComoRealizado:
         }
 
         for uuid_solicitacao in self.uuids_solicitacoes_acertos_documentos:
+            pode_atualizar_status = True
 
             solicitacao_acerto = SolicitacaoAcertoDocumento.by_uuid(uuid_solicitacao)
             categoria = solicitacao_acerto.tipo_acerto.categoria
@@ -43,6 +43,11 @@ class MarcarComoRealizado:
 
                     self.response["todas_as_solicitacoes_marcadas_como_realizado"] = False
                     self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+                    if solicitacao_acerto.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO:
+                        solicitacao_acerto.altera_status_realizacao(
+                            novo_status=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_PENDENTE,
+                        )
 
             elif categoria == TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS:
                 pode_atualizar_status = True
@@ -82,19 +87,49 @@ class JustificarNaoRealizacao:
         self.__set_response()
 
     def __set_response(self):
+        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes já foram realizados."
 
         self.response = {
             "mensagem": "Status alterados com sucesso!",
             "status": status.HTTP_200_OK,
+            "todas_as_solicitacoes_marcadas_como_justificado": True,
         }
 
         for uuid_solicitacao in self.uuids_solicitacoes_acertos_documentos:
-            solicitacao_acerto = SolicitacaoAcertoDocumento.by_uuid(uuid_solicitacao)
+            pode_atualizar_status = True
 
-            solicitacao_acerto.altera_status_realizacao(
-                novo_status=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO,
-                justificativa=self.justificativa
-            )
+            solicitacao_acerto = SolicitacaoAcertoDocumento.by_uuid(uuid_solicitacao)
+            categoria = solicitacao_acerto.tipo_acerto.categoria
+
+            if categoria == TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO:
+                if solicitacao_acerto.receita_incluida:
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO:
+                if solicitacao_acerto.despesa_incluida:
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO:
+                if solicitacao_acerto.esclarecimentos != "":
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS:
+                pode_atualizar_status = True
+
+            if pode_atualizar_status:
+                solicitacao_acerto.altera_status_realizacao(
+                    novo_status=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO,
+                    justificativa=self.justificativa
+                )
 
 
 class SolicitacaoAcertoDocumentoService:

--- a/sme_ptrf_apps/core/services/solicitacao_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/solicitacao_acerto_lancamento_service.py
@@ -9,7 +9,6 @@ class MarcarComoRealizado:
         self.__set_response()
 
     def __set_response(self):
-        pode_atualizar_status = True
         texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes solicitados não foram realizados."
         self.response = {
             "mensagem": "Status alterados com sucesso!",
@@ -18,6 +17,7 @@ class MarcarComoRealizado:
         }
 
         for uuid_solicitacao in self.uuids_solicitacoes_acertos_lancamentos:
+            pode_atualizar_status = True
 
             solicitacao_acerto = SolicitacaoAcertoLancamento.by_uuid(uuid_solicitacao)
             analise_lancamento = solicitacao_acerto.analise_lancamento
@@ -51,6 +51,11 @@ class MarcarComoRealizado:
                     self.response["todas_as_solicitacoes_marcadas_como_realizado"] = False
                     self.response["mensagem"] = texto_solicitacoes_nao_atendidas
 
+                    if solicitacao_acerto.status_realizacao == SolicitacaoAcertoLancamento.STATUS_REALIZACAO_JUSTIFICADO:
+                        solicitacao_acerto.altera_status_realizacao(
+                            novo_status=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE,
+                        )
+
             elif categoria == TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS:
                 pode_atualizar_status = True
 
@@ -68,19 +73,59 @@ class JustificarNaoRealizacao:
         self.__set_response()
 
     def __set_response(self):
+        texto_solicitacoes_nao_atendidas = "Não foi possível alterar o status da solicitação, pois os ajustes já foram realizados."
 
         self.response = {
             "mensagem": "Status alterados com sucesso!",
             "status": status.HTTP_200_OK,
+            "todas_as_solicitacoes_marcadas_como_justificado": True,
         }
 
         for uuid_solicitacao in self.uuids_solicitacoes_acertos_lancamentos:
-            solicitacao_acerto = SolicitacaoAcertoLancamento.by_uuid(uuid_solicitacao)
+            pode_atualizar_status = True
 
-            solicitacao_acerto.altera_status_realizacao(
-                novo_status=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_JUSTIFICADO,
-                justificativa=self.justificativa
-            )
+            solicitacao_acerto = SolicitacaoAcertoLancamento.by_uuid(uuid_solicitacao)
+            analise_lancamento = solicitacao_acerto.analise_lancamento
+            categoria = solicitacao_acerto.tipo_acerto.categoria
+
+            if categoria == TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO:
+                if analise_lancamento.lancamento_atualizado:
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoLancamento.CATEGORIA_DEVOLUCAO:
+                if analise_lancamento.devolucao_tesouro_atualizada:
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO:
+                if analise_lancamento.lancamento_excluido:
+                    pode_atualizar_status = False
+
+                    self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                    self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO:
+                if solicitacao_acerto.esclarecimentos is not None:
+                    if solicitacao_acerto.esclarecimentos != "":
+                        pode_atualizar_status = False
+
+                        self.response["todas_as_solicitacoes_marcadas_como_justificado"] = False
+                        self.response["mensagem"] = texto_solicitacoes_nao_atendidas
+
+            elif categoria == TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS:
+                pode_atualizar_status = True
+
+
+            if pode_atualizar_status:
+                solicitacao_acerto.altera_status_realizacao(
+                    novo_status=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_JUSTIFICADO,
+                    justificativa=self.justificativa
+                )
 
 
 class LimparStatus:

--- a/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_documento_service/test_service_solicitacao_acerto_documento.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_documento_service/test_service_solicitacao_acerto_documento.py
@@ -36,12 +36,45 @@ def test_service_limpar_status(
 
 
 def test_service_justificar_nao_realizado(
-    solicitacao_acerto_documento_pendente_service_01,
+    solicitacao_acerto_documento_pendente_service_04,
     solicitacao_acerto_documento_pendente_service_02
 ):
     resultado_esperado = {
         "mensagem": "Status alterados com sucesso!",
-        "status": status.HTTP_200_OK
+        "status": status.HTTP_200_OK,
+        "todas_as_solicitacoes_marcadas_como_justificado": True
+    }
+
+    uuids_solicitacoes = [
+        f"{solicitacao_acerto_documento_pendente_service_04.uuid}",
+        f"{solicitacao_acerto_documento_pendente_service_02.uuid}"
+    ]
+
+    justificativa = "justificativa teste"
+
+    result = SolicitacaoAcertoDocumentoService.justificar_nao_realizacao(
+        uuids_solicitacoes_acertos_documentos=uuids_solicitacoes,
+        justificativa=justificativa
+    )
+
+    solicitacao_1 = SolicitacaoAcertoDocumento.by_uuid(solicitacao_acerto_documento_pendente_service_04.uuid)
+    solicitacao_2 = SolicitacaoAcertoDocumento.by_uuid(solicitacao_acerto_documento_pendente_service_02.uuid)
+
+    assert solicitacao_1.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO
+    assert solicitacao_1.justificativa == justificativa
+    assert solicitacao_2.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO
+    assert solicitacao_2.justificativa == justificativa
+    assert resultado_esperado == result
+
+
+def test_service_justificar_nao_realizado_lote_ajuste_realizado_e_nao_realizado(
+    solicitacao_acerto_documento_pendente_service_01,
+    solicitacao_acerto_documento_pendente_service_02
+):
+    resultado_esperado = {
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes já foram realizados.",
+        "status": status.HTTP_200_OK,
+        "todas_as_solicitacoes_marcadas_como_justificado": False
     }
 
     uuids_solicitacoes = [
@@ -59,8 +92,8 @@ def test_service_justificar_nao_realizado(
     solicitacao_1 = SolicitacaoAcertoDocumento.by_uuid(solicitacao_acerto_documento_pendente_service_01.uuid)
     solicitacao_2 = SolicitacaoAcertoDocumento.by_uuid(solicitacao_acerto_documento_pendente_service_02.uuid)
 
-    assert solicitacao_1.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO
-    assert solicitacao_1.justificativa == justificativa
+    assert solicitacao_1.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_PENDENTE
+    assert solicitacao_1.justificativa is None
     assert solicitacao_2.status_realizacao == SolicitacaoAcertoDocumento.STATUS_REALIZACAO_JUSTIFICADO
     assert solicitacao_2.justificativa == justificativa
     assert resultado_esperado == result

--- a/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_lancamento_service/test_service_solicitacao_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_solicitacao_acertos_lancamento_service/test_service_solicitacao_acerto_lancamento.py
@@ -38,7 +38,8 @@ def test_service_justificar_nao_realizado(
 ):
     resultado_esperado = {
         "mensagem": "Status alterados com sucesso!",
-        "status": status.HTTP_200_OK
+        "status": status.HTTP_200_OK,
+        "todas_as_solicitacoes_marcadas_como_justificado": True
     }
 
     uuids_solicitacoes = [
@@ -60,6 +61,39 @@ def test_service_justificar_nao_realizado(
     assert solicitacao_1.justificativa == justificativa
     assert solicitacao_2.status_realizacao == SolicitacaoAcertoLancamento.STATUS_REALIZACAO_JUSTIFICADO
     assert solicitacao_2.justificativa == justificativa
+    assert resultado_esperado == result
+
+
+def test_service_justificar_nao_realizado_lote_ajuste_realizado_e_nao_realizado(
+    solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_01,
+    solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_02
+):
+    resultado_esperado = {
+        "mensagem": "Não foi possível alterar o status da solicitação, pois os ajustes já foram realizados.",
+        "status": status.HTTP_200_OK,
+        "todas_as_solicitacoes_marcadas_como_justificado": False
+    }
+
+    uuids_solicitacoes = [
+        f"{solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_01.uuid}",
+        f"{solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_02.uuid}"
+    ]
+
+    justificativa = "justificativa teste"
+
+
+    result = SolicitacaoAcertoLancamentoService.justificar_nao_realizacao(
+        uuids_solicitacoes_acertos_lancamentos=uuids_solicitacoes,
+        justificativa=justificativa
+    )
+
+    solicitacao_1 = SolicitacaoAcertoLancamento.by_uuid(solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_01.uuid)
+    solicitacao_2 = SolicitacaoAcertoLancamento.by_uuid(solicitacao_acerto_lancamento_pendente_categoria_solicitacao_esclarecimento_service_02.uuid)
+
+    assert solicitacao_1.status_realizacao == SolicitacaoAcertoLancamento.STATUS_REALIZACAO_JUSTIFICADO
+    assert solicitacao_1.justificativa == justificativa
+
+    assert solicitacao_2.status_realizacao == SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE
     assert resultado_esperado == result
 
 


### PR DESCRIPTION
feat(83473): Nao permitir justificar

Esse PR:

- Adiciona regra nas solicitacoes de lancamentos para não permitir justificar acertos que ja tenham sido realizados
- Adiciona regra nas solicitacoes de documentos para não permitir justificar acertos que ja tenham sido realizados
- Adiciona regra para voltar para status pendente quando o usuario tentar marcar como realizado um acerto justificado da categoria solicitação de esclarecimento
- Altera testes relacionados

História: [AB#83473](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/83473)