### PR TITLE
fix(85660): Monitoramento de PCs: reversão de devoluções não pode apagar os arquivos, apenas alterar o status para devolvido

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -7,12 +7,12 @@ from django.db.models import Q
 from django.db import transaction
 from django.db.models.aggregates import Sum
 
+from sme_ptrf_apps.core.models import Ata
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from sme_ptrf_apps.dre.models import Atribuicao
 
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
-
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,8 @@ class PrestacaoConta(ModeloBase):
 
     motivos_aprovacao_ressalva = models.ManyToManyField('dre.MotivoAprovacaoRessalva', blank=True)
 
-    outros_motivos_aprovacao_ressalva = models.TextField('Outros motivos para aprovação com ressalvas pela DRE', blank=True, default='')
+    outros_motivos_aprovacao_ressalva = models.TextField('Outros motivos para aprovação com ressalvas pela DRE',
+                                                         blank=True, default='')
 
     analise_atual = models.ForeignKey('AnalisePrestacaoConta', on_delete=models.SET_NULL,
                                       related_name='+',
@@ -100,7 +101,8 @@ class PrestacaoConta(ModeloBase):
                                         related_name='prestacoes_de_conta_do_consolidado_dre',
                                         blank=True, null=True)
 
-    justificativa_pendencia_realizacao = models.TextField('Justificativa de pendências de realização de ajustes.', blank=True, default='')
+    justificativa_pendencia_realizacao = models.TextField('Justificativa de pendências de realização de ajustes.',
+                                                          blank=True, default='')
 
     @property
     def tecnico_responsavel(self):
@@ -117,7 +119,8 @@ class PrestacaoConta(ModeloBase):
 
     @property
     def total_devolucao_ao_tesouro_str(self):
-        return f'{self.total_devolucao_ao_tesouro:.2f}'.replace('.', ',') if self.devolucoes_ao_tesouro_da_prestacao.count() > 0 else 'Não'
+        return f'{self.total_devolucao_ao_tesouro:.2f}'.replace('.',
+                                                                ',') if self.devolucoes_ao_tesouro_da_prestacao.count() > 0 else 'Não'
 
     def __str__(self):
         return f"{self.periodo} - {self.status}"
@@ -377,7 +380,8 @@ class PrestacaoConta(ModeloBase):
 
     @transaction.atomic
     def concluir_analise(self, resultado_analise, analises_de_conta_da_prestacao, motivos_aprovacao_ressalva,
-                         outros_motivos_aprovacao_ressalva, data_limite_ue, motivos_reprovacao, outros_motivos_reprovacao, recomendacoes):
+                         outros_motivos_aprovacao_ressalva, data_limite_ue, motivos_reprovacao,
+                         outros_motivos_reprovacao, recomendacoes):
 
         from ..services.notificacao_services import notificar_prestacao_de_contas_aprovada
 
@@ -404,7 +408,8 @@ class PrestacaoConta(ModeloBase):
 
         if resultado_analise == PrestacaoConta.STATUS_APROVADA_RESSALVA:
             try:
-                notificar_prestacao_de_contas_aprovada_com_ressalvas(self, motivos_aprovacao_ressalva, outros_motivos_aprovacao_ressalva)
+                notificar_prestacao_de_contas_aprovada_com_ressalvas(self, motivos_aprovacao_ressalva,
+                                                                     outros_motivos_aprovacao_ressalva)
             except Exception as erro:
                 logger.error(f'Houve um erro ao notificar aprovação com ressalva da PC. {erro}')
 
@@ -439,6 +444,16 @@ class PrestacaoConta(ModeloBase):
         logger.info(f'Apagando a prestação de contas de uuid {uuid}.')
         try:
             prestacao_de_conta = cls.by_uuid(uuid=uuid)
+
+            ata_da_pc = prestacao_de_conta.atas_da_prestacao.first()
+
+            if ata_da_pc:
+                ata_da_pc.prestacao_conta = None
+                ata_da_pc.previa = True
+                ata_da_pc.arquivo_pdf = None
+                ata_da_pc.status_geracao_pdf = Ata.STATUS_NAO_GERADO
+                ata_da_pc.save()
+
             prestacao_de_conta.apaga_fechamentos()
             prestacao_de_conta.apaga_relacao_bens()
             prestacao_de_conta.apaga_demonstrativos_financeiros()
@@ -466,7 +481,8 @@ class PrestacaoConta(ModeloBase):
         return cls.objects.filter(associacao=associacao, periodo=periodo).first()
 
     @classmethod
-    def dashboard(cls, periodo_uuid, dre_uuid, add_aprovado_ressalva=False, add_info_devolvidas_retornadas=False, apenas_nao_publicadas=False):
+    def dashboard(cls, periodo_uuid, dre_uuid, add_aprovado_ressalva=False, add_info_devolvidas_retornadas=False,
+                  apenas_nao_publicadas=False):
         """
         :param add_aprovado_ressalva: True para retornar a quantidade de aprovados com ressalva separadamente ou
         False para retornar a quantidade de aprovadas com ressalva somada a quantidade de aprovadas
@@ -492,7 +508,8 @@ class PrestacaoConta(ModeloBase):
         if not apenas_nao_publicadas:
             qs = cls.objects.filter(periodo__uuid=periodo_uuid, associacao__unidade__dre__uuid=dre_uuid)
         else:
-            qs = cls.objects.filter(periodo__uuid=periodo_uuid, associacao__unidade__dre__uuid=dre_uuid, publicada=False)
+            qs = cls.objects.filter(periodo__uuid=periodo_uuid, associacao__unidade__dre__uuid=dre_uuid,
+                                    publicada=False)
 
         quantidade_pcs_apresentadas = 0
         for status, titulo in titulos_por_status.items():
@@ -505,7 +522,8 @@ class PrestacaoConta(ModeloBase):
                 quantidade_status += qs.filter(status=cls.STATUS_APROVADA_RESSALVA).count()
 
             if status == cls.STATUS_DEVOLVIDA:
-                quantidade_status += qs.filter(status__in=[cls.STATUS_DEVOLVIDA_RETORNADA, cls.STATUS_DEVOLVIDA_RECEBIDA]).count()
+                quantidade_status += qs.filter(
+                    status__in=[cls.STATUS_DEVOLVIDA_RETORNADA, cls.STATUS_DEVOLVIDA_RECEBIDA]).count()
 
             quantidade_pcs_apresentadas += quantidade_status
 
@@ -595,7 +613,8 @@ class PrestacaoConta(ModeloBase):
             qs = cls.objects.filter(periodo__uuid=periodo_uuid, associacao__unidade__dre__uuid=dre.uuid)
 
             quantidade_pcs_apresentadas = 0
-            qtd_por_status['TOTAL_UNIDADES'] = Associacao.objects.filter(unidade__dre__uuid=dre.uuid).exclude(cnpj__exact='').count()
+            qtd_por_status['TOTAL_UNIDADES'] = Associacao.objects.filter(unidade__dre__uuid=dre.uuid).exclude(
+                cnpj__exact='').count()
 
             for status in qtd_por_status.keys():
                 if status == 'TOTAL_UNIDADES' or status == cls.STATUS_NAO_APRESENTADA:
@@ -640,7 +659,7 @@ class PrestacaoConta(ModeloBase):
         result = [{
             'id': choice[0],
             'nome': choice[1]
-            } for choice in cls.STATUS_CHOICES if choice[0] not in cls._status_nao_selecionaveis()]
+        } for choice in cls.STATUS_CHOICES if choice[0] not in cls._status_nao_selecionaveis()]
 
         return result
 

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -627,7 +627,8 @@ def lancamentos_da_prestacao(
     from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaConciliacaoSerializer
     from sme_ptrf_apps.receitas.api.serializers.receita_serializer import ReceitaConciliacaoSerializer
     from sme_ptrf_apps.core.api.serializers.analise_lancamento_prestacao_conta_serializer import \
-        AnaliseLancamentoPrestacaoContaRetrieveSerializer, AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer
+        AnaliseLancamentoPrestacaoContaRetrieveSerializer, \
+        AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer
 
     def documentos_de_despesa_por_conta_e_acao_no_periodo(
         conta_associacao,
@@ -728,7 +729,8 @@ def lancamentos_da_prestacao(
             despesas_filter = despesa.rateios.filter(status=STATUS_COMPLETO, conta_associacao=conta_associacao)
 
             if inclui_inativas:
-                despesas_filter = despesa.rateios.exclude(status=STATUS_INCOMPLETO).filter(conta_associacao=conta_associacao)
+                despesas_filter = despesa.rateios.exclude(status=STATUS_INCOMPLETO).filter(
+                    conta_associacao=conta_associacao)
             for rateio in despesas_filter:
                 if rateio.notificar_dias_nao_conferido > max_notificar_dias_nao_conferido:
                     max_notificar_dias_nao_conferido = rateio.notificar_dias_nao_conferido
@@ -754,7 +756,8 @@ def lancamentos_da_prestacao(
                 'descricao': despesa.nome_fornecedor,
                 'valor_transacao_total': despesa.valor_total,
                 'valor_transacao_na_conta': despesas_filter.aggregate(Sum('valor_rateio'))['valor_rateio__sum'],
-                'valores_por_conta': despesas_filter.values('conta_associacao__tipo_conta__nome').annotate(Sum('valor_rateio')),
+                'valores_por_conta': despesas_filter.values('conta_associacao__tipo_conta__nome').annotate(
+                    Sum('valor_rateio')),
                 'conferido': despesa.conferido,
                 'documento_mestre': DespesaDocumentoMestreSerializer(despesa, many=False).data,
                 'rateios': RateioDespesaConciliacaoSerializer(despesas_filter.order_by('id'), many=True).data,
@@ -775,7 +778,8 @@ def lancamentos_da_prestacao(
                         analise_lancamento,
                         many=False).data
                 else:
-                    lancamento['analise_lancamento'] = AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer(
+                    lancamento[
+                        'analise_lancamento'] = AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer(
                         analise_lancamento,
                         many=False).data
             else:
@@ -820,7 +824,8 @@ def lancamentos_da_prestacao(
                     analise_lancamento,
                     many=False).data
             else:
-                novo_lancamento['analise_lancamento'] = AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer(
+                novo_lancamento[
+                    'analise_lancamento'] = AnaliseLancamentoPrestacaoContaSolicitacoesNaoAgrupadasRetrieveSerializer(
                     analise_lancamento,
                     many=False).data
 
@@ -900,7 +905,6 @@ def marca_lancamentos_como_corretos(analise_prestacao, lancamentos_corretos):
             minhas_solicitacoes = minha_analise_lancamento.solicitacoes_de_ajuste_da_analise.all()
 
             for solicitacao_acerto in minhas_solicitacoes:
-
                 # TODO Remover o bloco comentado após conclusão da mudança em solicitações de dev.tesouro
                 # if solicitacao_acerto.copiado:
                 #     devolucao_ao_tesouro = solicitacao_acerto.devolucao_ao_tesouro
@@ -1005,7 +1009,8 @@ def __cria_analise_lancamento_solicitacao_acerto(analise_prestacao, lancamento):
 
 
 def __analisa_solicitacoes_acerto(solicitacoes_acerto, analise_lancamento, atualizacao_em_lote):
-    logging.info(f'Verificando quais solicitações de ajustes existentes devem ser apagadas para a análise de lançamento {analise_lancamento.uuid}.')
+    logging.info(
+        f'Verificando quais solicitações de ajustes existentes devem ser apagadas para a análise de lançamento {analise_lancamento.uuid}.')
 
     keep_solicitacoes = []
     for solicitacao_acerto in solicitacoes_acerto:
@@ -1019,12 +1024,15 @@ def __analisa_solicitacoes_acerto(solicitacoes_acerto, analise_lancamento, atual
                 solicitacao_encontrada.save()
 
                 # Realizando update na solicitação de devolucao ao tesouro da solicitação encontrada
-                if hasattr(solicitacao_encontrada, 'solicitacao_devolucao_ao_tesouro') and solicitacao_encontrada.solicitacao_devolucao_ao_tesouro:
+                if hasattr(solicitacao_encontrada,
+                           'solicitacao_devolucao_ao_tesouro') and solicitacao_encontrada.solicitacao_devolucao_ao_tesouro:
                     tipo_devolucao_ao_tesouro = TipoDevolucaoAoTesouro.objects.get(
                         uuid=solicitacao_acerto['devolucao_tesouro']['tipo'])
                     solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.tipo = tipo_devolucao_ao_tesouro
-                    solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.devolucao_total = solicitacao_acerto['devolucao_tesouro']['devolucao_total']
-                    solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.valor = solicitacao_acerto['devolucao_tesouro']['valor']
+                    solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.devolucao_total = \
+                    solicitacao_acerto['devolucao_tesouro']['devolucao_total']
+                    solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.valor = \
+                    solicitacao_acerto['devolucao_tesouro']['valor']
                     solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.motivo = solicitacao_acerto['detalhamento']
 
                     solicitacao_encontrada.solicitacao_devolucao_ao_tesouro.save()
@@ -1056,19 +1064,20 @@ def __analisa_solicitacoes_acerto(solicitacoes_acerto, analise_lancamento, atual
                 logging.info(f'Criando solicitação de acerto para a análise de lançamento {analise_lancamento.uuid}.')
 
                 solicitacao_criada = SolicitacaoAcertoLancamento.objects.create(
-                                        analise_lancamento=analise_lancamento,
-                                        tipo_acerto=tipo_acerto,
-                                        devolucao_ao_tesouro=None,  # devolucao_tesouro,
-                                        detalhamento=solicitacao_acerto['detalhamento'],
-                                        status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE
-                                    )
+                    analise_lancamento=analise_lancamento,
+                    tipo_acerto=tipo_acerto,
+                    devolucao_ao_tesouro=None,  # devolucao_tesouro,
+                    detalhamento=solicitacao_acerto['detalhamento'],
+                    status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE
+                )
 
                 logging.info(f"Solicitação criada: {solicitacao_criada}.")
 
                 keep_solicitacoes.append(solicitacao_criada.uuid)
 
             if analise_lancamento.tipo_lancamento == 'GASTO' and solicitacao_acerto['devolucao_tesouro']:
-                logging.info(f'Criando solicitação de devolução ao tesouro para a análise de lançamento {analise_lancamento.uuid}.')
+                logging.info(
+                    f'Criando solicitação de devolução ao tesouro para a análise de lançamento {analise_lancamento.uuid}.')
                 solicitacao_devolucao_ao_tesouro = SolicitacaoDevolucaoAoTesouro.objects.create(
                     solicitacao_acerto_lancamento=solicitacao_criada,
                     tipo=TipoDevolucaoAoTesouro.objects.get(uuid=solicitacao_acerto['devolucao_tesouro']['tipo']),
@@ -1162,7 +1171,8 @@ def documentos_da_prestacao(analise_prestacao_conta):
             contas_com_movimento = analise_prestacao_conta.prestacao_conta.get_contas_com_movimento(
                 add_sem_movimento_com_saldo=True)
             for conta in contas_com_movimento:
-                if documento.e_relacao_bens and not analise_prestacao_conta.prestacao_conta.relacoes_de_bens_da_prestacao.filter(conta_associacao=conta).exists():
+                if documento.e_relacao_bens and not analise_prestacao_conta.prestacao_conta.relacoes_de_bens_da_prestacao.filter(
+                    conta_associacao=conta).exists():
                     continue
                 documentos.append(result_documento(documento, conta))
         else:
@@ -1502,33 +1512,57 @@ class MonitoraPC:
 
                 if pc.status == self.status:
 
-                    self.revoke_tasks_by_name(
-                        task_name='sme_ptrf_apps.core.tasks.concluir_prestacao_de_contas_async'
-                    )
+                    try:
 
-                    reaberta = reabrir_prestacao_de_contas(self.uuid_prestacao_de_contas)
-                    if reaberta:
-                        logger.info(f"Monitoramento de PC: Prestação de contas reaberta com sucesso. Todos os seus "
+                        self.revoke_tasks_by_name(
+                            task_name='sme_ptrf_apps.core.tasks.concluir_prestacao_de_contas_async'
+                        )
+
+                        ultima_analise = pc.analises_da_prestacao.last()
+
+                        if ultima_analise:
+                            pc.status = PrestacaoConta.STATUS_DEVOLVIDA
+                            pc.save()
+                            logger.info(
+                                f"Monitoramento de PC: Prestação de contas passada para status DEVOLVIDA com sucesso.")
+
+                            notificar_erro_ao_concluir_pc(
+                                prestacao_de_contas=None,
+                                usuario=self.usuario,
+                                associacao=self.associacao,
+                                periodo=periodo,
+                            )
+                        else:
+                            reaberta = reabrir_prestacao_de_contas(self.uuid_prestacao_de_contas)
+
+                            if reaberta:
+                                logger.info(
+                                    f"Monitoramento de PC: Prestação de contas reaberta com sucesso. Todos os seus "
                                     f"registros foram apagados.")
 
-                        notificar_erro_ao_concluir_pc(
-                            prestacao_de_contas=None,
-                            usuario=self.usuario,
-                            associacao=self.associacao,
-                            periodo=periodo,
-                        )
-                    else:
-                        logger.info(f"Monitoramento de PC: Houve algum erro ao tentar reabrir a prestação de contas.")
+                                notificar_erro_ao_concluir_pc(
+                                    prestacao_de_contas=None,
+                                    usuario=self.usuario,
+                                    associacao=self.associacao,
+                                    periodo=periodo,
+                                )
+                            else:
+                                logger.info(
+                                    f"Monitoramento de PC: Houve algum erro ao tentar reabrir a prestação de contas.")
+
+                    except Exception as e:
+                        logger.info(f"Monitoramento de PC: Houve algum erro ao no processo de monitoramento de PC. {e}")
+
         if self.t:
             self.t.cancel()
 
     def set_interval(self, func, sec):
         pc = PrestacaoConta.objects.filter(uuid=self.uuid_prestacao_de_contas).first()
+
         if pc:
             periodo = pc.periodo
 
             if periodo:
-
                 import threading
 
                 def func_wrapper():
@@ -1555,9 +1589,12 @@ class MonitoraPC:
             )
         """
 
-        for worker_name, tasks in c.inspect().active().items():
-            if worker_name.startswith(worker_prefix):
-                for task in tasks:
-                    if task['type'] == task_name:
-                        print('Revoking task {}'.format(task))
-                        c.revoke(task['id'], terminate=True)
+        items = c.inspect().active().items() if c and c.inspect() and c.inspect().active() and c.inspect().active().items() else None
+
+        if items:
+            for worker_name, tasks in items:
+                if worker_name.startswith(worker_prefix):
+                    for task in tasks:
+                        if task['type'] == task_name:
+                            print('Revoking task {}'.format(task))
+                            c.revoke(task['id'], terminate=True)

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/test_monitora_prestacao_de_contas_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/test_monitora_prestacao_de_contas_service.py
@@ -1,0 +1,209 @@
+import time
+from datetime import date
+
+import pytest
+from model_bakery import baker
+
+from sme_ptrf_apps.core.models import Notificacao, PrestacaoConta
+
+pytestmark = pytest.mark.django_db
+
+from sme_ptrf_apps.core.services.prestacao_contas_services import concluir_prestacao_de_contas
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def create_user(django_user_model):
+    def make_user(**kwargs):
+        return django_user_model.objects.create_user(**kwargs)
+
+    return make_user
+
+
+@pytest.fixture
+def usuario_notificavel():
+    from django.contrib.auth import get_user_model
+
+    senha = 'Sgp0418'
+    login = '2711001'
+    email = 'notificavel@amcom.com.br'
+
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email)
+    user.save()
+    return user
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def periodo_anterior():
+    return baker.make(
+        'Periodo',
+        referencia='2019.1',
+        data_inicio_realizacao_despesas=date(2019, 1, 1),
+        data_fim_realizacao_despesas=date(2019, 8, 31),
+    )
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def periodo(periodo_anterior):
+    return baker.make(
+        'Periodo',
+        referencia='2019.2',
+        data_inicio_realizacao_despesas=date(2019, 9, 1),
+        data_fim_realizacao_despesas=date(2019, 11, 30),
+        data_prevista_repasse=date(2019, 10, 1),
+        data_inicio_prestacao_contas=date(2019, 12, 1),
+        data_fim_prestacao_contas=date(2019, 12, 5),
+        periodo_anterior=periodo_anterior,
+    )
+
+
+@pytest.fixture
+def devolucao_prestacao_conta_2020_1_monitora_pc(prestacao_conta_com_analise_nao_apresentada):
+    return baker.make(
+        'DevolucaoPrestacaoConta',
+        prestacao_conta=prestacao_conta_com_analise_nao_apresentada,
+        data=date(2020, 7, 1),
+        data_limite_ue=date(2020, 8, 1),
+        data_retorno_ue=None
+    )
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def analise_prestacao_conta_2020_1_monitora_pc(prestacao_conta_com_analise_nao_apresentada,
+                                               devolucao_prestacao_conta_2020_1_monitora_pc):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_com_analise_nao_apresentada,
+        devolucao_prestacao_conta=devolucao_prestacao_conta_2020_1_monitora_pc
+    )
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def prestacao_conta_com_analise_nao_apresentada(periodo, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo,
+        associacao=associacao,
+        data_recebimento=date(2020, 10, 1),
+        data_ultima_analise=date(2020, 10, 1),
+        status='NAO_APRESENTADA',
+    )
+
+
+@pytest.mark.django_db(True)
+@pytest.fixture
+def prestacao_conta_com_analise_nao_apresentada_02(periodo, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo,
+        associacao=associacao,
+        status='NAO_APRESENTADA',
+    )
+
+
+@pytest.fixture
+def parametros_monitora_pc():
+    return baker.make(
+        'Parametros',
+        tempo_aguardar_conclusao_pc=1,
+        permite_saldo_conta_negativo=True,
+        fique_de_olho='',
+        fique_de_olho_relatorio_dre='',
+        texto_pagina_suporte_dre='Teste DRE',
+        texto_pagina_suporte_sme='Teste SME',
+        texto_pagina_valores_reprogramados_ue='Teste UE',
+        texto_pagina_valores_reprogramados_dre='Teste DRE'
+    )
+
+
+@pytest.mark.django_db(True)
+def test_monitora_pc_deve_passar_pc_para_devolvida(
+    prestacao_conta_com_analise_nao_apresentada,
+    analise_prestacao_conta_2020_1_monitora_pc,
+    devolucao_prestacao_conta_2020_1_monitora_pc,
+    periodo,
+    associacao,
+    usuario_notificavel,
+    parametros_monitora_pc,
+):
+    uuid_pc = prestacao_conta_com_analise_nao_apresentada.uuid
+
+    pc = PrestacaoConta.by_uuid(uuid_pc)
+
+    assert pc.status == 'NAO_APRESENTADA'
+
+    assert not Notificacao.objects.filter(
+        usuario=usuario_notificavel,
+        categoria="ERRO_AO_CONCLUIR_PC",
+        prestacao_conta=None,
+        periodo=periodo,
+        unidade=associacao.unidade
+    ).exists()
+
+    concluir_prestacao_de_contas(
+        associacao=associacao,
+        periodo=periodo,
+        usuario=usuario_notificavel,
+        monitoraPc=True,
+    )
+    time.sleep(10)
+
+    pc = PrestacaoConta.by_uuid(uuid_pc)
+
+    assert pc.status == 'DEVOLVIDA'
+
+    assert Notificacao.objects.filter(
+        usuario=usuario_notificavel,
+        categoria="ERRO_AO_CONCLUIR_PC",
+        prestacao_conta=None,
+        periodo=periodo,
+        unidade=associacao.unidade
+    ).exists()
+
+
+@pytest.mark.django_db(True)
+def test_monitora_pc_deve_reabrir_pc(
+    periodo,
+    associacao,
+    usuario_notificavel,
+    parametros_monitora_pc,
+):
+    assert not Notificacao.objects.filter(
+        usuario=usuario_notificavel,
+        categoria="ERRO_AO_CONCLUIR_PC",
+        prestacao_conta=None,
+        periodo=periodo,
+        unidade=associacao.unidade
+    ).exists()
+
+    concluir_prestacao_de_contas(
+        associacao=associacao,
+        periodo=periodo,
+        usuario=usuario_notificavel,
+        monitoraPc=True,
+    )
+
+    assert PrestacaoConta.objects.filter(
+        associacao=associacao,
+        periodo=periodo,
+    ).exists()
+
+    time.sleep(10)
+
+    assert Notificacao.objects.filter(
+        usuario=usuario_notificavel,
+        categoria="ERRO_AO_CONCLUIR_PC",
+        prestacao_conta=None,
+        periodo=periodo,
+        unidade=associacao.unidade
+    ).exists()
+
+    assert not PrestacaoConta.objects.filter(
+        associacao=associacao,
+        periodo=periodo,
+    ).exists()


### PR DESCRIPTION
Esse PR:

- Implementa Monitoramento de PC - Reversão sem apagar arquivos

História: [AB#85660](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85660)