### PR TITLE
fix(85017): Corrige verificação de saldo em despesas com períodos fechados

### DIFF
--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/conftest.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/conftest.py
@@ -1,5 +1,7 @@
 import pytest
+import datetime
 
+from model_bakery import baker
 
 @pytest.fixture
 def payload_despesa_valida(
@@ -127,6 +129,164 @@ def payload_despesa_valida_anterior_periodo_inicial(
                 "valor_rateio": 1000.00,
                 "quantidade_itens_capital": 2,
                 "valor_item_capital": 500.00,
+                "numero_processo_incorporacao_capital": "6234673223462364632"
+            }
+        ]
+    }
+    return payload
+
+
+@pytest.fixture
+def payload_despesa_justa(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    conta_associacao,
+    acao_associacao,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    especificacao_material_servico,
+):
+    payload = {
+        "associacao": f'{associacao.uuid}',
+        "tipo_documento": tipo_documento.id,
+        "tipo_transacao": tipo_transacao.id,
+        "numero_documento": "634767",
+        "data_documento": "2020-03-10",
+        "cpf_cnpj_fornecedor": "36.352.197/0001-75",
+        "nome_fornecedor": "FORNECEDOR TESTE SA",
+        "data_transacao": "2020-03-10",
+        "valor_total": 110.50,
+        "valor_recursos_proprios": 10.50,
+        "rateios": [
+            {
+                "associacao": f'{associacao.uuid}',
+                "conta_associacao": f'{conta_associacao.uuid}',
+                "acao_associacao": f'{acao_associacao.uuid}',
+                "aplicacao_recurso": tipo_aplicacao_recurso,
+                "tipo_custeio": tipo_custeio.id,
+                "especificacao_material_servico": especificacao_material_servico.id,
+                "valor_rateio": 100.00,
+                "quantidade_itens_capital": 2,
+                "valor_item_capital": 50.00,
+                "numero_processo_incorporacao_capital": "6234673223462364632"
+            }
+        ]
+    }
+    return payload
+
+
+@pytest.fixture
+def despesa_justa(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='123456',
+        data_documento=datetime.date(2020, 3, 10),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='11.478.276/0001-04',
+        nome_fornecedor='Fornecedor SA',
+        tipo_transacao=tipo_transacao,
+        documento_transacao='',
+        data_transacao=datetime.date(2020, 3, 10),
+        valor_total=100.00,
+        valor_recursos_proprios=10.00,
+        valor_original=90.00,
+    )
+
+@pytest.fixture
+def rateio_despesa_justa(associacao, despesa_justa, conta_associacao, acao, tipo_aplicacao_recurso, tipo_custeio,
+                         especificacao_material_servico, acao_associacao, periodo_2020_1):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_justa,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_material_servico,
+        valor_rateio=100.00,
+        quantidade_itens_capital=2,
+        valor_item_capital=50.00,
+        numero_processo_incorporacao_capital='Teste123456',
+        update_conferido=True,
+        conferido=True,
+        periodo_conciliacao=periodo_2020_1,
+        valor_original=90.00,
+    )
+
+@pytest.fixture
+def fechamento_periodo_com_saldo_justo(periodo_2020_1, associacao, conta_associacao, acao_associacao, ):
+    from sme_ptrf_apps.core.models import STATUS_FECHADO
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=None,
+        total_receitas_capital=0,
+        total_repasses_capital=0,
+        total_despesas_capital=0,
+        total_receitas_custeio=100,
+        total_repasses_custeio=100,
+        total_despesas_custeio=100,
+        status=STATUS_FECHADO
+    )
+
+@pytest.fixture
+def fechamento_periodo_com_saldo_justo_outra_acao(periodo_2020_1, associacao, conta_associacao, acao_associacao_role_cultural, ):
+    from sme_ptrf_apps.core.models import STATUS_FECHADO
+    return baker.make(
+        'FechamentoPeriodo',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao_role_cultural,
+        fechamento_anterior=None,
+        total_receitas_capital=0,
+        total_repasses_capital=0,
+        total_despesas_capital=0,
+        total_receitas_custeio=100,
+        total_repasses_custeio=100,
+        total_despesas_custeio=0,
+        status=STATUS_FECHADO
+    )
+
+@pytest.fixture
+def payload_despesa_maior(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    conta_associacao,
+    acao_associacao,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    especificacao_material_servico,
+):
+    payload = {
+        "associacao": f'{associacao.uuid}',
+        "tipo_documento": tipo_documento.id,
+        "tipo_transacao": tipo_transacao.id,
+        "numero_documento": "634767",
+        "data_documento": "2020-03-10",
+        "cpf_cnpj_fornecedor": "36.352.197/0001-75",
+        "nome_fornecedor": "FORNECEDOR TESTE SA",
+        "data_transacao": "2020-03-10",
+        "valor_total": 112.50,
+        "valor_recursos_proprios": 10.50,
+        "rateios": [
+            {
+                "associacao": f'{associacao.uuid}',
+                "conta_associacao": f'{conta_associacao.uuid}',
+                "acao_associacao": f'{acao_associacao.uuid}',
+                "aplicacao_recurso": tipo_aplicacao_recurso,
+                "tipo_custeio": tipo_custeio.id,
+                "especificacao_material_servico": especificacao_material_servico.id,
+                "valor_rateio": 102.00,
+                "quantidade_itens_capital": 2,
+                "valor_item_capital": 51.00,
                 "numero_processo_incorporacao_capital": "6234673223462364632"
             }
         ]

--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_put.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_put.py
@@ -84,3 +84,122 @@ def test_api_verifica_saldo_antes_put_sem_saldo(
     }
     result = json.loads(response.content)
     assert result == result_esperado
+
+
+def test_api_verifica_saldo_antes_put_saldo_ok_com_saldo_exato_em_fechamento(
+    periodo,
+    periodo_2020_1,
+    fechamento_periodo_com_saldo_justo,
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao,
+    despesa_justa,
+    rateio_despesa_justa,
+    payload_despesa_justa
+):
+    response = jwt_authenticated_client_d.post(f'/api/rateios-despesas/verificar-saldos/?despesa_uuid={despesa_justa.uuid}',
+                          data=json.dumps(payload_despesa_justa),
+                          content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    result_esperado = {
+        'situacao_do_saldo': 'saldo_suficiente',
+        'mensagem': 'Há saldo disponível para cobertura da despesa.',
+        'saldos_insuficientes': [],
+        'aceitar_lancamento': True
+    }
+    result = json.loads(response.content)
+
+    assert result == result_esperado
+
+
+def test_api_verifica_saldo_antes_put_saldo_insuficiente_conta_com_saldo_exato_em_fechamento_e_despesa_alterada_para_mais(
+    periodo,
+    periodo_2020_1,
+    fechamento_periodo_com_saldo_justo,
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao,
+    despesa_justa,
+    rateio_despesa_justa,
+    payload_despesa_maior
+):
+    response = jwt_authenticated_client_d.post(f'/api/rateios-despesas/verificar-saldos/?despesa_uuid={despesa_justa.uuid}',
+                          data=json.dumps(payload_despesa_maior),
+                          content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    result_esperado = {
+        'aceitar_lancamento': True,
+        'mensagem': 'Não há saldo disponível em alguma das contas da despesa.',
+        'saldos_insuficientes': [
+            {
+                'conta': 'Cheque',
+                'saldo_disponivel': 100.0,
+                'total_rateios': 102.0
+            }
+        ],
+        'situacao_do_saldo': 'saldo_conta_insuficiente'
+    }
+    result = json.loads(response.content)
+
+    assert result == result_esperado
+
+
+def test_api_verifica_saldo_antes_put_saldo_insuficiente_acao_com_saldo_exato_em_fechamento_e_despesa_alterada_para_mais(
+    periodo,
+    periodo_2020_1,
+    fechamento_periodo_com_saldo_justo,
+    fechamento_periodo_com_saldo_justo_outra_acao,
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao,
+    despesa_justa,
+    rateio_despesa_justa,
+    payload_despesa_maior
+):
+    response = jwt_authenticated_client_d.post(f'/api/rateios-despesas/verificar-saldos/?despesa_uuid={despesa_justa.uuid}',
+                          data=json.dumps(payload_despesa_maior),
+                          content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    result_esperado = {
+        'aceitar_lancamento': True,
+        'mensagem': 'Não há saldo disponível em alguma das ações da despesa.',
+        'saldos_insuficientes': [
+            {
+                'acao': 'PTRF',
+                'aplicacao': 'CUSTEIO',
+                'saldo_disponivel': 100.0,
+                'total_rateios': 102.0
+            }
+        ],
+        'situacao_do_saldo': 'saldo_insuficiente'
+    }
+    result = json.loads(response.content)
+
+    assert result == result_esperado


### PR DESCRIPTION
Esse PR alterar a forma de verificar a suficiência de saldo no ato da edição de uma despesa.

Agora a aplicação, ao encontrar um fechamento na verificação de saldos para edição de uma despesa, passa a voltar com o valor original da despesa para o saldo antes de checar a suficiência. Anteriormente isso só ocorria no caso de períodos abertos (sem fechamentos).

[AB#85017](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85017)