### PR TITLE
feat(81495): Incluir novas retificações

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -244,9 +244,10 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
 class PrestacaoContaListRetificaveisSerializer(serializers.ModelSerializer):
     unidade_eol = serializers.SerializerMethodField('get_unidade_eol')
     unidade_nome = serializers.SerializerMethodField('get_unidade_nome')
+    unidade_tipo_unidade = serializers.SerializerMethodField('get_unidade_tipo_unidade')
+
     pode_desfazer_retificacao = serializers.SerializerMethodField('get_pode_desfazer_retificacao')
     tooltip_nao_pode_desfazer_retificacao = serializers.SerializerMethodField('get_tooltip_nao_pode_desfazer_retificacao')
-    unidade_tipo_unidade = serializers.SerializerMethodField('get_unidade_tipo_unidade')
 
     def get_unidade_eol(self, obj):
         return obj.associacao.unidade.codigo_eol if obj.associacao and obj.associacao.unidade else ''
@@ -265,4 +266,46 @@ class PrestacaoContaListRetificaveisSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PrestacaoConta
-        fields = ('uuid', 'unidade_eol', 'unidade_nome', 'unidade_tipo_unidade', 'pode_desfazer_retificacao', 'tooltip_nao_pode_desfazer_retificacao')
+        fields = (
+            'uuid',
+            'unidade_eol',
+            'unidade_nome',
+            'unidade_tipo_unidade',
+            'pode_desfazer_retificacao',
+            'tooltip_nao_pode_desfazer_retificacao',
+        )
+
+
+class PrestacaoContaDoConsolidadoListSerializer(serializers.ModelSerializer):
+    unidade_eol = serializers.SerializerMethodField('get_unidade_eol')
+    unidade_nome = serializers.SerializerMethodField('get_unidade_nome')
+    unidade_tipo_unidade = serializers.SerializerMethodField('get_unidade_tipo_unidade')
+    pc_em_retificacao = serializers.SerializerMethodField('get_pc_em_retificacao')
+    tooltip_nao_pode_retificar = serializers.SerializerMethodField('get_tooltip_nao_pode_retificar')
+
+
+    def get_unidade_eol(self, obj):
+        return obj.associacao.unidade.codigo_eol if obj.associacao and obj.associacao.unidade else ''
+
+    def get_unidade_nome(self, obj):
+        return obj.associacao.unidade.nome if obj.associacao and obj.associacao.unidade else ''
+
+    def get_unidade_tipo_unidade(self, obj):
+        return obj.associacao.unidade.tipo_unidade if obj.associacao and obj.associacao.unidade else ''
+
+    def get_pc_em_retificacao(self, obj):
+        return obj.em_retificacao
+
+    def get_tooltip_nao_pode_retificar(self, obj):
+        return obj.get_tooltip_nao_pode_retificar
+
+    class Meta:
+        model = PrestacaoConta
+        fields = (
+            'uuid',
+            'unidade_eol',
+            'unidade_nome',
+            'unidade_tipo_unidade',
+            'pc_em_retificacao',
+            'tooltip_nao_pode_retificar',
+        )

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -157,6 +157,13 @@ class PrestacaoConta(ModeloBase):
         else:
             return "Essa PC não pode ser removida pois seu status foi alterado"
 
+    @property
+    def get_tooltip_nao_pode_retificar(self):
+        if self.em_retificacao:
+            return "Esta PC foi retificada em outra publicação."
+        else:
+            return None
+
     def __str__(self):
         return f"{self.periodo} - {self.status}"
 

--- a/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
@@ -1199,6 +1199,15 @@ class ConsolidadosDreViewSet(mixins.RetrieveModelMixin,
 
         return Response(ConsolidadoDreSerializer(consolidado_dre, many=False).data, status=status.HTTP_200_OK)
 
+    @action(detail=True, methods=['get'], url_path='pcs-do-consolidado',
+            permission_classes=[IsAuthenticated & PermissaoAPIApenasDreComLeituraOuGravacao])
+    def pcs_do_consolidado(self, request, uuid):
+        consolidado: ConsolidadoDRE = self.get_object()
+        from sme_ptrf_apps.core.api.serializers.prestacao_conta_serializer import \
+            PrestacaoContaDoConsolidadoListSerializer
+        pcs = consolidado.pcs_do_consolidado()
+        return Response(PrestacaoContaDoConsolidadoListSerializer(pcs, many=True).data, status=status.HTTP_200_OK)
+
     @action(detail=True, methods=['get'], url_path='pcs-retificaveis',
             permission_classes=[IsAuthenticated & PermissaoAPIApenasDreComLeituraOuGravacao])
     def pcs_retificaveis(self, request, uuid):
@@ -1207,7 +1216,7 @@ class ConsolidadosDreViewSet(mixins.RetrieveModelMixin,
         pcs = consolidado.pcs_retificaveis()
         return Response(PrestacaoContaListRetificaveisSerializer(pcs, many=True).data, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['get'], url_path='pcs_em_retificacao',
+    @action(detail=True, methods=['get'], url_path='pcs-em-retificacao',
             permission_classes=[IsAuthenticated & PermissaoAPIApenasDreComLeituraOuGravacao])
     def pcs_em_retificacao(self, request, uuid):
         consolidado: ConsolidadoDRE = self.get_object()

--- a/sme_ptrf_apps/dre/models/consolidado_dre.py
+++ b/sme_ptrf_apps/dre/models/consolidado_dre.py
@@ -139,17 +139,35 @@ class ConsolidadoDRE(ModeloBase):
         return self.status_sme == self.STATUS_SME_PUBLICADO
 
     @property
-    def permite_retificacao(self):
+    def exibe_botao_retificar(self):
         if self.gerou_uma_retificacao:
-            retificacoes_publicadas = self.retificacoes.filter(status_sme=self.STATUS_SME_PUBLICADO)
-            todas_retificacoes_publicadas = len(self.retificacoes.all()) == len(retificacoes_publicadas)
-
-            if self.foi_publicado and todas_retificacoes_publicadas:
-                return True
-            else:
-                return False
+            return True
         else:
             return self.foi_publicado
+
+    @property
+    def permite_retificacao(self):
+        result = {
+            "permite": True,
+            "tooltip": ''
+        }
+
+        if self.gerou_uma_retificacao:
+            possui_retificacoes_nao_geradas = False
+
+            for retificacao in self.retificacoes.all():
+                if not retificacao.retificacao_gerada:
+                    possui_retificacoes_nao_geradas = True
+
+            if possui_retificacoes_nao_geradas:
+                result["permite"] = False
+                result["tooltip"] = "As PCs habilitadas para retificação estão disponíveis na edição" \
+                                    " da retificação desta publicação."
+            elif not self.prestacoes_de_conta_do_consolidado_dre.all():
+                result["permite"] = False
+                result["tooltip"] = "Esta publicação não possui PCs disponíveis para retificação"
+
+        return result
 
 
     @property
@@ -167,12 +185,20 @@ class ConsolidadoDRE(ModeloBase):
     @property
     def habilita_geracao(self):
         if self.eh_retificacao:
-            if self.versao == self.VERSAO_FINAL and not self.laudas_do_consolidado_dre.all():
+            if self.versao == self.VERSAO_FINAL and not self.retificacao_gerada:
                 return True
             else:
                 return False
         else:
             return False
+
+    @property
+    def retificacao_gerada(self):
+        if self.eh_retificacao and self.laudas_do_consolidado_dre.all():
+            return True
+
+        return False
+
 
     class Meta:
         verbose_name = 'Consolidado DRE'
@@ -484,6 +510,25 @@ class ConsolidadoDRE(ModeloBase):
             logger.error(f'Houve algum erro ao tentar concluir a análise do consolidado dre de uuid {self.uuid}.')
             logger.error(f'{e}')
             return False
+
+    def pcs_do_consolidado(self):
+        lista_pcs = []
+
+        # Pcs do proprio consolidado
+        for pc in self.prestacoes_de_conta_do_consolidado_dre.all():
+            lista_pcs.append(pc)
+
+        # O consolidado original pode ter mais de uma retificacao
+        for retificacao in self.retificacoes.all():
+
+            # Pcs que ja entraram em retificacao
+            for pc in retificacao.prestacoes_de_conta_do_consolidado_dre.all():
+                lista_pcs.append(pc)
+
+        # Ordenando a lista de PCs por tipo unidade e nome
+        lista_ordenada = sorted(lista_pcs, key=lambda prestacao: (prestacao.associacao.unidade.tipo_unidade, prestacao.associacao.unidade.nome))
+
+        return lista_ordenada
 
     def pcs_retificaveis(self):
         if self.eh_retificacao:

--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -121,7 +121,9 @@ def retornar_ja_publicadas(dre, periodo):
             'habilita_botao_gerar': consolidado_dre.habilita_geracao,
             'texto_tool_tip_botao_gerar': 'É necessário informar a data e a página da publicação anterior<br/>'
                                         'no Diário Oficial da Cidade para gerar uma nova publicação.',
-            'permite_retificacao': consolidado_dre.permite_retificacao,
+            'exibe_botao_retificar': consolidado_dre.exibe_botao_retificar,
+            'habilita_retificar': consolidado_dre.permite_retificacao["permite"],
+            'tooltip_habilita_retificar': consolidado_dre.permite_retificacao["tooltip"],
             'referencia': consolidado_dre.referencia,
             'eh_retificacao': consolidado_dre.eh_retificacao,
             'gerou_uma_retificacao': consolidado_dre.gerou_uma_retificacao,

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/conftest.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from model_bakery import baker
-
+from sme_ptrf_apps.core.models import PrestacaoConta
+from sme_ptrf_apps.dre.models import Lauda
+from django.contrib.auth import get_user_model
 
 from sme_ptrf_apps.dre.models import ConsolidadoDRE
 
@@ -14,6 +16,7 @@ def consolidado_dre_publicado_no_diario_oficial(dre, periodo):
         dre=dre,
         periodo=periodo,
         status_sme=ConsolidadoDRE.STATUS_SME_PUBLICADO,
+        gerou_uma_retificacao=True
     )
 
 
@@ -50,14 +53,15 @@ def retificacao_dre(periodo, dre, consolidado_dre_publicado_no_diario_oficial):
 
 
 @pytest.fixture
-def prestacao_conta_pc2(periodo, associacao, retificacao_dre):
+def prestacao_conta_pc2(periodo, associacao_status_nao_finalizado, retificacao_dre):
     return baker.make(
         'PrestacaoConta',
         periodo=periodo,
-        associacao=associacao,
+        associacao=associacao_status_nao_finalizado,
         consolidado_dre=retificacao_dre,
         publicada=False,
-        status_anterior_a_retificacao="APROVADA"
+        status_anterior_a_retificacao="APROVADA",
+        status=PrestacaoConta.STATUS_RECEBIDA
     )
 
 @pytest.fixture
@@ -68,5 +72,50 @@ def prestacao_conta_pc3(periodo, outra_associacao, retificacao_dre):
         associacao=outra_associacao,
         consolidado_dre=retificacao_dre,
         publicada=False,
-        status_anterior_a_retificacao="APROVADA"
+        status_anterior_a_retificacao="APROVADA",
+        status=PrestacaoConta.STATUS_EM_ANALISE
+    )
+
+@pytest.fixture
+def tipo_conta_cartao_teste_model_lauda_vinculada_a_retificacao():
+    return baker.make('TipoConta', nome='Cartão')
+
+
+@pytest.fixture
+def visao_dre_teste_lauda_model_lauda_vinculada_a_retificacao():
+    return baker.make('Visao', nome='DRE')
+
+
+@pytest.fixture
+def usuario_dre_teste_lauda_model_lauda_vinculada_a_retificacao(
+    dre,
+    visao_dre_teste_lauda_model_lauda_vinculada_a_retificacao,
+):
+    senha = 'Sgp0418'
+    login = '7654321'
+    email = 'teste.lauda.model@amcom.com.br'
+    User = get_user_model()
+    user = User.objects.create_user(username=login, password=senha, email=email)
+    user.unidades.add(dre)
+    user.visoes.add(visao_dre_teste_lauda_model_lauda_vinculada_a_retificacao)
+    user.save()
+    return user
+
+@pytest.fixture
+def lauda_vinculada_a_retificacao(
+    dre,
+    periodo,
+    retificacao_dre,
+    tipo_conta_cartao_teste_model_lauda_vinculada_a_retificacao,
+    usuario_dre_teste_lauda_model_lauda_vinculada_a_retificacao
+):
+    return baker.make(
+        'Lauda',
+        arquivo_lauda_txt=None,
+        consolidado_dre=retificacao_dre,
+        dre=dre,
+        periodo=periodo,
+        tipo_conta=tipo_conta_cartao_teste_model_lauda_vinculada_a_retificacao,
+        usuario=usuario_dre_teste_lauda_model_lauda_vinculada_a_retificacao,
+        status=Lauda.STATUS_GERADA_TOTAL
     )

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_desfazer_retificacao_consolidado.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_desfazer_retificacao_consolidado.py
@@ -131,3 +131,25 @@ def test_desfazer_retificacao_deve_apagar_retificacao(
     assert prestacao_conta_pc2.consolidado_dre == consolidado_original
     assert prestacao_conta_pc2.publicada is True
     assert prestacao_conta_pc2.status == PrestacaoConta.STATUS_APROVADA
+
+
+def test_pode_desfazer_retificacao(
+    jwt_authenticated_client_dre,
+    retificacao_dre,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    assert prestacao_conta_pc2.pode_desfazer_retificacao is True
+    assert prestacao_conta_pc3.pode_desfazer_retificacao is False
+
+
+def test_tooltip_pode_desfazer_retificacao(
+    jwt_authenticated_client_dre,
+    retificacao_dre,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    assert prestacao_conta_pc2.tooltip_nao_pode_desfazer_retificacao is None
+    assert prestacao_conta_pc3.tooltip_nao_pode_desfazer_retificacao == "Essa PC não pode ser removida pois seu status foi alterado"
+
+

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_permite_retificacao.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_permite_retificacao.py
@@ -1,0 +1,90 @@
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_permite_retificacao_consolidado_sem_retificacoes(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    prestacao_conta_pc1,
+):
+    result = consolidado_dre_publicado_no_diario_oficial.permite_retificacao
+
+    assert result["permite"] is True
+    assert result["tooltip"] == ""
+
+
+def test_permite_retificacao_consolidado_com_retificacoes_nao_geradas(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    result = consolidado_dre_publicado_no_diario_oficial.permite_retificacao
+
+    assert result["permite"] is False
+    assert result["tooltip"] == "As PCs habilitadas para retificação estão disponíveis na edição " \
+                                "da retificação desta publicação."
+
+
+def test_permite_retificacao_consolidado_com_retificacoes_geradas(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3,
+    lauda_vinculada_a_retificacao
+):
+    result = consolidado_dre_publicado_no_diario_oficial.permite_retificacao
+
+    assert result["permite"] is True
+    assert result["tooltip"] == ""
+
+
+def test_permite_retificacao_consolidado_com_pcs_retificaveis(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    prestacao_conta_pc1,
+    retificacao_dre,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3,
+    lauda_vinculada_a_retificacao
+):
+    result = consolidado_dre_publicado_no_diario_oficial.permite_retificacao
+
+    assert result["permite"] is True
+    assert result["tooltip"] == ""
+
+
+def test_permite_retificacao_consolidado_sem_pcs_retificaveis(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3,
+    lauda_vinculada_a_retificacao
+):
+    result = consolidado_dre_publicado_no_diario_oficial.permite_retificacao
+
+    assert result["permite"] is False
+    assert result["tooltip"] == "Esta publicação não possui PCs disponíveis para retificação"
+
+
+def test_tooltip_permite_retificar_pc(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3,
+):
+
+    assert prestacao_conta_pc1.get_tooltip_nao_pode_retificar is None
+    assert prestacao_conta_pc2.get_tooltip_nao_pode_retificar == "Esta PC foi retificada em outra publicação."
+    assert prestacao_conta_pc3.get_tooltip_nao_pode_retificar == "Esta PC foi retificada em outra publicação."
+
+

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_ja_publicados.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_ja_publicados.py
@@ -14,7 +14,7 @@ def test_retorna_ja_publicados_publicados_no_diario_oficial(
 
     assert len(result) == 1
     assert result[0]['status_sme'] == 'PUBLICADO'
-    assert result[0]['permite_retificacao'] is True
+    assert result[0]['exibe_botao_retificar'] is True
 
 
 def test_retorna_ja_publicados_nao_publicados_no_diario_oficial(
@@ -25,4 +25,18 @@ def test_retorna_ja_publicados_nao_publicados_no_diario_oficial(
 
     assert len(result) == 1
     assert result[0]['status_sme'] == 'NAO_PUBLICADO'
-    assert result[0]['permite_retificacao'] is False
+    assert result[0]['exibe_botao_retificar'] is False
+
+
+def test_retorna_ja_publicados_nao_publicados_no_diario_oficial_com_retificacao(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre
+):
+    result = retornar_ja_publicadas(consolidado_dre_publicado_no_diario_oficial.dre, consolidado_dre_publicado_no_diario_oficial.periodo)
+
+    assert len(result) == 2
+    assert result[0]['status_sme'] == 'NAO_PUBLICADO'
+    assert result[1]['status_sme'] == 'PUBLICADO'
+    assert result[0]['exibe_botao_retificar'] is False
+    assert result[1]['exibe_botao_retificar'] is True

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_do_consolidado.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_do_consolidado.py
@@ -1,0 +1,42 @@
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_retorna_pcs_do_consolidado_com_retificacao(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    result = consolidado_dre_publicado_no_diario_oficial.pcs_do_consolidado()
+
+    # Pcs vinculadas ao consolidado original
+    assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
+
+    # Pcs vinculadas a retificação
+    assert len(retificacao_dre.prestacoes_de_conta_do_consolidado_dre.all()) == 2
+
+    # Total de Pcs (consolidado original + retificacao)
+    assert len(result) == 3
+
+
+def test_retorna_pcs_do_consolidado_sem_retificacao(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+):
+    result = consolidado_dre_publicado_no_diario_oficial.pcs_do_consolidado()
+
+    # Pcs vinculadas ao consolidado original
+    assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
+
+    # Pcs vinculadas a retificação
+    assert len(retificacao_dre.prestacoes_de_conta_do_consolidado_dre.all()) == 0
+
+    # Total de Pcs (consolidado original + retificacao)
+    assert len(result) == 1

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_em_retificacao.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_em_retificacao.py
@@ -1,0 +1,23 @@
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_retorna_pcs_em_retificacao(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    result = retificacao_dre.pcs_em_retificacao()
+
+    # Pcs retificaveis
+    assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
+
+    # Pcs ja retificadas
+    assert len(retificacao_dre.prestacoes_de_conta_do_consolidado_dre.all()) == 2
+
+    assert len(result) == 2

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_retificaveis.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_retificaveis.py
@@ -1,0 +1,42 @@
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_retorna_pcs_retificaveis_consolidado_original(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    result = consolidado_dre_publicado_no_diario_oficial.pcs_retificaveis()
+
+    # Pcs retificaveis
+    assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
+
+    # Pcs ja retificadas
+    assert len(retificacao_dre.prestacoes_de_conta_do_consolidado_dre.all()) == 2
+
+    assert len(result) == 1
+
+
+def test_retorna_pcs_retificaveis_retificacao(
+    jwt_authenticated_client_dre,
+    consolidado_dre_publicado_no_diario_oficial,
+    retificacao_dre,
+    prestacao_conta_pc1,
+    prestacao_conta_pc2,
+    prestacao_conta_pc3
+):
+    result = retificacao_dre.pcs_retificaveis()
+
+    # Pcs retificaveis
+    assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
+
+    # Pcs ja retificadas
+    assert len(retificacao_dre.prestacoes_de_conta_do_consolidado_dre.all()) == 2
+
+    assert len(result) == 1

--- a/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_pcs_do_consolidado.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_pcs_do_consolidado.py
@@ -13,7 +13,7 @@ def test_get_consolidado_dre_pcs_em_retificacao(
     retificacao_uuid = retificacao_dre_teste_api_consolidado_dre.uuid
 
     response = jwt_authenticated_client_dre.get(
-        f'/api/consolidados-dre/{retificacao_uuid}/pcs-em-retificacao/',
+        f'/api/consolidados-dre/{retificacao_uuid}/pcs-do-consolidado/',
         content_type='application/json'
     )
 


### PR DESCRIPTION
feat(81495): Incluir novas retificações

Esse PR:

- Adiciona endpoint para retornar PCs do consolidado
- Adiciona regras para controles dos botões
- Altera testes relacionados
- Adiciona testes relacionados
- Adiciona propertys ao modelo ConsolidadoDre para utilização na API

História: [AB#81495](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/81495)