### PR TITLE
feat(85658): Ajustes pós integração com develop

### DIFF
--- a/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
@@ -1147,7 +1147,7 @@ class ConsolidadosDreViewSet(mixins.RetrieveModelMixin,
         consolidado: ConsolidadoDRE = self.get_object()
         from sme_ptrf_apps.core.api.serializers.prestacao_conta_serializer import \
             PrestacaoContaDoConsolidadoListSerializer
-        pcs = consolidado.pcs_do_consolidado()
+        pcs = consolidado.pcs_vinculadas_ao_consolidado()
         return Response(PrestacaoContaDoConsolidadoListSerializer(pcs, many=True).data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['get'], url_path='pcs-retificaveis',

--- a/sme_ptrf_apps/dre/models/consolidado_dre.py
+++ b/sme_ptrf_apps/dre/models/consolidado_dre.py
@@ -519,7 +519,7 @@ class ConsolidadoDRE(ModeloBase):
             logger.error(f'{e}')
             return False
 
-    def pcs_do_consolidado(self):
+    def pcs_vinculadas_ao_consolidado(self):
         lista_pcs = []
 
         # Pcs do proprio consolidado

--- a/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_do_consolidado.py
+++ b/sme_ptrf_apps/dre/services/tests/tests_consolidado_dre_service/test_retornar_pcs_do_consolidado.py
@@ -12,7 +12,7 @@ def test_retorna_pcs_do_consolidado_com_retificacao(
     prestacao_conta_pc2,
     prestacao_conta_pc3
 ):
-    result = consolidado_dre_publicado_no_diario_oficial.pcs_do_consolidado()
+    result = consolidado_dre_publicado_no_diario_oficial.pcs_vinculadas_ao_consolidado()
 
     # Pcs vinculadas ao consolidado original
     assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1
@@ -30,7 +30,7 @@ def test_retorna_pcs_do_consolidado_sem_retificacao(
     retificacao_dre,
     prestacao_conta_pc1,
 ):
-    result = consolidado_dre_publicado_no_diario_oficial.pcs_do_consolidado()
+    result = consolidado_dre_publicado_no_diario_oficial.pcs_vinculadas_ao_consolidado()
 
     # Pcs vinculadas ao consolidado original
     assert len(consolidado_dre_publicado_no_diario_oficial.prestacoes_de_conta_do_consolidado_dre.all()) == 1


### PR DESCRIPTION
Esse PR:

- [X] Renomeia método pcs_vinculadas_ao_consolidado que estava conflitando com campo m2m 

Atende [AB#85658](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85658)