### PR TITLE
fix(85715): Relatório consolidado: o loading não é exibido corretamente na solicitação de geração do demonstrativo - Parte 02

### DIFF
--- a/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
@@ -397,8 +397,12 @@ class ConsolidadosDreViewSet(mixins.RetrieveModelMixin,
                 usuario=request.user.username,
             )
 
-            return Response({"data": "Consolidado de publicações parciais gerados com sucesso"},
-                            status=status.HTTP_200_OK)
+            data = {
+                "data": "Consolidado de publicações parciais gerados com sucesso",
+                "status": RelatorioConsolidadoDRE.STATUS_EM_PROCESSAMENTO
+            }
+
+            return Response(data, status=status.HTTP_200_OK)
         except:
             erro = {
                 'erro': 'erro_ao_gerar_consolidado_de_publicacoes_parciais',


### PR DESCRIPTION
Esse PR:

- Altera retorno API gerar_consolidado_de_publicacoes_parciais - EM_PROCESSAMENTO

História: [AB#85715](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85715)