### PR TITLE
feat(81196): Altera layout PDF Relatório Consolidado

### DIFF
--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -84,7 +84,7 @@ def cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo, eh_consolidado
                 titulo_parcial = f"Retificação da publicação de {data_publicacao_consolidado_origem_retificacao}"
             
         elif(not consolidado.eh_parcial):
-            titulo_parcial = f"Unica #{numero_sequencia}"
+            titulo_parcial = f"Única"
 
         else:
             titulo_parcial = f"Parcial #{numero_sequencia}"
@@ -657,7 +657,7 @@ def cria_dados_fisicos_financeiros(dre, periodo, apenas_nao_publicadas, eh_conso
                 "tipo": infos["unidade"]["tipo_unidade"],
             },
             "situacao_pc": get_status_label(infos['status_prestacao_contas']),
-            "referencia_consolidado": f"Publicação Parcial #{infos['referencia_consolidado']}" if infos['referencia_consolidado'] else None,
+            "referencia_consolidado": f"{infos['referencia_consolidado']}" if infos['referencia_consolidado'] else None,
         }
 
         for info in infos['por_tipo_de_conta']:

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -89,7 +89,7 @@ def cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo, eh_consolidado
         else:
             titulo_parcial = f"Parcial #{numero_sequencia}"
         
-        data_publicacao = consolidado.alterado_em.strftime("%d/%m/%Y") if consolidado.alterado_em else ""
+        data_publicacao = consolidado.data_publicacao.strftime("%d/%m/%Y") if consolidado.data_publicacao else ""
         numero_unidades = len(consolidado.pcs_vinculadas_ao_consolidado())
         result = {
             'titulo_parcial': titulo_parcial,

--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -1076,7 +1076,19 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
 
         status_prestacao_conta = prestacao_conta.status if prestacao_conta else 'NAO_APRESENTADA'
 
-        referencia_consolidado = prestacao_conta.consolidado_dre.sequencia_de_publicacao if eh_consolidado_de_publicacoes_parciais and prestacao_conta.consolidado_dre and prestacao_conta.consolidado_dre.sequencia_de_publicacao else None
+        referencia_consolidado = ""
+        if(prestacao_conta.consolidado_dre.eh_parcial and prestacao_conta.consolidado_dre.consolidado_retificado_id):
+            consolidado_origem_retificacao = ConsolidadoDRE.objects.filter(pk=prestacao_conta.consolidado_dre.consolidado_retificado_id)
+
+            if(consolidado_origem_retificacao.count() > 0 and consolidado_origem_retificacao[0].data_publicacao):
+                data_publicacao_consolidado_origem_retificacao = consolidado_origem_retificacao[0].data_publicacao.strftime("%d/%m/%Y")
+                referencia_consolidado = f"Retificação da publicação de {data_publicacao_consolidado_origem_retificacao}"
+            
+        elif(not prestacao_conta.consolidado_dre.eh_parcial):
+            referencia_consolidado = f"Única"
+
+        else:
+            referencia_consolidado = f"Parcial #{prestacao_conta.consolidado_dre.sequencia_de_publicacao}"
 
         dado = []
         objeto_tipo_de_conta = []

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela_consolidado_das_publicacoes_parciais.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela_consolidado_das_publicacoes_parciais.html
@@ -5,7 +5,7 @@
   <table class="table table-bordered">
     <thead>
     <tr>
-      <th class="py-2 font-12" scope="col" style="width: 50%">Consolidação das Publicações Parciais:</th>
+      <th class="py-2 font-12" scope="col" style="width: 50%">Consolidação das Publicações:</th>
       <th class="py-2 font-12" scope="col">Data de Publicação:</th>
       <th class="py-2 font-12" scope="col">Número de Unidades:</th>
     </tr>


### PR DESCRIPTION
Esse PR:

- altera o layout/nome das PCs apresentadas no PDF do consolidado
- altera a ordenação das PCs no consoldiado
- adiciona a referência atual de qual consolidado a PC nos dados físico-financeiros

História: [AB#81196](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/81196)