### PR TITLE
feat(84790): Adiciona campo no teste retrieve prestacao conta

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -393,6 +393,7 @@ def test_api_retrieve_prestacao_conta_por_uuid(
         },
         'publicada': None,
         'referencia_consolidado_dre': '',
+        'referencia_consolidado_dre_original': None,
         'justificativa_pendencia_realizacao': 'Teste de justificativa.',
         'em_retificacao': prestacao_conta.em_retificacao
     }


### PR DESCRIPTION
Esse PR:

- Adiciona o campo referencia_consolidado_dre_original no teste de prestacao de conta

História: [AB#84790](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/84790)