### PR TITLE
feat(86718): Ajustar relatório de apresentação após acertos

### DIFF
--- a/sme_ptrf_apps/static/css/pdf-relatorio-apos-acertos.css
+++ b/sme_ptrf_apps/static/css/pdf-relatorio-apos-acertos.css
@@ -298,4 +298,16 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
     font-weight: 700;
 }
 
-
+/* checkbox */
+.checkbox-pdf {
+    margin-left: 40%;
+    text-align: center;
+    display: flex;
+    flex: 1;
+    max-width: 14px;
+    justify-content: center;
+    margin-bottom: 10px;
+    color: #ffffff;
+    background-color: #d8d8d8;
+    font-weight: 700;
+}

--- a/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-lancamentos.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-lancamentos.html
@@ -60,6 +60,8 @@
                     <td colspan="5" class="sem-borda border-bottom pb-4">
 
                       <div class="row mt-2">
+                        <div class="col-10">
+                          <div class="row">
 
                           <div class='col-2'>
                               <span class="item font-12"><strong>Item {{ acerto.ordem }}</strong></span>
@@ -130,8 +132,17 @@
 
                           </div>
 
+                        </div>
+                        </div>
+                        <div class="col-2">
+                            <p><strong class="font-12 mb-0">Demonstrado</strong></p>
+                            {% if lancamento.conferido %}            
+                              <p class="mt-1 font-10 checkbox-pdf">&#x2714;</p>
+                            {% else %}
+                              <p class="mt-1 font-10 checkbox-pdf">&nbsp;</p>
+                            {% endif %}
+                        </div>
                       </div>
-
                     </td>
 
                   </tr>


### PR DESCRIPTION
Esse PR:

- Modifica o layout do PDF de apresentação após acertos adicionando o indicativo de demonstrado
- Adiciona um checkbox em css para renderização no PDF

História: AB#86718