### PR TITLE
feat(85901): Add info categorias de acerto em conciliação

### DIFF
--- a/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
@@ -62,6 +62,18 @@ class TipoAcertoLancamentoAgrupadoPorCategoria:
                          "não reabre o lançamento para alteração.",
                 "cor": 2
             }
+        elif TipoAcertoLancamento.CATEGORIA_CONCILIACAO_LANCAMENTO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto requer que o usuário concilie o lançamento e "
+                         "provoca a regeração dos fechamentos e arquivos.",
+                "cor": 1
+            }
+        elif TipoAcertoLancamento.CATEGORIA_DESCONCILIACAO_LANCAMENTO == categoria_id:
+            return {
+                "texto": "Esse tipo de acerto requer que o usuário desconcilie o lançamento e "
+                         "provoca a regeração dos fechamentos e arquivos.",
+                "cor": 1
+            }
 
 
 class TipoAcertoLancamentoCategorias:


### PR DESCRIPTION
Esse PR:
- Altera em tipos_acerto_lancamento_service o retorno de informações sobre os tipos de solicitação de acerto para incluir informações sobre as categorias de conciliação e desconciliação.

História [AB#85901](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85901)