### PR TITLE
feat(85393): Padronizar pdf DRE devolução acertos

### DIFF
--- a/sme_ptrf_apps/core/services/dados_relatorio_acertos_service.py
+++ b/sme_ptrf_apps/core/services/dados_relatorio_acertos_service.py
@@ -1,6 +1,6 @@
 from sme_ptrf_apps.core.services.prestacao_contas_services import (lancamentos_da_prestacao)
 from ..api.serializers.analise_documento_prestacao_conta_serializer import AnaliseDocumentoPrestacaoContaRetrieveSerializer
-from datetime import date
+from datetime import datetime
 from ...utils.numero_ordinal import formata_numero_ordinal
 
 import logging
@@ -64,7 +64,7 @@ def gerar_dados_relatorio_acertos(analise_prestacao_conta, previa, usuario=""):
 
     dados_documentos = AnaliseDocumentoPrestacaoContaRetrieveSerializer(documentos, many=True).data
 
-    data_geracao_documento = cria_data_geracao_documento(usuario, previa)
+    data_geracao_documento = cria_data_geracao_documento(usuario, previa, dados_associacao["nome_dre"])
 
     dados = {
         'info_cabecalho': info_cabecalho,
@@ -106,11 +106,13 @@ def nome_blocos(dados_ajustes_contas, dados_lancamentos, dados_documentos, dados
     return dados
 
 
-def cria_data_geracao_documento(usuario, previa):
-    data_geracao = date.today().strftime("%d/%m/%Y")
-    tipo_texto = "prévio" if previa else "final"
-    quem_gerou = "" if usuario == "" else f"pelo usuário {usuario}. "
-    texto = f"Documento {tipo_texto} gerado pelo SIG-Escola em {data_geracao} {quem_gerou}"
+def cria_data_geracao_documento(usuario, previa, nome_dre):
+    data_tempo = datetime.now()
+    data_geracao = data_tempo.strftime("%d/%m/%Y às %H:%M")
+    dre = "" if nome_dre == "" else f"DRE {nome_dre}, "
+    tipo_texto = "Prévia gerada" if previa else "Documento final gerado"
+    quem_gerou = "" if usuario == "" else f"pelo usuário {usuario}"
+    texto = f"{dre}{tipo_texto} {quem_gerou}, via SIG-Escola, em {data_geracao}."
 
     return texto
 

--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/bloco-de-identificacao.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/bloco-de-identificacao.html
@@ -1,0 +1,74 @@
+{% load staticfiles %}
+{% load formata_valores %}
+{% load formata_string %}
+
+<article class="mt-4">
+    <table class="table table-bordered tabela-resumo-por-acao">
+      <thead class="">
+        <tr class="">
+          <th colSpan="1">
+            <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.identificacao_associacao }}</strong>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="col-12">
+              <p class="pt-2 mt-2 font-12"><strong>Nome da Associação:</strong> {{ dados.dados_associacao.nome_associacao }}</p>
+            </div>
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            <div class="col-12">
+              <div class="row">
+                <div class="col">
+                  <p class="pt-2 mt-2 mb-0 font-12"><strong>CNPJ:</strong></p>
+                  <p class="font-12">{{ dados.dados_associacao.cnpj_associacao }}</p>
+                </div>
+                <div class="col">
+                  <p class="pt-2 mt-2 mb-0 font-12"><strong>Código EOL:</strong></p>
+                  <p class="font-12">{{ dados.dados_associacao.codigo_eol_associacao }}</p>
+                </div>
+                <div class="col">
+                  <p class="pt-2 mt-2 mb-0 font-12"><strong>Diretoria Regional de Educação:</strong></p>
+                  <p class="font-12">{{ dados.dados_associacao.nome_dre }}</p>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+
+      <tr>
+        <td>
+          <div class="col-12">
+            <div class="row">
+
+              <div class="col-4">
+                <p class="pt-2 mt-2 mb-0 font-12"><strong>Data da devolução da DRE:</strong></p>
+                {% if dados.dados_associacao.data_devolucao_dre == '-' %}
+                  <p class="font-12">{{ dados.dados_associacao.data_devolucao_dre }}</p>
+                {% else %}
+                  <p class="font-12">{{ dados.dados_associacao.data_devolucao_dre|date:'d/m/Y' }}</p>
+                {% endif %}
+
+              </div>
+              <div class="col-8">
+                <p class="ml-5 pt-2 mt-2 mb-0 font-12"><strong>Prazo para devolução da Associação:</strong></p>
+                {% if dados.dados_associacao.prazo_devolucao_associacao == '-' %}
+                  <p class="ml-5 font-12">{{ dados.dados_associacao.prazo_devolucao_associacao }}</p>
+                {% else %}
+                  <p class="ml-5 font-12">{{ dados.dados_associacao.prazo_devolucao_associacao|date:'d/m/Y' }}</p>
+                {% endif %}
+              </div>
+
+            </div>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </article>

--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
@@ -8,25 +8,24 @@
   <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
-        integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
-  <link href="{{ base_static_url }}/css/pdf-relatorio-dos-acertos.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
+  <link href="{{ base_static_url }}/css/pdf-relatorio-apos-acertos.css" rel="stylesheet">
   <title>Relatório de acertos PTRF</title>
 </head>
 <body>
 {# ************************* Cabecalho das páginas *************************  #}
 
 <header>
-  <div class="d-flex p-2 bd-highlight mt-2">
+  <div class="d-flex p-2 bd-highlight mt-1">
     <div class="col-6 mt-2">
-      <p class="subtitulo font-14 mb-0">Prestação de Contas - Relatório de Devolução</p>
+      <p class="subtitulo font-12 mb-0">Prestação de Contas - Relatório de Devolução</p>
       <p class="font-14">Devolução para acertos a Associação</p>
     </div>
     <div class="col-6">
       <div class="row">
         <div class="col-auto borda-box-cabecalho-right ml-5 ml-auto">
-          <p class="font-14 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-14">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
+          <p class="font-10 mb-0">Período de Realização:</p>
+          <p class="subtitulo font-10 mb-0 pb-0">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
         </div>
       </div>
     </div>
@@ -37,11 +36,11 @@
 
 {# ************************* Rodape ************************* #}
 <p id="data-geracao-rodape">
-  <i>{{ dados.data_geracao_documento }}</i>
+  <i class="font-10">{{ dados.data_geracao_documento }}</i>
 </p>
 {# ************************* Fim Rodape ************************* #}
 
-<section id="cabecalho" class="mt-3">
+<section id="cabecalho" class="mt-2">
   <div class="d-flex p-2 bd-highlight">
     <div class="col-4">
       <img src="{{ base_static_url }}/images/logo-color.svg" alt="logo">
@@ -53,14 +52,14 @@
   <hr class="divisao"/>
   <div class="d-flex p-2 bd-highlight mt-2">
     <div class="col-6 mt-2">
-      <p class="subtitulo font-14 mb-0">Prestação de Contas - Relatório de Devolução</p>
-      <p class="font-14">Devolução para acertos a Associação</p>
+      <p class="subtitulo font-12 mb-0">Prestação de Contas - Relatório de Devolução</p>
+      <p class="font-12">Devolução para acertos a Associação</p>
     </div>
     <div class="col-6">
       <div class="row">
         <div class="col-auto borda-box-cabecalho-right ml-5 ml-auto">
-          <p class="font-14 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-14">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
+          <p class="font-12 mb-0">Período de Realização:</p>
+          <p class="subtitulo font-12">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
         </div>
       </div>
     </div>
@@ -68,76 +67,9 @@
 </section>
 
 <section class="conteudo mt-4">
-  <article class="mt-4">
-    <table class="table table-bordered tabela-resumo-por-acao">
-      <thead class="">
-        <tr class="">
-          <th colSpan="1">
-            <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.identificacao_associacao }}</strong>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div class="col-12">
-              <p class="pt-2 mt-2 font-12"><strong>Nome da Associação:</strong> {{ dados.dados_associacao.nome_associacao }}</p>
-            </div>
-          </td>
-        </tr>
 
-        <tr>
-          <td>
-            <div class="col-12">
-              <div class="row">
-                <div class="col">
-                  <p class="pt-2 mt-2 mb-0 font-12"><strong>CNPJ:</strong></p>
-                  <p class="font-12">{{ dados.dados_associacao.cnpj_associacao }}</p>
-                </div>
-                <div class="col">
-                  <p class="pt-2 mt-2 mb-0 font-12"><strong>Código EOL:</strong></p>
-                  <p class="font-12">{{ dados.dados_associacao.codigo_eol_associacao }}</p>
-                </div>
-                <div class="col">
-                  <p class="pt-2 mt-2 mb-0 font-12"><strong>Diretoria Regional de Educação:</strong></p>
-                  <p class="font-12">{{ dados.dados_associacao.nome_dre }}</p>
-                </div>
-              </div>
-            </div>
-          </td>
-        </tr>
-
-      <tr>
-        <td>
-          <div class="col-12">
-            <div class="row">
-
-              <div class="col-4">
-                <p class="pt-2 mt-2 mb-0 font-12"><strong>Data da devolução da DRE:</strong></p>
-                {% if dados.dados_associacao.data_devolucao_dre == '-' %}
-                  <p class="font-12">{{ dados.dados_associacao.data_devolucao_dre }}</p>
-                {% else %}
-                  <p class="font-12">{{ dados.dados_associacao.data_devolucao_dre|date:'d/m/Y' }}</p>
-                {% endif %}
-
-              </div>
-              <div class="col-8">
-                <p class="ml-5 pt-2 mt-2 mb-0 font-12"><strong>Prazo para devolução da Associação:</strong></p>
-                {% if dados.dados_associacao.prazo_devolucao_associacao == '-' %}
-                  <p class="ml-5 font-12">{{ dados.dados_associacao.prazo_devolucao_associacao }}</p>
-                {% else %}
-                  <p class="ml-5 font-12">{{ dados.dados_associacao.prazo_devolucao_associacao|date:'d/m/Y' }}</p>
-                {% endif %}
-              </div>
-
-            </div>
-          </div>
-        </td>
-      </tr>
-      </tbody>
-    </table>
-
-  </article>
+  {% comment %} Bloco de identificação {% endcomment %}
+  {% include "./bloco-de-identificacao.html" with dados=dados %}
 
   {% if dados.dados_ajustes_contas %}
     <article class="mt-4">
@@ -186,186 +118,11 @@
     </article>
   {% endif %}
 
-  {% if dados.dados_lancamentos %}
-    <article class="mt-4">
-      {% for conta in dados.dados_lancamentos %}
-        <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
-          <thead class="">
+  {% comment %} Tabela Acertos em Lançamentos {% endcomment %}
+  {% include "./tabela-acertos-em-lancamentos.html" with dados=dados %}
 
-            <tr class="">
-              <th colSpan="6">
-                <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_lancamentos }}</strong>
-              </th>
-            </tr>
-
-            <tr>
-              <th colSpan="6">
-                <strong class="font-12 titulo-bloco">Conta {{ conta.nome_conta }}</strong>
-              </th>
-            </tr>
-
-            <tr>
-              <th style="width: 2%" class="fundo-verde"></th>
-              <th class="font-10 fundo-verde"><strong>Data</strong></th>
-              <th class="font-10 fundo-verde"><strong>Tipo de lançamento</strong></th>
-              <th class="font-10 fundo-verde"><strong>Nº do documento</strong></th>
-              <th class="font-10 fundo-verde" style="width: 40%"><strong>Descrição</strong></th>
-              <th class="font-10 fundo-verde"><strong>Valor (R$)</strong></th>
-            </tr>
-          </thead>
-
-          {% for lancamento in conta.lancamentos %}
-            <tbody>
-            <tr>
-              <td class="fundo-cinza font-12">{{ forloop.counter }}</td>
-              <td class="fundo-cinza font-12">{{ lancamento.data|date:'d/m/Y' }}</td>
-              {% if lancamento.tipo_transacao == 'Gasto' %}
-                <td class="fundo-cinza font-12">Despesa</td>
-              {% else %}
-                <td class="fundo-cinza font-12">{{ lancamento.tipo_transacao }}</td>
-              {% endif %}
-
-              {% if lancamento.numero_documento == '' %}
-                <td class="fundo-cinza font-12">-</td>
-              {% else %}
-                <td class="fundo-cinza font-12">{{ lancamento.numero_documento }}</td>
-              {% endif %}
-
-              <td class="fundo-cinza font-12">{{ lancamento.descricao }}</td>
-              <td class="fundo-cinza font-12">{{ lancamento.valor_transacao_total|formata_valor }}</td>
-            </tr>
-
-            <tr>
-              <td rowspan="1" class="sem-borda pb-4"></td>
-              <td colspan="5" class="sem-borda pb-4">
-
-                {% for acerto in lancamento.analise_lancamento.solicitacoes_de_ajuste_da_analise %}
-                  {% if acerto.tipo_acerto.categoria == 'DEVOLUCAO' %}
-                    <div class="row">
-                      <div class="col-12 mt-4">
-                        <span class="item font-12"><strong>Item {{ forloop.counter }}:</strong></span>
-                        <span class="ml-2 font-12">{{ acerto.tipo_acerto.nome }}</span>
-                      </div>
-                    </div>
-
-                    <div class="row mt-2">
-                      <div class="col-12">
-                        <span class="font-12"><strong>Tipo de devolução</strong></span>
-                        <br>
-                        <span class="font-12">{{ acerto.devolucao_ao_tesouro.tipo.nome }}</span>
-                      </div>
-                    </div>
-
-                    <div class="row mt-2">
-                      <div class="col-6">
-                        <span class="font-12"><strong>Valor total ou parcial da despesa</strong></span>
-                        <br>
-                        {% if acerto.devolucao_ao_tesouro.devolucao_total is True %}
-                          <span class="font-12">Total</span>
-                        {% else %}
-                          <span class="font-12">Parcial</span>
-                        {% endif %}
-                      </div>
-
-                      <div class="col-6">
-                        <span class="font-12"><strong>Valor (R$)</strong></span>
-                        <br>
-                        <span class="font-12">{{ acerto.devolucao_ao_tesouro.valor|formata_valor }}</span>
-                      </div>
-                    </div>
-
-                    <div class="row mt-2">
-                      <div class="col-12">
-                        <span class="font-12"><strong>Motivo</strong></span>
-                        <br>
-                        <span class="font-12">{{ acerto.devolucao_ao_tesouro.motivo }}</span>
-                      </div>
-                    </div>
-
-                  {% else %}
-                    <div class="row">
-                      <div class="col-12 mt-4">
-                        <span class="item font-12"><strong>Item {{ forloop.counter }}:</strong></span>
-                        <span class="ml-2 font-12">{{ acerto.tipo_acerto.nome }}</span>
-                      </div>
-                    </div>
-
-                    {% if acerto.detalhamento %}
-                      <div class="row mt-2">
-                        <div class="col-12">
-                          <span class="font-12"><strong>Detalhamento do acerto:</strong></span>
-                          <br>
-                          <span class="font-12">{{ acerto.detalhamento }}</span>
-                        </div>
-                      </div>
-                    {% endif %}
-
-                  {% endif %}
-
-                {% endfor %}
-              </td>
-            </tr>
-            </tbody>
-          {% endfor %}
-        </table>
-      {% endfor %}
-
-    </article>
-  {% endif %}
-
-  {% if dados.dados_documentos %}
-    <article class="mt-4">
-      <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
-        <thead class="">
-
-          <tr class="">
-            <th colSpan="2">
-              <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_documentos }}</strong>
-            </th>
-          </tr>
-
-          <tr>
-            <th style="width: 2%" class="fundo-th-cinza font-10"></th>
-            <th class="fundo-th-cinza font-10"><strong>Nome do documento</strong></th>
-          </tr>
-        </thead>
-
-          {% for documento in dados.dados_documentos %}
-          <tbody>
-            <tr>
-              <td class="fundo-cinza font-12">{{ forloop.counter }}</td>
-              <td class="fundo-cinza font-12">{{ documento.tipo_documento_prestacao_conta.nome }}</td>
-            </tr>
-          <tr>
-            <td rowspan="1" class="sem-borda pb-4"></td>
-            <td colspan="1" class="sem-borda pb-4">
-              {% for acertos in documento.solicitacoes_de_ajuste_da_analise %}
-                <div class="row">
-                  <div class="col-12 mt-4">
-                    <span class="item font-12"><strong>Item {{ forloop.counter }}:</strong></span>
-                    <span class="ml-2 font-12">{{ acertos.tipo_acerto.nome }}</span>
-
-                    {% if acertos.detalhamento %}
-                      <div class="row mt-2">
-                        <div class="col-12">
-                          <span class="font-12"><strong>Detalhamento do acerto:</strong></span>
-                          <br>
-                          <span class="font-12">{{ acertos.detalhamento }}</span>
-                        </div>
-                      </div>
-                    {% endif %}
-
-                  </div>
-                </div>
-              {% endfor %}
-            </td>
-          </tr>
-          </tbody>
-          {% endfor %}
-
-      </table>
-    </article>
-  {% endif %}
+  {% comment %} Tabela Acertos em Documentos {% endcomment %}
+  {% include "./tabela-acertos-em-documentos.html" with dados=dados %}
 
   {% if dados.versao_devolucao != "Rascunho" %}
     <article class="mt-4">

--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/tabela-acertos-em-documentos.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/tabela-acertos-em-documentos.html
@@ -1,0 +1,59 @@
+{% load staticfiles %}
+{% load formata_valores %}
+{% load formata_string %}
+
+{% if dados.dados_documentos %}
+    <article class="mt-4">
+      <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
+        <thead>
+          <tr class="">
+            <th colspan="6">
+              <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_documentos }}</strong>
+            </th>
+          </tr>
+  
+          <tr>
+            <th class="fundo-th-cinza py-1" style="width: 2%"> </th>
+            <th colspan="5" class="fundo-th-cinza font-12 py-1">
+              <strong>Nome do documento:</strong>
+            </th>
+          </tr>
+        </thead>
+
+        {% for documento in dados.dados_documentos %}
+          <tbody>
+            <tr>
+              <td class="fundo-td-cinza-mais-escuro font-12 py-1">{{ forloop.counter }}</td>
+              <td colspan="5" class="fundo-td-cinza-mais-escuro font-12 py-1">{{ documento.tipo_documento_prestacao_conta.nome }}</td>
+            </tr>
+            
+              {% for acerto in documento.solicitacoes_de_ajuste_da_analise %}
+                <tr class="border-bottom">
+                  <td rowspan="1" class="sem-borda pb-4"></td>
+                  <td colspan="5" class="sem-borda border-bottom pb-4">
+                    <div class="row mt-2">
+                      <div class="col-2">
+                        <span class="item font-12"><strong>Item {{ forloop.counter }}:</strong></span>
+                      </div>
+
+                      <div class="col-8">
+                        <p class="font-12 mb-0"><strong>Tipo de acerto</strong></p>
+                        <p class="font-12">{{ acerto.tipo_acerto.nome }}</p>
+
+                        {% if acerto.detalhamento %}
+                          <p class="font-12 mb-0"><strong>Detalhamento do acerto</strong></p>
+                          <p class="font-12">{{ acerto.detalhamento }}</p>
+                        {% endif %}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %} {% comment %}End for acerto{% endcomment %}
+            </td>
+          </tr>
+          </tbody>
+        {% endfor %} {% comment %}End for documento{% endcomment %}
+
+      </table>
+    </article>
+  {% endif %}

--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/tabela-acertos-em-lancamentos.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/tabela-acertos-em-lancamentos.html
@@ -1,0 +1,118 @@
+{% load staticfiles %}
+{% load formata_valores %}
+{% load formata_string %}
+
+{% if dados.dados_lancamentos %}
+  <article class="mt-4">
+    {% for conta in dados.dados_lancamentos %}
+      <table class="table table-bordered tabela-resumo-por-acao nao-quebra-linha">
+        <thead class="">
+
+          <tr class="">
+            <th colSpan="12">
+              <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_lancamentos }}</strong>
+            </th>
+          </tr>
+
+          <tr>
+            <th colSpan="12">
+              <strong class="font-12 titulo-bloco">Conta {{ conta.nome_conta }}</strong>
+            </th>
+          </tr>
+
+          <tr>
+            <th class="font-10 fundo-verde" style="width: 2%"></th>
+            <th class="font-10 fundo-verde" style="width: 10%"><strong>Data</strong></th>
+            <th class="font-10 fundo-verde" style="width: 15%"><strong>Tipo de lançamento</strong></th>
+            <th class="font-10 fundo-verde" style="width: 15%"><strong>Nº do documento</strong></th>
+            <th class="font-10 fundo-verde" style="width: 30%"><strong>Descrição</strong></th>
+            <th class="font-10 fundo-verde" style="width: 13%"><strong>Valor (R$)</strong></th>
+            <th class="font-10 fundo-verde" style="width: 15%"><strong>Demonstrado</strong></th>
+          </tr>
+        </thead>
+
+        {% for lancamento in conta.lancamentos %}
+          <tbody>
+          <tr>
+            <td class="fundo-cinza font-12">{{ forloop.counter }}</td>
+            <td class="fundo-cinza font-12">{{ lancamento.data|date:'d/m/Y' }}</td>
+            {% if lancamento.tipo_transacao == 'Gasto' %}
+              <td class="fundo-cinza font-12">Despesa</td>
+            {% else %}
+              <td class="fundo-cinza font-12">{{ lancamento.tipo_transacao }}</td>
+            {% endif %}
+
+            {% if lancamento.numero_documento == '' %}
+              <td class="fundo-cinza font-12">-</td>
+            {% else %}
+              <td class="fundo-cinza font-12">{{ lancamento.numero_documento }}</td>
+            {% endif %}
+
+            <td class="fundo-cinza font-12">{{ lancamento.descricao }}</td>
+            <td class="fundo-cinza font-12">{{ lancamento.valor_transacao_total|formata_valor }}</td>
+
+            {% if lancamento.conferido %}
+              <td class="fundo-cinza font-12 pt-2"><span class="mt-1 font-10 checkbox-pdf">&#x2714;</span></td>
+            {% else %}
+              <td class="fundo-cinza font-12 pt-2"><span class="mt-1 font-10 checkbox-pdf">&nbsp;</span></td>
+            {% endif %}
+          </tr>
+
+          {% for acerto in lancamento.analise_lancamento.solicitacoes_de_ajuste_da_analise %}
+            <tr class="border-bottom">
+              <td rowspan="1" class="sem-borda pb-4"></td>
+              <td colspan="5" class="sem-borda border-bottom pb-4">
+
+                <div class="row mt-2">
+                  <div class="col-2">
+                    <span class="item font-12"><strong>Item {{ forloop.counter }}</strong></span>
+                  </div>
+
+                  <div class="col-8">
+                    <p class="font-12 mb-0"><strong>Tipo de acerto</strong></p>
+                    <p class="font-12">{{ acerto.tipo_acerto.nome }}</p>
+
+                    {% if acerto.tipo_acerto.categoria == 'DEVOLUCAO' %}
+
+                      <p class="font-12 mb-0"><strong>Tipo de devolução</strong></p>
+                      <p class="font-12">{{ acerto.devolucao_ao_tesouro.tipo.nome }}</p>
+
+                      <p class="font-12 mb-0"><strong>Valor total ou parcial da despesa</strong></p>
+                      {% if acerto.devolucao_ao_tesouro.devolucao_total is True %}
+                        <p class="font-12">Total</p>
+                      {% else %}
+                        <p class="font-12">Parcial</p>
+                      {% endif %}
+
+                      <p class="font-12 mb-0"><strong>Valor (R$)</strong></p>
+                      <p class="font-12">{{ acerto.devolucao_ao_tesouro.valor|formata_valor }}</p>
+
+                      {% if acerto.devolucao_ao_tesouro.motivo %}
+                        <p class="font-12 mb-0"><strong>Motivo</strong></p>
+                        <p class="font-12">{{ acerto.devolucao_ao_tesouro.motivo }}</p>
+                      {% endif %}
+
+                    {% else %}
+
+                      {% if acerto.detalhamento %}
+                        <div class="row mt-2">
+                          <div class="col-12">
+                            <span class="font-12"><strong>Detalhamento do acerto</strong></span>
+                            <br>
+                            <span class="font-12">{{ acerto.detalhamento }}</span>
+                          </div>
+                        </div>
+                      {% endif %}
+
+                    {% endif %}
+                  </div>
+                </div>
+              </td>
+            </tr>
+          {% endfor %} {% comment %}End for acerto{% endcomment %}
+          </tbody>
+        {% endfor %} {% comment %}End for lancamento{% endcomment %}
+      </table>
+    {% endfor %} {% comment %}End for conta{% endcomment %}
+  </article>
+{% endif %}


### PR DESCRIPTION
Esse PR:

- Padroniza o pdf de relatório de acertos na visão da DRE com o layout do relatório de acertos na visão da associação.
- Modifica o serviço dados_relatorio_acertos_service para resgatar o nome da DRE e obter o horário em que o relatório foi gerado.

História: AB#85393
