### PR TITLE
feat(86930): Gerar laudas não exibir conta zerada na lauda

### DIFF
--- a/sme_ptrf_apps/utils/string_to_float.py
+++ b/sme_ptrf_apps/utils/string_to_float.py
@@ -1,0 +1,9 @@
+def string_to_float(string):
+    """
+    Recebe uma string númerica e retorna um número float.
+
+    Exemplos: 
+        string_to_float('12,34') -> 12.34
+        string_to_float('1.234,56') -> 1234.56
+    """
+    return float(string.replace('.', '').replace(',','.'))


### PR DESCRIPTION
Esse PR:

- Altera o serviço lauda_service adicionando uma verificação para não adicionar linhas de contas com valores nulos.
- Altera o serviço lauda_service adicionando uma verificação para não gerar (remover) a lauda caso as contas estejam zeradas ou não exista uma conta vinculada a PC.
- Adiciona uma função para transformar números no formato de string para float.

História: [AB#86930](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/86930)