### PR TITLE
feat(89033):Permite devolução pc anterior com período consecutivo

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -101,7 +101,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     motivos_reprovacao = MotivoReprovacaoSerializer(many=True)
     arquivos_referencia = serializers.SerializerMethodField('get_arquivos_referencia')
     analise_atual = AnalisePrestacaoContaSerializer(many=False)
-    pode_reabrir = serializers.SerializerMethodField('get_pode_reabrir')
+    pode_devolver = serializers.SerializerMethodField('get_pode_devolver')
     informacoes_conciliacao_ue = serializers.SerializerMethodField('get_conciliacao_bancaria_ue')
     referencia_consolidado_dre = serializers.SerializerMethodField('get_referencia_consolidado_dre')
     referencia_consolidado_dre_original = serializers.SerializerMethodField('get_referencia_consolidado_dre_original')
@@ -166,8 +166,8 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
 
         return result
 
-    def get_pode_reabrir(self, obj):
-        return obj.pode_reabrir()
+    def get_pode_devolver(self, obj):
+        return obj.pode_devolver()
 
     def get_ajustes_por_analise(self, prestacao_contas):
         result = []
@@ -246,7 +246,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
             'arquivos_referencia',
             'analise_atual',
             'recomendacoes',
-            'pode_reabrir',
+            'pode_devolver',
             'informacoes_conciliacao_ue',
             'publicada',
             'referencia_consolidado_dre',

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -551,7 +551,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
         if resultado_analise == PrestacaoConta.STATUS_DEVOLVIDA:
-            if not prestacao_conta.pode_reabrir():
+            if not prestacao_conta.pode_devolver():
                 response = {
                     'uuid': f'{uuid}',
                     'erro': 'prestacao_de_contas_posteriores',

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -132,52 +132,7 @@ class AnalisePrestacaoConta(ModeloBase):
 
     @property
     def requer_alteracao_em_lancamentos(self):
-        from sme_ptrf_apps.core.models import TipoAcertoDocumento, TipoAcertoLancamento
-        from sme_ptrf_apps.core.models import SolicitacaoAcertoLancamento, SolicitacaoAcertoDocumento
-        categorias_que_requerem_alteracoes = [
-            TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_CONCILIACAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_DESCONCILIACAO_LANCAMENTO,
-            TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO,
-            TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO,
-            TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO
-        ]
-
-        analises_de_lancamentos_requerem_alteracoes = False
-        analises_de_lancamento_que_requerem_alteracoes = self.analises_de_lancamentos.filter(
-            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
-        )
-        if analises_de_lancamento_que_requerem_alteracoes.exists():
-            for analise_de_lancamento in analises_de_lancamento_que_requerem_alteracoes:
-                solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = analise_de_lancamento.solicitacoes_de_ajuste_da_analise.filter(
-                    tipo_acerto__categoria__in=categorias_que_requerem_alteracoes,
-                    status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_REALIZADO
-                )
-                if solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.exists():
-                    analises_de_lancamentos_requerem_alteracoes = True
-                    break
-
-        analises_de_documentos_requerem_alteracoes = False
-        analises_de_documento_que_requerem_alteracoes = self.analises_de_documento.filter(
-            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
-        )
-        if analises_de_documento_que_requerem_alteracoes.exists():
-            for analise_de_documento in analises_de_documento_que_requerem_alteracoes:
-                solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = analise_de_documento.solicitacoes_de_ajuste_da_analise.filter(
-                    tipo_acerto__categoria__in=categorias_que_requerem_alteracoes,
-                    status_realizacao=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_REALIZADO
-                )
-                if solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.exists():
-                    analises_de_documentos_requerem_alteracoes = True
-                    break
-
-        logger.info(f'Prestação de conta: {self.prestacao_conta.id}')
-        logger.info(f'Análise de Prestação de conta: {self.id}')
-        logger.info(f'analises_de_lancamentos_requerem_alteracoes: {analises_de_lancamentos_requerem_alteracoes}')
-        logger.info(f'analises_de_documentos_requerem_alteracoes: {analises_de_documentos_requerem_alteracoes}')
-        logger.info(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}')
-        return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
+        return self.verifica_se_requer_alteracao_em_lancamentos()
 
     @property
     def requer_informacao_devolucao_ao_tesouro(self):
@@ -320,6 +275,59 @@ class AnalisePrestacaoConta(ModeloBase):
         self.status_versao_apresentacao_apos_acertos = self.STATUS_NAO_GERADO
         self.save()
         logging.info(f'Geração de arquivo pdf do relatorio após acertos {self.pk} cancelada')
+
+    def verifica_se_requer_alteracao_em_lancamentos(self, considera_realizacao=True):
+        from sme_ptrf_apps.core.models import TipoAcertoDocumento, TipoAcertoLancamento
+        from sme_ptrf_apps.core.models import SolicitacaoAcertoLancamento, SolicitacaoAcertoDocumento
+        categorias_que_requerem_alteracoes = [
+            TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
+            TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
+            TipoAcertoLancamento.CATEGORIA_CONCILIACAO_LANCAMENTO,
+            TipoAcertoLancamento.CATEGORIA_DESCONCILIACAO_LANCAMENTO,
+            TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO,
+            TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO,
+            TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO
+        ]
+
+        analises_de_lancamentos_requerem_alteracoes = False
+        analises_de_lancamento_que_requerem_alteracoes = self.analises_de_lancamentos.filter(
+            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
+        )
+        if analises_de_lancamento_que_requerem_alteracoes.exists():
+            for analise_de_lancamento in analises_de_lancamento_que_requerem_alteracoes:
+                solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = analise_de_lancamento.solicitacoes_de_ajuste_da_analise.filter(
+                    tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
+                )
+
+                if(considera_realizacao):
+                    solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.filter(
+                    status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_REALIZADO)
+
+                if solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.exists():
+                    analises_de_lancamentos_requerem_alteracoes = True
+                    break
+
+        analises_de_documentos_requerem_alteracoes = False
+        analises_de_documento_que_requerem_alteracoes = self.analises_de_documento.filter(
+            solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
+        )
+        if analises_de_documento_que_requerem_alteracoes.exists():
+            for analise_de_documento in analises_de_documento_que_requerem_alteracoes:
+                solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = analise_de_documento.solicitacoes_de_ajuste_da_analise.filter(tipo_acerto__categoria__in=categorias_que_requerem_alteracoes)
+
+                if(considera_realizacao):
+                    solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.filter(status_realizacao=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_REALIZADO)
+
+                if solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.exists():
+                    analises_de_documentos_requerem_alteracoes = True
+                    break
+
+        logger.info(f'Prestação de conta: {self.prestacao_conta.id}')
+        logger.info(f'Análise de Prestação de conta: {self.id}')
+        logger.info(f'analises_de_lancamentos_requerem_alteracoes: {analises_de_lancamentos_requerem_alteracoes}')
+        logger.info(f'analises_de_documentos_requerem_alteracoes: {analises_de_documentos_requerem_alteracoes}')
+        logger.info(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}')
+        return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
 
     @classmethod
     def editavel(cls, uuid_analise, visao):

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -299,7 +299,7 @@ class AnalisePrestacaoConta(ModeloBase):
                     tipo_acerto__categoria__in=categorias_que_requerem_alteracoes
                 )
 
-                if(considera_realizacao):
+                if considera_realizacao:
                     solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.filter(
                     status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_REALIZADO)
 
@@ -315,7 +315,7 @@ class AnalisePrestacaoConta(ModeloBase):
             for analise_de_documento in analises_de_documento_que_requerem_alteracoes:
                 solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = analise_de_documento.solicitacoes_de_ajuste_da_analise.filter(tipo_acerto__categoria__in=categorias_que_requerem_alteracoes)
 
-                if(considera_realizacao):
+                if considera_realizacao:
                     solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas = solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.filter(status_realizacao=SolicitacaoAcertoDocumento.STATUS_REALIZACAO_REALIZADO)
 
                 if solicitacoes_de_ajuste_da_analise_que_requerem_alteracoes_realizadas.exists():

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -597,7 +597,7 @@ class PrestacaoConta(ModeloBase):
         return self
 
     def pode_devolver(self):
-        if(self.analise_atual):
+        if self.analise_atual:
             requer_alteracao_em_lancamento = self.analise_atual.verifica_se_requer_alteracao_em_lancamentos(False)
 
             if not requer_alteracao_em_lancamento:

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -596,7 +596,13 @@ class PrestacaoConta(ModeloBase):
         self.save()
         return self
 
-    def pode_reabrir(self):
+    def pode_devolver(self):
+        if(self.analise_atual):
+            requer_alteracao_em_lancamento = self.analise_atual.verifica_se_requer_alteracao_em_lancamentos(False)
+
+            if not requer_alteracao_em_lancamento:
+                return True
+            
         pode_rebrir_pc = not self.associacao.fechamentos_associacao.filter(
             periodo__referencia__gt=self.periodo.referencia
         ).exists()

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_retrieve_prestacao_conta.py
@@ -298,7 +298,7 @@ def test_api_retrieve_prestacao_conta_por_uuid(
                 'uuid': f'{_devolucao_prestacao_conta.uuid}'
             }
         ],
-        'pode_reabrir': True,
+        'pode_devolver': True,
         'processo_sei': '123456',
         'data_ultima_analise': f'{prestacao_conta.data_ultima_analise}',
         'devolucao_ao_tesouro': '100,00',

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_pode_reabrir.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_pode_reabrir.py
@@ -52,7 +52,6 @@ def fechamento_implantacao_2019_1(periodo_implantacao_2019_1, associacao, conta_
         status=STATUS_IMPLANTACAO,
     )
 
-
 @pytest.fixture
 def prestacao_conta_2019_2(periodo_fechamento_2019_2, associacao):
     return baker.make(
@@ -60,7 +59,248 @@ def prestacao_conta_2019_2(periodo_fechamento_2019_2, associacao):
         id=1000,
         periodo=periodo_fechamento_2019_2,
         associacao=associacao,
-        status="EM_ANALISE"
+        status="EM_ANALISE",
+    )
+
+# DOCUMENTO: INCLUSAO_CREDITO.
+@pytest.fixture
+def tipo_acerto_documento_inclusao_credito():
+    return baker.make(
+        'TipoAcertoDocumento', categoria="INCLUSAO_CREDITO"
+    )
+@pytest.fixture
+def solicitacao_acerto_documento_inclusao_credito(
+    analise_documento,
+    tipo_acerto_documento_inclusao_credito,
+):
+    return baker.make(
+        'SolicitacaoAcertoDocumento',
+        analise_documento=analise_documento,
+        tipo_acerto=tipo_acerto_documento_inclusao_credito
+    )
+
+# DOCUMENTO: INCLUSAO_GASTO.
+@pytest.fixture
+def tipo_acerto_documento_inclusao_gasto():
+    return baker.make(
+        'TipoAcertoDocumento', categoria="INCLUSAO_GASTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_documento_inclusao_gasto(
+    analise_documento,
+    tipo_acerto_documento_inclusao_gasto,
+):
+    return baker.make(
+        'SolicitacaoAcertoDocumento',
+        analise_documento=analise_documento,
+        tipo_acerto=tipo_acerto_documento_inclusao_gasto
+    )
+
+# DOCUMENTO: EDICAO_INFORMACAO.
+@pytest.fixture
+def tipo_acerto_documento_edicao_informacao():
+    return baker.make(
+        'TipoAcertoDocumento', categoria="EDICAO_INFORMACAO"
+    )
+@pytest.fixture
+def solicitacao_acerto_documento_edicao_informacao(
+    analise_documento,
+    tipo_acerto_documento_edicao_informacao,
+):
+    return baker.make(
+        'SolicitacaoAcertoDocumento',
+        analise_documento=analise_documento,
+        tipo_acerto=tipo_acerto_documento_edicao_informacao
+    )
+
+# DOCUMENTO: AJUSTES_EXTERNOS. (Não demanda exclusão de documentos e fechamentos)
+@pytest.fixture
+def tipo_acerto_documento_ajustes_externos():
+    return baker.make(
+        'TipoAcertoDocumento', categoria="AJUSTES_EXTERNOS"
+    )
+@pytest.fixture
+def solicitacao_acerto_documento_ajustes_externos(
+    analise_documento,
+    tipo_acerto_documento_ajustes_externos,
+):
+    return baker.make(
+        'SolicitacaoAcertoDocumento',
+        analise_documento=analise_documento,
+        tipo_acerto=tipo_acerto_documento_ajustes_externos
+    )
+
+# DOCUMENTO: SOLICITACAO_ESCLARECIMENTO. (Não demanda exclusão de documentos e fechamentos)
+@pytest.fixture
+def tipo_acerto_documento_solicitacao_esclarecimento():
+    return baker.make(
+        'TipoAcertoDocumento', categoria="SOLICITACAO_ESCLARECIMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_documento_solicitacao_esclarecimento(
+    analise_documento,
+    tipo_acerto_documento_solicitacao_esclarecimento,
+):
+    return baker.make(
+        'SolicitacaoAcertoDocumento',
+        analise_documento=analise_documento,
+        tipo_acerto=tipo_acerto_documento_solicitacao_esclarecimento
+    )
+
+# LANCAMENTO: DEVOLUCAO (Não demanda exclusão de documentos e fechamentos)
+@pytest.fixture
+def tipo_acerto_lancamento_devolucao():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="DEVOLUCAO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_devolucao(
+    analise_lancamento,
+    tipo_acerto_lancamento_devolucao,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_devolucao
+    )
+
+# LANCAMENTO: EDICAO_LANCAMENTO
+@pytest.fixture
+def tipo_acerto_lancamento_edicao_lancamento():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="EDICAO_LANCAMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_edicao_lancamento(
+    analise_lancamento,
+    tipo_acerto_lancamento_edicao_lancamento,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_edicao_lancamento
+    )
+
+# LANCAMENTO: CONCILIACAO_LANCAMENTO
+@pytest.fixture
+def tipo_acerto_lancamento_conciliacao_lancamento():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="CONCILIACAO_LANCAMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_conciliacao_lancamento(
+    analise_lancamento,
+    tipo_acerto_lancamento_conciliacao_lancamento,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_conciliacao_lancamento,
+        devolucao_ao_tesouro=None,
+        detalhamento="teste"
+    )
+
+# LANCAMENTO: DESCONCILIACAO_LANCAMENTO
+@pytest.fixture
+def tipo_acerto_lancamento_desconciliacao_lancamento():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="DESCONCILIACAO_LANCAMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_desconciliacao_lancamento(
+    analise_lancamento,
+    tipo_acerto_lancamento_desconciliacao_lancamento,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_desconciliacao_lancamento
+    )
+
+# LANCAMENTO: EXCLUSAO_LANCAMENTO
+@pytest.fixture
+def tipo_acerto_lancamento_exclusao_lancamento():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="EXCLUSAO_LANCAMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_exclusao_lancamento(
+    analise_lancamento,
+    tipo_acerto_lancamento_exclusao_lancamento,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_exclusao_lancamento
+    )
+
+# LANCAMENTO: AJUSTES_EXTERNOS (Não demanda exclusão de documentos e fechamentos)
+@pytest.fixture
+def tipo_acerto_lancamento_ajustes_externos():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="AJUSTES_EXTERNOS"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_ajustes_externos(
+    analise_lancamento,
+    tipo_acerto_lancamento_ajustes_externos,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_ajustes_externos
+    )
+
+# LANCAMENTO: SOLICITACAO_ESCLARECIMENTO (Não demanda exclusão de documentos e fechamentos)
+@pytest.fixture
+def tipo_acerto_lancamento_solicitacao_esclarecimento():
+    return baker.make(
+        'TipoAcertoLancamento', categoria="SOLICITACAO_ESCLARECIMENTO"
+    )
+@pytest.fixture
+def solicitacao_acerto_lancamento_solicitacao_esclarecimento(
+    analise_lancamento,
+    tipo_acerto_lancamento_solicitacao_esclarecimento,
+):
+    return baker.make(
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto_lancamento_solicitacao_esclarecimento
+    )
+
+@pytest.fixture
+def analise_prestacao_conta_2019_2(prestacao_conta_2019_2):
+    return baker.make(
+        'AnalisePrestacaoConta',
+        prestacao_conta=prestacao_conta_2019_2
+    )
+
+@pytest.fixture
+def prestacao_conta_2019_2_em_analise(periodo_fechamento_2019_2, associacao, analise_prestacao_conta_2019_2):
+    return baker.make(
+        'PrestacaoConta',
+        id=1000,
+        periodo=periodo_fechamento_2019_2,
+        associacao=associacao,
+        data_recebimento=date(2019, 8, 1),
+        status="EM_ANALISE",
+        analise_atual=analise_prestacao_conta_2019_2,
+        criado_em=date(2019, 8, 1)
+    )
+
+@pytest.fixture
+def analise_documento(analise_prestacao_conta_2019_2):
+    return baker.make(
+        'AnaliseDocumentoPrestacaoConta',
+        analise_prestacao_conta=analise_prestacao_conta_2019_2,
+        resultado='AJUSTE'
+    )
+
+@pytest.fixture
+def analise_lancamento(analise_prestacao_conta_2019_2):
+    return baker.make(
+        'AnaliseLancamentoPrestacaoConta',
+        analise_prestacao_conta=analise_prestacao_conta_2019_2,
     )
 
 
@@ -127,29 +367,102 @@ def prestacao_conta_2020_1_devolvida(periodo_fechamento_2020_1, associacao):
         status="DEVOLVIDA"
     )
 
-
-def test_nao_pode_reabrir_se_houver_fechamentos_posteriores(
+def test_pode_devolver_se_os_acertos_nao_demandam_exclusao_de_documentos_e_fechamentos(
     prestacao_conta_2020_1_em_analise,
     fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_documento_ajustes_externos,
+    solicitacao_acerto_documento_solicitacao_esclarecimento,
+    solicitacao_acerto_lancamento_devolucao,
+    solicitacao_acerto_lancamento_ajustes_externos,
+    solicitacao_acerto_lancamento_solicitacao_esclarecimento
+):
+    assert prestacao_conta_2019_2_em_analise.pode_devolver()
+
+def test_nao_pode_devolver_se_tiver_acerto_documento_inclusao_credito(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_documento_inclusao_credito
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver()
+
+def test_nao_pode_devolver_se_tiver_acerto_documento_inclusao_gasto(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_documento_inclusao_gasto
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver()
+
+def test_nao_pode_devolver_se_tiver_acerto_documento_edicao_informacao(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_documento_edicao_informacao
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver()
+
+def test_nao_pode_devolver_se_tiver_acerto_lancamento_edicao_lancamento(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_lancamento_edicao_lancamento
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver() 
+
+def test_nao_pode_devolver_se_tiver_acerto_lancamento_conciliacao_lancamento(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_lancamento_conciliacao_lancamento
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver() 
+
+def test_nao_pode_devolver_se_tiver_acerto_lancamento_desconciliacao_lancamento(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_lancamento_desconciliacao_lancamento
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver()
+
+def test_nao_pode_devolver_se_tiver_acerto_lancamento_exclusao_lancamento(
+    prestacao_conta_2020_1_em_analise,
+    fechamento_2020_1,
+    prestacao_conta_2019_2_em_analise,
+    fechamento_2019_2,
+    fechamento_implantacao_2019_1,
+    solicitacao_acerto_lancamento_exclusao_lancamento
+):
+    assert not prestacao_conta_2019_2_em_analise.pode_devolver() 
+
+def test_pode_devolver_se_nao_houver_fechamentos_posteriores(
     prestacao_conta_2019_2,
     fechamento_2019_2,
     fechamento_implantacao_2019_1,
 ):
-    assert not prestacao_conta_2019_2.pode_reabrir()
+    assert prestacao_conta_2019_2.pode_devolver()
 
 
-def test_pode_reabrir_se_nao_houver_fechamentos_posteriores(
-    prestacao_conta_2019_2,
-    fechamento_2019_2,
-    fechamento_implantacao_2019_1,
-):
-    assert prestacao_conta_2019_2.pode_reabrir()
-
-
-def test_pode_reabrir_quando_proxima_pc_esta_devolvida(
+def test_pode_devolver_quando_proxima_pc_esta_devolvida(
     prestacao_conta_2020_1_devolvida,
     prestacao_conta_2019_2,
     fechamento_implantacao_2019_1,
     fechamento_2019_2
 ):
-    assert prestacao_conta_2019_2.pode_reabrir()
+    assert prestacao_conta_2019_2.pode_devolver()


### PR DESCRIPTION
Esse PR:

- Renomeia no modelo de PC a função "pode_reabrir" por "pode_devolver". Já que o papel dela estava sendo usado para tratar apenas da devolução de PCs.
- Adiciona a verificação de tipos de acertos de lancamentos e documentos que demandam exclusão de documentos e fechamentos.
- Adiciona testes para cada caso de tipo de acerto na devolução de PCs.

História: [AB#89033](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/89033)