### PR TITLE
feat(89232): Altera listagem de periodos na geração de documentos

### DIFF
--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -137,14 +137,15 @@ class Associacao(ModeloIdNome):
                 'cargo_educacao': ''
             }
 
-    def periodos_com_prestacao_de_contas(self, ignorar_devolvidas=False):
+    def periodos_com_prestacao_de_contas(self, ignorar_pcs_com_acertos_que_demandam_exclusoes_e_fechamentos=False):
         periodos = set()
 
         prestacoes_da_associacao = self.prestacoes_de_conta_da_associacao
-        if ignorar_devolvidas:
-            prestacoes_da_associacao = prestacoes_da_associacao.exclude(status='DEVOLVIDA')
 
         for prestacao in prestacoes_da_associacao.all():
+            if ignorar_pcs_com_acertos_que_demandam_exclusoes_e_fechamentos:
+                if prestacao.analise_atual and prestacao.analise_atual.requer_alteracao_em_lancamentos == True:
+                    continue
             periodos.add(prestacao.periodo)
 
         return periodos
@@ -162,7 +163,7 @@ class Associacao(ModeloIdNome):
             return self.periodo_inicial.periodo_seguinte.first() if self.periodo_inicial else None
 
     def periodos_para_prestacoes_de_conta(self):
-        periodos = list(self.periodos_com_prestacao_de_contas(ignorar_devolvidas=True))
+        periodos = list(self.periodos_com_prestacao_de_contas(ignorar_pcs_com_acertos_que_demandam_exclusoes_e_fechamentos=True))
         proximo_periodo = self.proximo_periodo_de_prestacao_de_contas(ignorar_devolvidas=True)
         if proximo_periodo:
             periodos.append(proximo_periodo)


### PR DESCRIPTION
Esse PR:

- Refatora o método que define a listagem de períodos na página de geração de documentos, levando em consideração as prestações de contas com acertos que não demandam exclusões e fechametos.

História: [AB#89232](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/89232)