### PR TITLE
feat(88024): Adiciona campo justificativa e informações adicionais

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/solicitacao_acerto_documento_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/solicitacao_acerto_documento_serializer.py
@@ -16,4 +16,4 @@ class SolicitacaoAcertoDocumentoRetrieveSerializer(serializers.ModelSerializer):
     class Meta:
         model = SolicitacaoAcertoDocumento
         fields = ('analise_documento', 'tipo_acerto', 'detalhamento', 'id', 'uuid', 'copiado', 'status_realizacao',
-                  'justificativa', 'esclarecimentos')
+                  'justificativa', 'esclarecimentos', 'texto_do_acerto_do_tipo_edicao_de_informacao')

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -322,11 +322,11 @@ class AnalisePrestacaoConta(ModeloBase):
                     analises_de_documentos_requerem_alteracoes = True
                     break
 
-        logger.info(f'Prestação de conta: {self.prestacao_conta.id}')
-        logger.info(f'Análise de Prestação de conta: {self.id}')
+        """ logger.info(f'Prestação de conta: {self.prestacao_conta.id}')
+        logger.info(f'Análise de Prestação de conta: {self.id}')K
         logger.info(f'analises_de_lancamentos_requerem_alteracoes: {analises_de_lancamentos_requerem_alteracoes}')
         logger.info(f'analises_de_documentos_requerem_alteracoes: {analises_de_documentos_requerem_alteracoes}')
-        logger.info(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}')
+        logger.info(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}') """
         return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
 
     @classmethod

--- a/sme_ptrf_apps/core/models/solicitacao_acerto_documento.py
+++ b/sme_ptrf_apps/core/models/solicitacao_acerto_documento.py
@@ -4,6 +4,7 @@ from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
 from ...utils.choices_to_json import choices_to_json
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
+from sme_ptrf_apps.core.models.observacao_conciliacao import ObservacaoConciliacao
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -56,6 +57,18 @@ class SolicitacaoAcertoDocumento(ModeloBase):
     receita_incluida = models.ForeignKey('receitas.Receita', on_delete=models.SET_NULL,
                                          related_name='solicitacao_acerto_de_documento_que_incluiu_a_receita',
                                          blank=True, null=True)
+    
+    @property
+    def texto_do_acerto_do_tipo_edicao_de_informacao(self):
+        observacao = ''
+
+        if self.tipo_acerto.categoria == 'EDICAO_INFORMACAO':
+            periodo = self.analise_documento.analise_prestacao_conta.prestacao_conta.periodo
+            associacao = self.analise_documento.analise_prestacao_conta.prestacao_conta.associacao
+            conta = self.analise_documento.conta_associacao
+            observacao = ObservacaoConciliacao.objects.filter(periodo=periodo,conta_associacao=conta,associacao=associacao).first().texto
+
+        return observacao
 
     def __str__(self):
         return f"{self.tipo_acerto} - {self.detalhamento}"

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_documentos/test_get_documentos_solicitacoes_acerto.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/tests_api_documentos/test_get_documentos_solicitacoes_acerto.py
@@ -37,6 +37,7 @@ def test_api_get_solicitacoes_acerto_de_um_documento_nao_por_conta(
                 'analise_documento': f'{analise_documento_prestacao_conta_2020_1_ata_ajuste.uuid}',
                 'copiado': False,
                 'detalhamento': '',
+                'texto_do_acerto_do_tipo_edicao_de_informacao': '',
                 'tipo_acerto': {
                     'ativo': tipo_acerto_documento_assinatura.ativo,
                     'categoria': tipo_acerto_documento_assinatura.categoria,
@@ -103,6 +104,7 @@ def test_api_get_solicitacoes_acerto_de_um_documento_por_conta(
                 'analise_documento': f'{analise_documento_prestacao_conta_2020_1_declaracao_cartao_ajuste.uuid}',
                 'copiado': False,
                 'detalhamento': '',
+                'texto_do_acerto_do_tipo_edicao_de_informacao': '',
                 'tipo_acerto': {
                     'ativo': tipo_acerto_documento_assinatura.ativo,
                     'categoria': tipo_acerto_documento_assinatura.categoria,

--- a/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-documentos.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-documentos.html
@@ -53,6 +53,10 @@
                   <p class="font-12">{{ acerto.esclarecimentos }}</p>
                 {% endif %}
 
+                {% if acerto.texto_do_acerto_do_tipo_edicao_de_informacao %}
+                  <p class="font-12 mb-0"><strong>Justificativa e informações adicionais</strong></p>
+                  <p class="font-12">{{ acerto.texto_do_acerto_do_tipo_edicao_de_informacao }}</p>
+                {% endif %}
               </div>
 
             <div class='col-3'>


### PR DESCRIPTION
Esse PR:

- Adiciona uma property na model de solicitação de acerto de documento para resgatar a observação de conciliação para quando o tipo de acerto é edição de informação.
- Modifica serializer e testes que usam a nova property.
- Adiciona ao PDF da associação pós acerto o campo de observação.

História: [AB#88024](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/88024)