### PR TITLE
feat(89625): Adicionar filtros falha geração de PC

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1238,9 +1238,9 @@ class FalhaGeracaoPcAdmin(admin.ModelAdmin):
     list_display = ['ultimo_usuario', 'associacao', 'periodo', 'data_hora_ultima_ocorrencia',
                     'qtd_ocorrencias_sucessivas', 'resolvido']
     list_filter = ['ultimo_usuario', 'associacao', 'periodo', 'data_hora_ultima_ocorrencia',
-                   'qtd_ocorrencias_sucessivas', 'resolvido']
+                   'qtd_ocorrencias_sucessivas', 'resolvido', 'associacao__unidade__dre']
     readonly_fields = ('uuid', 'id')
-    search_fields = ('ultimo_usuario__username', 'associacao__nome')
+    search_fields = ('ultimo_usuario__username', 'associacao__nome', 'associacao__unidade__nome')
 
 @admin.register(TransferenciaEol)
 class TransferenciaEolAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Esse PR:

- Adiciona o filtro por dre e a pesquisa por nome de unidade no admin de falha de geração de PC.

História: [AB#89625](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/89625)