### PR TITLE
feat(90620): Extração devoluções ao tesouro

### DIFF
--- a/sme_ptrf_apps/sme/services/exporta_devolucao_tesouro_prestacoes_conta.py
+++ b/sme_ptrf_apps/sme/services/exporta_devolucao_tesouro_prestacoes_conta.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.core.files import File
 from sme_ptrf_apps.core.models.ambiente import Ambiente
 from sme_ptrf_apps.core.models.arquivos_download import ArquivoDownload
+from sme_ptrf_apps.core.models.devolucao_ao_tesouro import DevolucaoAoTesouro
 from sme_ptrf_apps.core.models.solicitacao_acerto_lancamento import SolicitacaoAcertoLancamento
 from sme_ptrf_apps.core.services.arquivo_download_service import (
     gerar_arquivo_download
@@ -15,22 +16,22 @@ from tempfile import NamedTemporaryFile
 logger = logging.getLogger(__name__)
 
 CABECALHO = [
-        ('Código EOL', 'prestacao_conta__associacao__unidade__codigo_eol'),
-        ('Nome Unidade', 'prestacao_conta__associacao__unidade__nome'),
-        ('Nome Associação', 'prestacao_conta__associacao__nome'),
-        ('Referência do Período da PC', 'prestacao_conta__periodo__referencia'),
-        ('Status da PC', 'prestacao_conta__status'),
-        ('ID da despesa','despesa__id'),
-        ('Número do documento','despesa__numero_documento'),
-        ('Tipo do documento', 'despesa__tipo_documento__nome'),
-        ('Data do documento', 'despesa__data_documento'),
-        ('CPF_CNPJ do fornecedor', 'despesa__cpf_cnpj_fornecedor'),
-        ('Nome do fornecedor', 'despesa__nome_fornecedor'),
-        ('Tipo de transação', 'despesa__tipo_transacao__nome'),
-        ('Número do documento da transação', 'despesa__documento_transacao'),
-        ('Data da transação', 'despesa__data_transacao'),
-        ('Valor (Despeza)', 'despesa__valor_original'),
-        ('Valor realizado (Despesa)', 'despesa__valor_total'),
+        ('Código EOL', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__associacao__unidade__codigo_eol'),
+        ('Nome Unidade', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__associacao__unidade__nome'),
+        ('Nome Associação', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__associacao__nome'),
+        ('Referência do Período da PC', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__periodo__referencia'),
+        ('Status da PC', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__status'),
+        ('ID da despesa','solicitacao_acerto_lancamento__analise_lancamento__despesa__id'),
+        ('Número do documento','solicitacao_acerto_lancamento__analise_lancamento__despesa__numero_documento'),
+        ('Tipo do documento', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__tipo_documento__nome'),
+        ('Data do documento', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__data_documento'),
+        ('CPF_CNPJ do fornecedor', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__cpf_cnpj_fornecedor'),
+        ('Nome do fornecedor', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__nome_fornecedor'),
+        ('Tipo de transação', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__tipo_transacao__nome'),
+        ('Número do documento da transação', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__documento_transacao'),
+        ('Data da transação', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__data_transacao'),
+        ('Valor (Despeza)', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__valor_original'),
+        ('Valor realizado (Despesa)', 'solicitacao_acerto_lancamento__analise_lancamento__despesa__valor_total'),
         ('Tipo de aplicação do recurso', 'aplicacao_recurso'),
         ('Nome do Tipo de Custeio','tipo_custeio'),
         ('Descrição da especificação de Material ou Serviço','desc_material_serv'),
@@ -38,12 +39,13 @@ CABECALHO = [
         ('Nome da Ação','nome_acao'),
         ('Valor (Rateios)','valor_rateio'),
         ('Valor realizado (Rateio)','valor_realizado'),
-        ('Tipo de devolução','tipo__id'),
-        ('Descrição do Tipo de devolução','tipo__nome'),
+        ('Tipo de devolução','tipo_id'),
+        ('Descrição do Tipo de devolução','tipo_nome'),
         ('Motivo','motivo'),
         ('É devolução total?','devolucao_total'),
         ('Valor (Devolução)','valor'),
-        ('Data de devolução ao tesouro','data')
+        ('Data de devolução ao tesouro','data'),
+        ('Justificativa (não realização)','justificativa')
     ],
 
 
@@ -57,6 +59,7 @@ class ExportacoesDevolucaoTesouroPrestacoesContaService:
         self.user = kwargs.get('user', None)
         self.cabecalho = CABECALHO[0]
         self.ambiente = self.get_ambiente
+        self.objeto_arquivo_download = None
 
     @property 
     def get_ambiente(self): 
@@ -64,10 +67,11 @@ class ExportacoesDevolucaoTesouroPrestacoesContaService:
         return ambiente.prefixo if ambiente else ""
 
     def exporta_devolucao_tesouro_pc(self):
+        self.cria_registro_central_download()
         self.filtra_range_data('criado_em')
-        self.exporta_devolucao_tesouro_pc()
+        self.exporta_devolucao_tesouro_pc_csv()
 
-    def exporta_devolucao_tesouro_pc(self):
+    def exporta_devolucao_tesouro_pc_csv(self):
         dados = self.monta_dados()
 
         with NamedTemporaryFile(
@@ -91,39 +95,49 @@ class ExportacoesDevolucaoTesouroPrestacoesContaService:
 
         for instance in self.queryset:
             linha_horizontal = []
-            rateios = list(instance.despesa.rateios.all())
+
+            devolucao_ao_tesouro = DevolucaoAoTesouro.objects.filter(despesa_id=instance.solicitacao_acerto_lancamento.analise_lancamento.despesa.id).first()
+
+            rateios = list(instance.solicitacao_acerto_lancamento.analise_lancamento.despesa.rateios.all())
 
             for _, campo in self.cabecalho:
 
                 if campo == 'aplicacao_recurso' or campo == 'tipo_custeio' or campo == 'desc_material_serv' or campo == 'nome_tipo_conta' or campo == 'nome_acao' or campo == 'valor_rateio' or campo == 'valor_realizado':
                     linha_horizontal.append('')
-                elif campo == 'despesa__data_documento':
+                elif campo == 'solicitacao_acerto_lancamento__analise_lancamento__despesa__data_documento':
                     campo = get_recursive_attr(instance, campo)
                     data_doc_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
                     linha_horizontal.append(data_doc_formatado)
-                elif campo == 'despesa__data_transacao':
+                elif campo == 'solicitacao_acerto_lancamento__analise_lancamento__despesa__data_transacao':
                     campo = get_recursive_attr(instance, campo)
                     data_tran_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
                     linha_horizontal.append(data_tran_formatado)
-                elif campo == 'data':
-                    campo = get_recursive_attr(instance, campo)
-                    data_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
-                    linha_horizontal.append(data_formatado)
-                elif campo == 'despesa__valor_original':
+                elif campo == 'solicitacao_acerto_lancamento__analise_lancamento__despesa__valor_original':
                     campo = get_recursive_attr(instance, campo)
                     valor_original_formatado = str(campo).replace(".", ",") if campo is not None else ''
                     linha_horizontal.append(valor_original_formatado)
-                elif campo == 'despesa__valor_total':
+                elif campo == 'solicitacao_acerto_lancamento__analise_lancamento__despesa__valor_total':
                     campo = get_recursive_attr(instance, campo)
                     valor_total_formatado = str(campo).replace(".", ",") if campo is not None else ''
                     linha_horizontal.append(valor_total_formatado)
-                elif campo == 'valor':
-                    campo = get_recursive_attr(instance, campo)
-                    valor_formatado = str(campo).replace(".", ",") if campo is not None else ''
-                    linha_horizontal.append(valor_formatado)
+                elif campo == 'tipo_id':
+                    linha_horizontal.append(devolucao_ao_tesouro.tipo.id if devolucao_ao_tesouro is not None else '')
+                elif campo == 'tipo_nome':
+                    linha_horizontal.append(devolucao_ao_tesouro.tipo.nome if devolucao_ao_tesouro is not None else '')
+                elif campo == 'motivo':
+                    linha_horizontal.append(devolucao_ao_tesouro.motivo if devolucao_ao_tesouro is not None else '')
                 elif campo == 'devolucao_total':
-                    campo = get_recursive_attr(instance, campo)
-                    linha_horizontal.append('Sim' if campo else 'Não')
+                    if devolucao_ao_tesouro is not None:   
+                        linha_horizontal.append('Sim' if devolucao_ao_tesouro.devolucao_total else 'Não')
+                    else:
+                        linha_horizontal.append('')
+                elif campo == 'valor':
+                    linha_horizontal.append(str(devolucao_ao_tesouro.valor).replace(".", ",") if devolucao_ao_tesouro is not None else '')
+                elif campo == 'data':
+                    data_formatada = devolucao_ao_tesouro.data.strftime("%d/%m/%Y") if devolucao_ao_tesouro is not None and devolucao_ao_tesouro.data is not None else ''
+                    linha_horizontal.append(data_formatada)
+                elif campo == 'justificativa':
+                    linha_horizontal.append(instance.solicitacao_acerto_lancamento.justificativa if instance.solicitacao_acerto_lancamento.justificativa is not None else '')
                 else:
                     campo = get_recursive_attr(instance, campo)
                     linha_horizontal.append(campo)
@@ -170,27 +184,27 @@ class ExportacoesDevolucaoTesouroPrestacoesContaService:
             )
         return self.queryset
     
-    def envia_arquivo_central_download(self, tmp):
-        logger.info("Gerando arquivo download...")
-        obj_arquivo_download = gerar_arquivo_download(
-            self.user,
-            self.nome_arquivo
-        )
-
-        try:
-            logger.info("Salvando arquivo download...")
-            obj_arquivo_download.arquivo.save(
-                name=obj_arquivo_download.identificador,
-                content=File(tmp)
-            )
-            obj_arquivo_download.status = ArquivoDownload.STATUS_CONCLUIDO
-            obj_arquivo_download.save()
-            logger.info("Arquivo salvo com sucesso...")
-
-        except Exception as e:
-            obj_arquivo_download.status = ArquivoDownload.STATUS_ERRO
-            obj_arquivo_download.msg_erro = str(e)
-            obj_arquivo_download.save()
+    def cria_registro_central_download(self): 
+        logger.info(f"Criando registro na central de download") 
+        obj = gerar_arquivo_download( 
+            self.user, 
+            self.nome_arquivo ) 
+        self.objeto_arquivo_download = obj 
+    
+    def envia_arquivo_central_download(self, tmp): 
+        try: 
+            logger.info("Salvando arquivo download...") 
+            self.objeto_arquivo_download.arquivo.save( 
+                name=self.objeto_arquivo_download.identificador, 
+                content=File(tmp) 
+            ) 
+            self.objeto_arquivo_download.status = ArquivoDownload.STATUS_CONCLUIDO 
+            self.objeto_arquivo_download.save() 
+            logger.info("Arquivo salvo com sucesso...") 
+        except Exception as e: 
+            self.objeto_arquivo_download.status = ArquivoDownload.STATUS_ERRO 
+            self.objeto_arquivo_download.msg_erro = str(e) 
+            self.objeto_arquivo_download.save() 
             logger.error("Erro arquivo download...")
 
     def texto_rodape(self):

--- a/sme_ptrf_apps/sme/services/exporta_devolucao_tesouro_prestacoes_conta.py
+++ b/sme_ptrf_apps/sme/services/exporta_devolucao_tesouro_prestacoes_conta.py
@@ -43,7 +43,7 @@ CABECALHO = [
         ('Motivo','motivo'),
         ('É devolução total?','devolucao_total'),
         ('Valor (Devolução)','valor'),
-        ('Data de devolução ao tesouro','data'),
+        ('Data de devolução ao tesouro','data')
     ],
 
 
@@ -99,27 +99,27 @@ class ExportacoesDevolucaoTesouroPrestacoesContaService:
                     linha_horizontal.append('')
                 elif campo == 'despesa__data_documento':
                     campo = get_recursive_attr(instance, campo)
-                    data_doc_formatado = campo.strftime("%d/%m/%Y")
+                    data_doc_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
                     linha_horizontal.append(data_doc_formatado)
                 elif campo == 'despesa__data_transacao':
                     campo = get_recursive_attr(instance, campo)
-                    data_tran_formatado = campo.strftime("%d/%m/%Y")
+                    data_tran_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
                     linha_horizontal.append(data_tran_formatado)
                 elif campo == 'data':
                     campo = get_recursive_attr(instance, campo)
-                    data_formatado = campo.strftime("%d/%m/%Y")
+                    data_formatado = campo.strftime("%d/%m/%Y") if campo is not None else ''
                     linha_horizontal.append(data_formatado)
                 elif campo == 'despesa__valor_original':
                     campo = get_recursive_attr(instance, campo)
-                    valor_original_formatado = str(campo).replace(".", ",")
+                    valor_original_formatado = str(campo).replace(".", ",") if campo is not None else ''
                     linha_horizontal.append(valor_original_formatado)
                 elif campo == 'despesa__valor_total':
                     campo = get_recursive_attr(instance, campo)
-                    valor_total_formatado = str(campo).replace(".", ",")
+                    valor_total_formatado = str(campo).replace(".", ",") if campo is not None else ''
                     linha_horizontal.append(valor_total_formatado)
                 elif campo == 'valor':
                     campo = get_recursive_attr(instance, campo)
-                    valor_formatado = str(campo).replace(".", ",")
+                    valor_formatado = str(campo).replace(".", ",") if campo is not None else ''
                     linha_horizontal.append(valor_formatado)
                 elif campo == 'devolucao_total':
                     campo = get_recursive_attr(instance, campo)

--- a/sme_ptrf_apps/sme/tasks.py
+++ b/sme_ptrf_apps/sme/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from celery import shared_task
 from sme_ptrf_apps.core.models.devolucao_ao_tesouro import DevolucaoAoTesouro
+from sme_ptrf_apps.core.models.solicitacao_devolucao_ao_tesouro import SolicitacaoDevolucaoAoTesouro
 from sme_ptrf_apps.despesas.models.especificacao_material_servico import EspecificacaoMaterialServico
 from sme_ptrf_apps.despesas.models.tipo_custeio import TipoCusteio
 from sme_ptrf_apps.core.models.prestacao_conta import PrestacaoConta
@@ -56,7 +57,7 @@ def exportar_receitas_async(data_inicio, data_final, username):
     retry_backoff=2,
     retry_kwargs={'max_retries': 8},
     time_limet=600,
-    soft_time_limit=300
+    soft_time_limit=30000
 )
 def exportar_materiais_e_servicos_async(data_inicio, data_final, username):
     logger.info("Exportando csv em processamento...")
@@ -155,7 +156,7 @@ def exportar_relacao_bens_async(data_inicio, data_final, username):
     retry_backoff=2,
     retry_kwargs={'max_retries': 8},
     time_limet=600,
-    soft_time_limit=300
+    soft_time_limit=30000
 )
 def exportar_status_prestacoes_contas_async(data_inicio, data_final, username):
     logger.info("Exportando csv em processamento...")
@@ -186,12 +187,12 @@ def exportar_status_prestacoes_contas_async(data_inicio, data_final, username):
     retry_backoff=2,
     retry_kwargs={'max_retries': 8},
     time_limet=600,
-    soft_time_limit=300
+    soft_time_limit=30000
 )
 def exportar_devolucoes_ao_tesouro_async(data_inicio, data_final, username):
     logger.info("Exportando csv em processamento...")
 
-    queryset = DevolucaoAoTesouro.objects.all().order_by('criado_em')
+    queryset = SolicitacaoDevolucaoAoTesouro.objects.all().order_by('criado_em')
 
     try:
         logger.info("Criando arquivo %s pcs_devolucoes_tesouro.csv")

--- a/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_dados_devolucao_tesouro/conftest.py
+++ b/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_dados_devolucao_tesouro/conftest.py
@@ -1,168 +1,122 @@
 import pytest
 import datetime
 
-from datetime import date
+from datetime import date, timedelta
 
 from model_bakery import baker
 from sme_ptrf_apps.core.models.devolucao_ao_tesouro import DevolucaoAoTesouro
 
 from sme_ptrf_apps.core.models.prestacao_conta import PrestacaoConta
+from sme_ptrf_apps.core.models.solicitacao_devolucao_ao_tesouro import SolicitacaoDevolucaoAoTesouro
 from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CUSTEIO
 
 pytestmark = pytest.mark.django_db
 
 @pytest.fixture
-def prestacao_conta_em_analise(periodo, associacao):
+def rateio_despesa_01(associacao, despesa_no_periodo, conta_associacao, acao, tipo_aplicacao_recurso_custeio, tipo_custeio_material, especificacao_material_eletrico, acao_associacao):
     return baker.make(
-        'PrestacaoConta',
-        periodo=periodo,
+        'RateioDespesa',
+        despesa=despesa_no_periodo,
         associacao=associacao,
-        data_recebimento=date(2020, 10, 1),
-        status=PrestacaoConta.STATUS_EM_ANALISE
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_material,
+        especificacao_material_servico=especificacao_material_eletrico,
+        valor_rateio=200.00,
+        valor_original=200.00,
+        quantidade_itens_capital=2,
+        valor_item_capital=100.00
     )
 
 @pytest.fixture
-def outra_prestacao_conta_em_analise(periodo, outra_associacao):
+def rateio_despesa_02(associacao, despesa_no_periodo, conta_associacao, acao,tipo_aplicacao_recurso_custeio, tipo_custeio, tipo_custeio_material, especificacao_material_eletrico, acao_associacao):
     return baker.make(
-        'PrestacaoConta',
-        periodo=periodo,
-        associacao=outra_associacao,
-        data_recebimento=date(2020, 8, 1),
-        status=PrestacaoConta.STATUS_EM_ANALISE
+        'RateioDespesa',
+        despesa=despesa_no_periodo,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio,
+        valor_rateio=100.00,
+        valor_original=100.00,
     )
 
 @pytest.fixture
-def tipo_devolucao_ao_tesouro():
-    return baker.make('TipoDevolucaoAoTesouro', nome='Tipo devolução 1', id=10)
-
-@pytest.fixture
-def outro_tipo_devolucao_ao_tesouro():
-    return baker.make('TipoDevolucaoAoTesouro', nome='Tipo devolução 2', id=11)
-
-@pytest.fixture
-def despesa(associacao, tipo_documento, tipo_transacao):
+def despesa_no_periodo(associacao, tipo_documento, tipo_transacao, periodo):
     return baker.make(
         'Despesa',
         id=10,
         associacao=associacao,
         numero_documento='123456',
-        data_documento=date(2020, 3, 10),
+        data_documento=periodo.data_inicio_realizacao_despesas,
         tipo_documento=tipo_documento,
         cpf_cnpj_fornecedor='11.478.276/0001-04',
         nome_fornecedor='Fornecedor SA',
         tipo_transacao=tipo_transacao,
-        data_transacao=date(2020, 3, 10),
-        valor_total=100.00,
-        documento_transacao=12345
+        data_transacao=periodo.data_inicio_realizacao_despesas,
+        valor_total=300.00,
+        valor_original=300,
+        documento_transacao=312321
     )
 
 @pytest.fixture
-def tipo_aplicacao_recurso():
-    return APLICACAO_CUSTEIO
-
-@pytest.fixture
-def especificacao_material_servico(tipo_aplicacao_recurso, tipo_custeio):
+def analise_lancamento_receita_prestacao_conta_2020_1(analise_prestacao_conta_2020_1, receita_no_periodo_2020_1, despesa_no_periodo):
     return baker.make(
-        'EspecificacaoMaterialServico',
-        descricao='Material elétrico',
-        aplicacao_recurso=tipo_aplicacao_recurso,
-        tipo_custeio=tipo_custeio,
+        'AnaliseLancamentoPrestacaoConta',
+        analise_prestacao_conta=analise_prestacao_conta_2020_1,
+        tipo_lancamento='CREDITO',
+        receita=receita_no_periodo_2020_1,
+        resultado='CORRETO',
+        despesa=despesa_no_periodo
     )
 
 @pytest.fixture
-def outra_especificacao_material_servico(tipo_aplicacao_recurso, tipo_custeio):
+def solicitacao_acerto_lancamento_devolucao(
+    analise_lancamento_receita_prestacao_conta_2020_1,
+    tipo_acerto_lancamento_devolucao,
+
+):
     return baker.make(
-        'EspecificacaoMaterialServico',
-        descricao='Material de construção',
-        aplicacao_recurso=tipo_aplicacao_recurso,
-        tipo_custeio=tipo_custeio,
+        'SolicitacaoAcertoLancamento',
+        analise_lancamento=analise_lancamento_receita_prestacao_conta_2020_1,
+        tipo_acerto=tipo_acerto_lancamento_devolucao,
+        devolucao_ao_tesouro=None,
+        detalhamento="teste"
     )
 
 @pytest.fixture
-def primeiro_rateio(associacao, despesa, conta_associacao, acao, tipo_aplicacao_recurso_custeio,
-                                    tipo_custeio_servico, especificacao_material_servico, acao_associacao):
-    return baker.make(
-        'RateioDespesa',
-        despesa=despesa,
-        associacao=associacao,
-        conta_associacao=conta_associacao,
-        acao_associacao=acao_associacao,
-        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
-        tipo_custeio=tipo_custeio_servico,
-        especificacao_material_servico=especificacao_material_servico,
-        valor_rateio=20.00,
-        valor_original=10.00
-    )
+def tipo_devolucao_ao_tesouro_teste():
+    return baker.make('TipoDevolucaoAoTesouro', id='20', nome='Teste tipo devolução')
 
 @pytest.fixture
-def segundo_rateio(associacao, despesa, conta_associacao, acao, tipo_aplicacao_recurso_custeio,
-                                    tipo_custeio_servico, especificacao_material_servico, acao_associacao):
-    return baker.make(
-        'RateioDespesa',
-        despesa=despesa,
-        associacao=associacao,
-        conta_associacao=conta_associacao,
-        acao_associacao=acao_associacao,
-        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
-        tipo_custeio=tipo_custeio_servico,
-        especificacao_material_servico=especificacao_material_servico,
-        valor_rateio=80.00,
-        valor_original=70.00
-    )
-
-@pytest.fixture
-def outra_despesa(outra_associacao, tipo_documento, tipo_transacao):
-    return baker.make(
-        'Despesa',
-        id=11,
-        associacao=outra_associacao,
-        numero_documento='123456',
-        data_documento=date(2020, 3, 10),
-        tipo_documento=tipo_documento,
-        cpf_cnpj_fornecedor='11.478.276/0001-04',
-        nome_fornecedor='Fornecedor SA',
-        tipo_transacao=tipo_transacao,
-        data_transacao=date(2020, 3, 10),
-        valor_total=200.00,
-        documento_transacao=6789
-    )
-
-@pytest.fixture
-def devolucao_ao_tesouro(prestacao_conta_em_analise, tipo_devolucao_ao_tesouro, despesa, primeiro_rateio, segundo_rateio):
+def devolucao_ao_tesouro_parcial(prestacao_conta_2020_1_conciliada, tipo_devolucao_ao_tesouro_teste, despesa_no_periodo):
     return baker.make(
         'DevolucaoAoTesouro',
-        prestacao_conta=prestacao_conta_em_analise,
-        tipo=tipo_devolucao_ao_tesouro,
-        data=date(2020, 7, 1),
-        despesa=despesa,
-        devolucao_total=True,
+        prestacao_conta=prestacao_conta_2020_1_conciliada,
+        tipo=tipo_devolucao_ao_tesouro_teste,
+        data=date(2020, 6, 6),
+        despesa=despesa_no_periodo,
         valor=100.00,
-        motivo='Motivo teste 1',
-        criado_em=datetime.date(2020, 1, 1)
-    )
-
-@pytest.fixture
-def outra_devolucao_ao_tesouro(outra_prestacao_conta_em_analise, outro_tipo_devolucao_ao_tesouro, outra_despesa):
-    return baker.make(
-        'DevolucaoAoTesouro',
-        prestacao_conta=outra_prestacao_conta_em_analise,
-        tipo=outro_tipo_devolucao_ao_tesouro,
-        data=date(2020, 5, 1),
-        despesa=outra_despesa,
+        motivo='Motivo devolucao parcial teste',
         devolucao_total=False,
-        valor=50.00,
-        motivo='Motivo teste 2',
-        criado_em=datetime.date(2021, 1, 1)
     )
 
 @pytest.fixture
-def ambiente():
+def solicitacao_devolucao_ao_tesouro(
+    solicitacao_acerto_lancamento_devolucao,
+    tipo_devolucao_ao_tesouro_teste,
+):
     return baker.make(
-        'Ambiente',
-        prefixo='dev-sig-escola',
-        nome='Ambiente de desenvolvimento',
+        'SolicitacaoDevolucaoAoTesouro',
+        solicitacao_acerto_lancamento=solicitacao_acerto_lancamento_devolucao,
+        tipo=tipo_devolucao_ao_tesouro_teste,
+        devolucao_total=False,
+        valor=100.00,
+        motivo='teste',
     )
 
 @pytest.fixture
-def queryset_ordered(devolucao_ao_tesouro, outra_devolucao_ao_tesouro):
-    return DevolucaoAoTesouro.objects.all().order_by('criado_em')
+def queryset_ordered(rateio_despesa_01, rateio_despesa_02, devolucao_ao_tesouro_parcial, solicitacao_devolucao_ao_tesouro):
+    return SolicitacaoDevolucaoAoTesouro.objects.all().order_by('criado_em')


### PR DESCRIPTION
Esse PR:

- Modifica a entidade base para a extração de dados que era as devoluções ao tesouro para as solicitações de devoluções ao tesouro.
- Adiciona o campo de justificativa de não realização da devolução ao tesouro.
- Altera soft time das tasks de extração de dados.
- Adiciona e melhora testes da extração de dados de devoluções ao tesouro.
- Adiciona método que adiciona indicativo de arquivo em processo de download na central de download.

História: [AB#90620](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/90620)