### PR TITLE
fix(92293): Corrige cópia de entradas na transferência de EOL

### DIFF
--- a/sme_ptrf_apps/core/models/transferencia_eol.py
+++ b/sme_ptrf_apps/core/models/transferencia_eol.py
@@ -335,6 +335,7 @@ class TransferenciaEol(ModeloBase):
             receita.uuid = uuid.uuid4()
             receita.associacao = associacao_nova
             receita.conta_associacao = associacao_nova.contas.filter(tipo_conta=self.tipo_conta_transferido).first()
+            receita.acao_associacao = associacao_nova.acoes.filter(acao=receita.acao_associacao.acao).first()
             receita.save()
             self.adicionar_log_info(f'Receita  {receita} copiada para a nova associação.')
 

--- a/sme_ptrf_apps/core/tests/tests_transferencia_eol/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_transferencia_eol/conftest.py
@@ -279,6 +279,30 @@ def transf_eol_associacao_nova(transf_eol_unidade_eol_historico, transferencia_e
 
 
 @pytest.fixture
+def transf_eol_acao_associacao_ptrf_nova(transf_eol_associacao_nova, transf_eol_acao_ptrf):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=transf_eol_associacao_nova,
+        acao=transf_eol_acao_ptrf
+    )
+
+@pytest.fixture
+def transf_eol_conta_associacao_cartao_nova(
+    transf_eol_associacao_nova,
+    transf_eol_tipo_conta_cartao
+):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=transf_eol_associacao_nova,
+        tipo_conta=transf_eol_tipo_conta_cartao,
+        banco_nome='ITAU',
+        agencia='45678',
+        numero_conta='999999-x',
+    )
+
+
+
+@pytest.fixture
 def transf_eol_despesa_2_conta_cheque(
     transf_eol_associacao_eol_transferido,
     tipo_documento,

--- a/sme_ptrf_apps/core/tests/tests_transferencia_eol/test_copiar_receitas_associacao_do_tipo_transferido.py
+++ b/sme_ptrf_apps/core/tests/tests_transferencia_eol/test_copiar_receitas_associacao_do_tipo_transferido.py
@@ -10,6 +10,8 @@ def test_deve_copiar_as_receitas_da_associacao_origem_que_tenham_o_tipo_de_conta
     transf_eol_acao_associacao_ptrf,
     transf_eol_acao_associacao_role,
     transf_eol_associacao_nova,
+    transf_eol_acao_associacao_ptrf_nova,
+    transf_eol_conta_associacao_cartao_nova,
     transf_eol_acao_ptrf,
     transf_eol_acao_role,
     transf_eol_conta_associacao_cheque,
@@ -23,7 +25,18 @@ def test_deve_copiar_as_receitas_da_associacao_origem_que_tenham_o_tipo_de_conta
     receitas_original = transf_eol_associacao_eol_transferido.receitas.all()
     receitas_nova = transf_eol_associacao_nova.receitas.all()
 
+    assert transf_eol_receita_conta_cartao.acao_associacao is not None
+
     assert receitas_nova.count() == 1, "Deve ter copiado apenas as receitas que possuem rateios em contas_associacao de tipo_conta transferido"
-    assert receitas_nova.first().detalhe_outros == transf_eol_receita_conta_cartao.detalhe_outros, "Deve ter copiado a receita correta"
+
+    receita_copiada = receitas_nova.first()
+    assert receita_copiada.detalhe_outros == transf_eol_receita_conta_cartao.detalhe_outros, "Deve ter copiado a receita correta"
+
+    assert receita_copiada.acao_associacao is not None, "A ação deve ser copiada"
+    assert receita_copiada.acao_associacao.associacao == transf_eol_associacao_nova, "A ação deve ser da nova associação"
+
+    assert receita_copiada.conta_associacao is not None, "A conta_associacao deve ser copiada"
+    assert receita_copiada.conta_associacao.associacao == transf_eol_associacao_nova, "A conta_associacao deve ser da nova associação"
+
     assert receitas_original.count() == 2, "A associação original deve manter as receitas originais"
 

--- a/sme_ptrf_apps/receitas/admin.py
+++ b/sme_ptrf_apps/receitas/admin.py
@@ -23,10 +23,27 @@ def customTitledFilter(title):
 
 @admin.register(Receita)
 class ReceitaAdmin(admin.ModelAdmin):
-
+    raw_id_fields = (
+        'associacao',
+        'conta_associacao',
+        'acao_associacao',
+        'tipo_receita',
+        'repasse',
+        'detalhe_tipo_receita',
+        'referencia_devolucao',
+        'periodo_conciliacao',
+        'saida_do_recurso',
+        'rateio_estornado',
+    )
     list_display = ('data', 'valor', 'categoria_receita', 'detalhamento', 'associacao', 'repasse','status')
     ordering = ('-data',)
-    search_fields = ('detalhe_tipo_receita__nome', 'detalhe_outros', 'associacao__nome', 'associacao__unidade__nome', 'associacao__unidade__codigo_eol')
+    search_fields = (
+        'detalhe_tipo_receita__nome',
+        'detalhe_outros',
+        'associacao__nome',
+        'associacao__unidade__nome',
+        'associacao__unidade__codigo_eol'
+    )
     list_filter = (
         ('conferido', customTitledFilter('Conferido')),
         ('data', DateRangeFilter),
@@ -34,9 +51,7 @@ class ReceitaAdmin(admin.ModelAdmin):
         ('acao_associacao__acao__nome', customTitledFilter('Ação')),
         ('conta_associacao__tipo_conta__nome', customTitledFilter('Tipo Conta')),
         ('tipo_receita', customTitledFilter('Tipo Receita')),
-        'detalhe_tipo_receita',
         'categoria_receita',
-        'repasse',
         'status',
     )
     readonly_fields = ('uuid', 'id',)


### PR DESCRIPTION
Esse PR:

- [X] Corrige a cópia de receitas da Associação histórico para referenciar a nova ação_associação
- [X] Alterar os testes unitários para testar a cópia dos campos de ação e conta.
- [X] Faz melhorias no admin de receitas 

Resolve [AB#92293](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/92293)