### PR TITLE
Hotfix/7.1.1 (#1951)

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "7.1.0"
+__version__ = "7.1.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/models/transferencia_eol.py
+++ b/sme_ptrf_apps/core/models/transferencia_eol.py
@@ -335,6 +335,7 @@ class TransferenciaEol(ModeloBase):
             receita.uuid = uuid.uuid4()
             receita.associacao = associacao_nova
             receita.conta_associacao = associacao_nova.contas.filter(tipo_conta=self.tipo_conta_transferido).first()
+            receita.acao_associacao = associacao_nova.acoes.filter(acao=receita.acao_associacao.acao).first()
             receita.save()
             self.adicionar_log_info(f'Receita  {receita} copiada para a nova associação.')
 

--- a/sme_ptrf_apps/core/tests/tests_transferencia_eol/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_transferencia_eol/conftest.py
@@ -279,6 +279,30 @@ def transf_eol_associacao_nova(transf_eol_unidade_eol_historico, transferencia_e
 
 
 @pytest.fixture
+def transf_eol_acao_associacao_ptrf_nova(transf_eol_associacao_nova, transf_eol_acao_ptrf):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=transf_eol_associacao_nova,
+        acao=transf_eol_acao_ptrf
+    )
+
+@pytest.fixture
+def transf_eol_conta_associacao_cartao_nova(
+    transf_eol_associacao_nova,
+    transf_eol_tipo_conta_cartao
+):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=transf_eol_associacao_nova,
+        tipo_conta=transf_eol_tipo_conta_cartao,
+        banco_nome='ITAU',
+        agencia='45678',
+        numero_conta='999999-x',
+    )
+
+
+
+@pytest.fixture
 def transf_eol_despesa_2_conta_cheque(
     transf_eol_associacao_eol_transferido,
     tipo_documento,

--- a/sme_ptrf_apps/core/tests/tests_transferencia_eol/test_copiar_receitas_associacao_do_tipo_transferido.py
+++ b/sme_ptrf_apps/core/tests/tests_transferencia_eol/test_copiar_receitas_associacao_do_tipo_transferido.py
@@ -10,6 +10,8 @@ def test_deve_copiar_as_receitas_da_associacao_origem_que_tenham_o_tipo_de_conta
     transf_eol_acao_associacao_ptrf,
     transf_eol_acao_associacao_role,
     transf_eol_associacao_nova,
+    transf_eol_acao_associacao_ptrf_nova,
+    transf_eol_conta_associacao_cartao_nova,
     transf_eol_acao_ptrf,
     transf_eol_acao_role,
     transf_eol_conta_associacao_cheque,
@@ -23,7 +25,18 @@ def test_deve_copiar_as_receitas_da_associacao_origem_que_tenham_o_tipo_de_conta
     receitas_original = transf_eol_associacao_eol_transferido.receitas.all()
     receitas_nova = transf_eol_associacao_nova.receitas.all()
 
+    assert transf_eol_receita_conta_cartao.acao_associacao is not None
+
     assert receitas_nova.count() == 1, "Deve ter copiado apenas as receitas que possuem rateios em contas_associacao de tipo_conta transferido"
-    assert receitas_nova.first().detalhe_outros == transf_eol_receita_conta_cartao.detalhe_outros, "Deve ter copiado a receita correta"
+
+    receita_copiada = receitas_nova.first()
+    assert receita_copiada.detalhe_outros == transf_eol_receita_conta_cartao.detalhe_outros, "Deve ter copiado a receita correta"
+
+    assert receita_copiada.acao_associacao is not None, "A ação deve ser copiada"
+    assert receita_copiada.acao_associacao.associacao == transf_eol_associacao_nova, "A ação deve ser da nova associação"
+
+    assert receita_copiada.conta_associacao is not None, "A conta_associacao deve ser copiada"
+    assert receita_copiada.conta_associacao.associacao == transf_eol_associacao_nova, "A conta_associacao deve ser da nova associação"
+
     assert receitas_original.count() == 2, "A associação original deve manter as receitas originais"
 

--- a/sme_ptrf_apps/receitas/admin.py
+++ b/sme_ptrf_apps/receitas/admin.py
@@ -23,10 +23,27 @@ def customTitledFilter(title):
 
 @admin.register(Receita)
 class ReceitaAdmin(admin.ModelAdmin):
-
+    raw_id_fields = (
+        'associacao',
+        'conta_associacao',
+        'acao_associacao',
+        'tipo_receita',
+        'repasse',
+        'detalhe_tipo_receita',
+        'referencia_devolucao',
+        'periodo_conciliacao',
+        'saida_do_recurso',
+        'rateio_estornado',
+    )
     list_display = ('data', 'valor', 'categoria_receita', 'detalhamento', 'associacao', 'repasse','status')
     ordering = ('-data',)
-    search_fields = ('detalhe_tipo_receita__nome', 'detalhe_outros', 'associacao__nome', 'associacao__unidade__nome', 'associacao__unidade__codigo_eol')
+    search_fields = (
+        'detalhe_tipo_receita__nome',
+        'detalhe_outros',
+        'associacao__nome',
+        'associacao__unidade__nome',
+        'associacao__unidade__codigo_eol'
+    )
     list_filter = (
         ('conferido', customTitledFilter('Conferido')),
         ('data', DateRangeFilter),
@@ -34,9 +51,7 @@ class ReceitaAdmin(admin.ModelAdmin):
         ('acao_associacao__acao__nome', customTitledFilter('Ação')),
         ('conta_associacao__tipo_conta__nome', customTitledFilter('Tipo Conta')),
         ('tipo_receita', customTitledFilter('Tipo Receita')),
-        'detalhe_tipo_receita',
         'categoria_receita',
-        'repasse',
         'status',
     )
     readonly_fields = ('uuid', 'id',)

--- a/sme_ptrf_apps/users/api/serializers/senha_serializer.py
+++ b/sme_ptrf_apps/users/api/serializers/senha_serializer.py
@@ -44,7 +44,7 @@ class EsqueciMinhaSenhaSerializer(serializers.ModelSerializer):
         except Exception as err:
             logger.info("Erro ao enviar email: %s", str(err))
             raise ProblemaEnvioEmail("Problema ao enviar email.")
-        
+
         instance.email = result['email'].strip()
         instance.save()
         return instance
@@ -80,18 +80,17 @@ class RedefinirSenhaSerializerCreator(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         try:
-            result = SmeIntegracaoService.redefine_senha(instance.username, validated_data['password'])
+            SmeIntegracaoService.redefine_senha(instance.username, validated_data['password'])
             instance.set_password(validated_data.get('password'))
             instance.hash_redefinicao = ''
             instance.save()
-            return Response(result)
+            return instance
         except SmeIntegracaoException as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except ReadTimeout:
             return Response({'detail': 'EOL Timeout'}, status=status.HTTP_400_BAD_REQUEST)
         except ConnectTimeout:
             return Response({'detail': 'EOL Timeout'}, status=status.HTTP_400_BAD_REQUEST)
-        return instance
 
     class Meta:
         model = User

--- a/sme_ptrf_apps/users/api/views/senha_viewset.py
+++ b/sme_ptrf_apps/users/api/views/senha_viewset.py
@@ -54,7 +54,7 @@ class RedefinirSenhaViewSet(viewsets.ModelViewSet):
         usuario = User.objects.get(hash_redefinicao=validated_data.get('hash_redefinicao'))
         result = serialize.update(usuario, validated_data)
         if isinstance(result, Response):
-            logger.error('Erro ao alterar a senha:', result)
+            logger.error(f'Erro ao alterar a senha: {result}')
             return result
         return Response({'detail': 'Senha redefinida com sucesso'}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
* Hotfix 7.1.1

Altera versão.

* fix(91941): Redefinição de senha (#1948)

Agora a redefinição de senha ira ocorrer sem erros

* fix(92293): transf eol (#1949)

* fix(92293): Corrige gravação de ação receita em transferência de EOL

Na transferência de eol a ação da receita copiada não estava sendo atualizado e ficava apontando para a da associação histórico.

* fix(92293): Melhora performance do admin de receitas

* fix(92293): Inclui testes para a cópia da ação e conta da entrada

---------



---------