### PR TITLE
feat(91685): Acomp PC cards ignorando encerradas e não iniciadas

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -287,6 +287,15 @@ def unidade(dre):
         dre_designacao_ano='2017',
     )
 
+@pytest.fixture
+def outra_unidade(dre):
+    return baker.make(
+        'Unidade',
+        nome='Outra Escola Teste',
+        tipo_unidade='CEU',
+        codigo_eol='777777',
+        dre=dre,
+    )
 
 @pytest.fixture
 def associacao(unidade, periodo_anterior):
@@ -300,6 +309,49 @@ def associacao(unidade, periodo_anterior):
         email="ollyverottoboni@gmail.com",
         processo_regularidade='123456'
     )
+
+@pytest.fixture
+def associacao_iniciada_2020_1(periodo_2020_1, unidade):
+    return baker.make(
+        'Associacao',
+        nome='Escola Iniciada em 2020.1',
+        cnpj='99.073.449/0001-47',
+        unidade=unidade,
+        periodo_inicial=periodo_2020_1,
+    )
+
+@pytest.fixture
+def associacao_iniciada_2020_2(periodo_2020_2, outra_unidade):
+    return baker.make(
+        'Associacao',
+        nome='Escola Iniciada em 2020.2',
+        cnpj='23.500.058/0001-08',
+        unidade=outra_unidade,
+        periodo_inicial=periodo_2020_2,
+    )
+
+@pytest.fixture
+def associacao_encerrada_2020_1(periodo_2019_2, periodo_2020_1, unidade):
+    return baker.make(
+        'Associacao',
+        nome='Escola Encerrada em 2020.1',
+        cnpj='99.073.449/0001-47',
+        unidade=unidade,
+        periodo_inicial=periodo_2019_2,
+        data_de_encerramento = periodo_2020_1.data_fim_realizacao_despesas,
+    )
+
+@pytest.fixture
+def associacao_encerrada_2020_2(periodo_2019_2, periodo_2020_2, outra_unidade):
+    return baker.make(
+        'Associacao',
+        nome='Escola Iniciada em 2020.2',
+        cnpj='23.500.058/0001-08',
+        unidade=outra_unidade,
+        periodo_inicial=periodo_2019_2,
+        data_de_encerramento=periodo_2020_2.data_fim_realizacao_despesas,
+    )
+
 
 
 @pytest.fixture
@@ -541,6 +593,25 @@ def periodo_2020_1(periodo):
         periodo_anterior=periodo
     )
 
+@pytest.fixture
+def periodo_2020_2(periodo_2020_1):
+    return baker.make(
+        'Periodo',
+        referencia='2020.2',
+        data_inicio_realizacao_despesas=date(2020, 7, 1),
+        data_fim_realizacao_despesas=date(2020, 12, 31),
+        periodo_anterior=periodo_2020_1,
+    )
+
+@pytest.fixture
+def periodo_2021_1(periodo_2020_2):
+    return baker.make(
+        'Periodo',
+        referencia='2021.1',
+        data_inicio_realizacao_despesas=date(2021, 1, 1),
+        data_fim_realizacao_despesas=date(2021, 6, 30),
+        periodo_anterior=periodo_2020_2,
+    )
 
 @pytest.fixture
 def periodo_2019_2(periodo):
@@ -1471,6 +1542,19 @@ def parametros():
         texto_pagina_valores_reprogramados_dre='Teste DRE'
     )
 
+@pytest.fixture
+def parametros_desconsidera_nao_iniciadas():
+    return baker.make(
+        'Parametros',
+        desconsiderar_associacoes_nao_iniciadas=True,
+    )
+
+@pytest.fixture
+def parametros_nao_desconsidera_nao_iniciadas():
+    return baker.make(
+        'Parametros',
+        desconsiderar_associacoes_nao_iniciadas=False,
+    )
 
 @pytest.fixture
 def parametro_fique_de_olho_pc():

--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -64,7 +64,12 @@ class AssociacaoAdmin(admin.ModelAdmin):
 
     get_nome_escola.short_description = 'Escola'
 
-    list_display = ('nome', 'cnpj', 'get_nome_escola')
+    def get_periodo_inicial_referencia(self, obj):
+        return obj.periodo_inicial.referencia if obj and obj.periodo_inicial else ''
+
+    get_periodo_inicial_referencia.short_description = 'Período Inicial'
+
+    list_display = ('nome', 'cnpj', 'get_nome_escola', 'get_periodo_inicial_referencia', 'data_de_encerramento')
     search_fields = ('uuid', 'nome', 'cnpj', 'unidade__nome', 'unidade__codigo_eol', )
     list_filter = (
         'unidade__dre',
@@ -881,6 +886,7 @@ class AnaliseLancamentoPrestacaoContaAdmin(admin.ModelAdmin):
         return f'{obj.analise_prestacao_conta.prestacao_conta.periodo.referencia}' if obj and obj.analise_prestacao_conta and obj.analise_prestacao_conta.prestacao_conta and obj.analise_prestacao_conta.prestacao_conta.periodo else ''
 
     get_periodo.short_description = 'Período'
+
 
     def get_analise_pc(self, obj):
         return f'#{obj.analise_prestacao_conta.pk}' if obj and obj.analise_prestacao_conta else ''

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -712,24 +712,27 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def dashboard(self, request):
         dre_uuid = request.query_params.get('dre_uuid')
-        periodo = request.query_params.get('periodo')
+        periodo_uuid = request.query_params.get('periodo')
 
-        if not dre_uuid or not periodo:
+        if not dre_uuid or not periodo_uuid:
             erro = {
                 'erro': 'parametros_requerido',
                 'mensagem': 'É necessário enviar o uuid da dre (dre_uuid) e o periodo como parâmetros.'
             }
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        total_associacoes_dre = Associacao.objects.filter(unidade__dre__uuid=dre_uuid).exclude(cnpj__exact='').count()
+        periodo = Periodo.by_uuid(periodo_uuid)
+        dre = Unidade.by_uuid(dre_uuid)
+
+        total_associacoes_dre = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo, dre=dre).count()
 
         par_add_aprovados_ressalva = request.query_params.get('add_aprovadas_ressalva')
         add_aprovados_ressalva = par_add_aprovados_ressalva == 'SIM'
         cards = PrestacaoConta.dashboard(
-            periodo,
+            periodo_uuid,
             dre_uuid,
             add_aprovado_ressalva=add_aprovados_ressalva,
-            add_info_devolvidas_retornadas=True
+            add_info_devolvidas_retornadas=True,
         )
         dashboard = {
             "total_associacoes_dre": total_associacoes_dre,

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -245,4 +245,20 @@ class Associacao(ModeloIdNome):
         return super().save(*args, **kwargs)
 
 
+    @classmethod
+    def get_associacoes_ativas_no_periodo(cls, periodo, dre=None):
+        from .parametros import Parametros
+
+        associacoes_ativas = cls.ativas
+
+        if dre:
+            associacoes_ativas = associacoes_ativas.filter(unidade__dre=dre)
+
+        if Parametros.get().desconsiderar_associacoes_nao_iniciadas:
+            associacoes_ativas = associacoes_ativas.exclude(periodo_inicial__referencia__gte=periodo.referencia)
+
+        associacoes_ativas = associacoes_ativas.exclude(data_de_encerramento__lte=periodo.data_inicio_realizacao_despesas)
+
+        return associacoes_ativas
+
 auditlog.register(Associacao)

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -626,16 +626,33 @@ class PrestacaoConta(ModeloBase):
         return cls.objects.filter(associacao=associacao, periodo=periodo).first()
 
     @classmethod
-    def dashboard(cls, periodo_uuid, dre_uuid, add_aprovado_ressalva=False, add_info_devolvidas_retornadas=False,
-                  apenas_nao_publicadas=False):
+    def dashboard(
+        cls,
+        periodo_uuid,
+        dre_uuid,
+        add_aprovado_ressalva=False,
+        add_info_devolvidas_retornadas=False,
+        apenas_nao_publicadas=False,
+    ):
         """
+        Retorna um dicionário com as informações para o dashboard de prestação de contas.
+
+        :param periodo_uuid: UUID do período que será utilizado para filtrar as prestações de contas.
+
+        :param dre_uuid: UUID da DRE que será utilizado para filtrar as prestações de contas.
+
         :param add_aprovado_ressalva: True para retornar a quantidade de aprovados com ressalva separadamente ou
         False para retornar a quantidade de aprovadas com ressalva somada a quantidade de aprovadas
 
         :param add_info_devolvidas_retornadas: True para retornar a quantidade de devolvidas retornadas no card de
         devolução.
+
+        :param apenas_nao_publicadas: True para retornar apenas as prestações de contas que não foram publicadas.
         """
-        from ..models import Associacao
+        from ..models import Associacao, Periodo, Unidade
+
+        periodo = Periodo.by_uuid(periodo_uuid)
+        dre = Unidade.by_uuid(dre_uuid)
 
         titulos_por_status = {
             cls.STATUS_NAO_RECEBIDA: "Prestações de contas não recebidas",
@@ -688,8 +705,12 @@ class PrestacaoConta(ModeloBase):
                 }
             cards.append(card)
 
-        quantidade_unidades_dre = Associacao.objects.filter(unidade__dre__uuid=dre_uuid).exclude(cnpj__exact='').count()
+        associacoes_dre = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo, dre=dre)
+
+        quantidade_unidades_dre = associacoes_dre.count()
+
         quantidade_pcs_nao_apresentadas = quantidade_unidades_dre - quantidade_pcs_apresentadas
+
         card_nao_recebidas = {
             "titulo": titulos_por_status['NAO_RECEBIDA'],
             "quantidade_prestacoes": quantidade_pcs_nao_apresentadas,

--- a/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_model.py
+++ b/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_model.py
@@ -36,3 +36,39 @@ def test_srt_model(associacao):
 def test_admin():
     # pylint: disable=W0212
     assert admin.site._registry[Associacao]
+
+
+def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_nao_iniciadas_parametro_ativo(
+    associacao_iniciada_2020_1,
+    associacao_iniciada_2020_2,
+    periodo_2020_2,
+    parametros_desconsidera_nao_iniciadas,
+    dre,
+):
+    result = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo_2020_2, dre=dre)
+    # Quantidade de associações deve ser 1, pois a associacao iniciada em 2020_2 nao deve ser considerada
+    assert len(result) == 1
+    assert result[0] == associacao_iniciada_2020_1
+
+def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_nao_iniciadas_parametro_inativo(
+    associacao_iniciada_2020_1,
+    associacao_iniciada_2020_2,
+    periodo_2020_2,
+    parametros_nao_desconsidera_nao_iniciadas,
+    dre,
+):
+    result = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo_2020_2, dre=dre)
+    # Quantidade de associações deve ser deve ser 2, pois o parâmetro de desconsiderar associacoes nao iniciadas está inativo
+    assert len(result) == 2
+
+
+def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_encerradas(
+    associacao_encerrada_2020_1,
+    associacao_encerrada_2020_2,
+    periodo_2020_2,
+    dre,
+):
+    result = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo_2020_2, dre=dre)
+    # Quantidade de associações deve ser 1, pois a associacao encerrada em 2020_1 nao deve ser considerada
+    assert len(result) == 1
+    assert result[0] == associacao_encerrada_2020_2

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_model.py
@@ -90,3 +90,51 @@ def test_dash_board(prestacao_conta1, prestacao_conta2, periodo, dre):
     ]
 
     assert esperado == prestacao_conta1.dashboard(periodo.uuid, dre.uuid)
+
+
+def test_dashboard_deve_desconsiderar_associacoes_nao_iniciadas_parametro_ativo(
+    associacao_iniciada_2020_1,
+    associacao_iniciada_2020_2,
+    periodo_2020_2,
+    parametros_desconsidera_nao_iniciadas,
+):
+    result = PrestacaoConta.dashboard(
+        periodo_2020_2.uuid,
+        associacao_iniciada_2020_1.unidade.dre.uuid,
+    )
+
+    # Quantidade de prestações deve ser 1, pois a associacao iniciada em 2020_2 nao deve ser considerada
+    assert result[0]['titulo'] == 'Prestações de contas não recebidas'
+    assert result[0]['quantidade_prestacoes'] == 1
+
+
+def test_dashboard_deve_desconsiderar_associacoes_nao_iniciadas_parametro_inativo(
+    associacao_iniciada_2020_1,
+    associacao_iniciada_2020_2,
+    periodo_2020_2,
+    parametros_nao_desconsidera_nao_iniciadas,
+):
+    result = PrestacaoConta.dashboard(
+        periodo_2020_2.uuid,
+        associacao_iniciada_2020_1.unidade.dre.uuid,
+    )
+
+    # Quantidade de prestações deve ser 2, pois o parâmetro de desconsiderar associacoes nao iniciadas esta inativo
+    assert result[0]['titulo'] == 'Prestações de contas não recebidas'
+    assert result[0]['quantidade_prestacoes'] == 2
+
+
+
+def test_dashboard_deve_desconsiderar_associacoes_encerradas(
+    associacao_encerrada_2020_1,
+    associacao_encerrada_2020_2,
+    periodo_2020_2,
+):
+    result = PrestacaoConta.dashboard(
+        periodo_2020_2.uuid,
+        associacao_encerrada_2020_1.unidade.dre.uuid,
+    )
+
+    # Quantidade de prestações deve ser 1, pois a associacao encerrada em 2020_1 nao deve ser considerada
+    assert result[0]['titulo'] == 'Prestações de contas não recebidas'
+    assert result[0]['quantidade_prestacoes'] == 1


### PR DESCRIPTION
Esse PR:

- Altera `api/prestacoes-contas/dashboard` para ignorar associações encerradas conforme o período consultado
- Altera `api/prestacoes-contas/dashboard` para ignorar associações não iniciadas conforme o período consultado, se o parâmetro `desconsiderar não iniciadas` estiver ativo

Atende [AB#91685](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91685)
