### PR TITLE
Feature(91273): Acompanhamento de PCs: Exibir associações correspondente ao período vigente

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -298,6 +298,16 @@ def outra_unidade(dre):
     )
 
 @pytest.fixture
+def terceira_unidade(dre):
+    return baker.make(
+        'Unidade',
+        nome='Terceira Escola Teste',
+        tipo_unidade='CEU',
+        codigo_eol='888889',
+        dre=dre,
+    )
+
+@pytest.fixture
 def associacao(unidade, periodo_anterior):
     return baker.make(
         'Associacao',
@@ -433,6 +443,16 @@ def associacao_sem_periodo_inicial(unidade):
         nome='Escola Teste',
         cnpj='44.219.758/0001-90',
         unidade=unidade,
+        periodo_inicial=None,
+    )
+
+@pytest.fixture
+def outra_associacao_sem_periodo_inicial(terceira_unidade):
+    return baker.make(
+        'Associacao',
+        nome='Associacao Não Iniciada',
+        cnpj='78.275.825/0001-06',
+        unidade=terceira_unidade,
         periodo_inicial=None,
     )
 

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -255,6 +255,8 @@ class Associacao(ModeloIdNome):
             associacoes_ativas = associacoes_ativas.filter(unidade__dre=dre)
 
         if Parametros.get().desconsiderar_associacoes_nao_iniciadas:
+            associacoes_ativas = associacoes_ativas.exclude(periodo_inicial__isnull=True)
+            
             associacoes_ativas = associacoes_ativas.exclude(periodo_inicial__referencia__gte=periodo.referencia)
 
         associacoes_ativas = associacoes_ativas.exclude(data_de_encerramento__lte=periodo.data_inicio_realizacao_despesas)

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -380,21 +380,7 @@ def lista_prestacoes_de_conta_todos_os_status(
     filtro_por_devolucao_tesouro=None,
     filtro_por_status=[]
 ):
-    desconsiderar_associacoes_nao_iniciadas = getattr(Parametros.get(), 'desconsiderar_associacoes_nao_iniciadas', False)
-    if desconsiderar_associacoes_nao_iniciadas:
-        associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(
-            Q(data_de_encerramento__isnull=False) & Q(data_de_encerramento__lt=periodo.data_fim_realizacao_despesas)
-            ).exclude(
-            periodo_inicial__isnull=True
-            ).exclude(
-            periodo_inicial__data_inicio_realizacao_despesas__gte=periodo.data_inicio_realizacao_despesas
-            ).exclude(
-            cnpj__exact=''
-            ).order_by(
-            'unidade__tipo_unidade', 'unidade__nome')
-    else:
-        associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(cnpj__exact='').order_by(
-        'unidade__tipo_unidade', 'unidade__nome')
+    associacoes_da_dre = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo, dre=dre).order_by('unidade__tipo_unidade', 'unidade__nome')
 
     if filtro_nome is not None:
         associacoes_da_dre = associacoes_da_dre.filter(Q(nome__unaccent__icontains=filtro_nome) | Q(

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -380,7 +380,20 @@ def lista_prestacoes_de_conta_todos_os_status(
     filtro_por_devolucao_tesouro=None,
     filtro_por_status=[]
 ):
-    associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(cnpj__exact='').order_by(
+    desconsiderar_associacoes_nao_iniciadas = getattr(Parametros.get(), 'desconsiderar_associacoes_nao_iniciadas', False)
+    if desconsiderar_associacoes_nao_iniciadas:
+        associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(
+            Q(data_de_encerramento__isnull=False) & Q(data_de_encerramento__lt=periodo.data_fim_realizacao_despesas)
+            ).exclude(
+            periodo_inicial__isnull=True
+            ).exclude(
+            periodo_inicial__data_inicio_realizacao_despesas__gte=periodo.data_inicio_realizacao_despesas
+            ).exclude(
+            cnpj__exact=''
+            ).order_by(
+            'unidade__tipo_unidade', 'unidade__nome')
+    else:
+        associacoes_da_dre = Associacao.objects.filter(unidade__dre=dre).exclude(cnpj__exact='').order_by(
         'unidade__tipo_unidade', 'unidade__nome')
 
     if filtro_nome is not None:

--- a/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_model.py
+++ b/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_model.py
@@ -41,25 +41,27 @@ def test_admin():
 def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_nao_iniciadas_parametro_ativo(
     associacao_iniciada_2020_1,
     associacao_iniciada_2020_2,
+    outra_associacao_sem_periodo_inicial,
     periodo_2020_2,
     parametros_desconsidera_nao_iniciadas,
     dre,
 ):
     result = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo_2020_2, dre=dre)
-    # Quantidade de associações deve ser 1, pois a associacao iniciada em 2020_2 nao deve ser considerada
+    # Quantidade de associações deve ser 1, pois a associacao iniciada em 2020_2 e a associacaoo sem periodo inicial nao devem ser consideradas
     assert len(result) == 1
     assert result[0] == associacao_iniciada_2020_1
 
 def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_nao_iniciadas_parametro_inativo(
     associacao_iniciada_2020_1,
     associacao_iniciada_2020_2,
+    outra_associacao_sem_periodo_inicial,
     periodo_2020_2,
     parametros_nao_desconsidera_nao_iniciadas,
     dre,
 ):
     result = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo_2020_2, dre=dre)
-    # Quantidade de associações deve ser deve ser 2, pois o parâmetro de desconsiderar associacoes nao iniciadas está inativo
-    assert len(result) == 2
+    # Quantidade de associações deve ser deve ser 3, pois o parâmetro de desconsiderar associacoes nao iniciadas está inativo
+    assert len(result) == 3
 
 
 def test_get_associacoes_ativas_no_periodo_deve_desconsiderar_associacoes_encerradas(


### PR DESCRIPTION
Esse PR:

- Adiciona a verificação de associações sem o período inicial no modelo de associações.
- Adiciona nos testes de associação a verificação de associações não iniciadas.
- Modifica as tabelas de resumo geral do período e das dres e resumo por dre e unidade educacional.

História: [AB#91273](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91273)