### PR TITLE
Feature(91686): Exibir associações ativas na consulta de saldos

### DIFF
--- a/sme_ptrf_apps/sme/api/views/saldos_bancarios_sme_detalhes_associacoes_viewset.py
+++ b/sme_ptrf_apps/sme/api/views/saldos_bancarios_sme_detalhes_associacoes_viewset.py
@@ -49,7 +49,7 @@ class SaldosBancariosSmeDetalhesAsocciacoesViewSet(mixins.ListModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            Periodo.objects.get(uuid=periodo_uuid)
+            periodo = Periodo.objects.get(uuid=periodo_uuid)
         except ValidationError:
             erro = {
                 'erro': 'Objeto não encontrado.',
@@ -96,7 +96,7 @@ class SaldosBancariosSmeDetalhesAsocciacoesViewSet(mixins.ListModelMixin,
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        saldos = saldo_detalhe_associacao(periodo_uuid=periodo_uuid, conta_uuid=conta_uuid, dre_uuid=dre_uuid,
+        saldos = saldo_detalhe_associacao(periodo=periodo, conta_uuid=conta_uuid, dre_uuid=dre_uuid,
                                           unidade=unidade, tipo_ue=tipo_ue)
 
         return Response(saldos, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/sme/api/views/saldos_bancarios_sme_viewset.py
+++ b/sme_ptrf_apps/sme/api/views/saldos_bancarios_sme_viewset.py
@@ -38,7 +38,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            Periodo.objects.get(uuid=periodo_uuid)
+            periodo = Periodo.objects.get(uuid=periodo_uuid)
         except ValidationError:
             erro = {
                 'erro': 'Objeto não encontrado.',
@@ -66,7 +66,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        saldos = saldo_por_tipo_de_unidade(self.queryset, periodo=periodo_uuid, conta=conta_uuid)
+        saldos = saldo_por_tipo_de_unidade(self.queryset, periodo=periodo, conta=conta_uuid)
 
         return Response(saldos, status=status.HTTP_200_OK)
 
@@ -86,7 +86,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            Periodo.objects.get(uuid=periodo_uuid)
+            periodo = Periodo.objects.get(uuid=periodo_uuid)
         except ValidationError:
             erro = {
                 'erro': 'Objeto não encontrado.',
@@ -114,7 +114,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        saldos = saldo_por_dre(self.queryset, periodo=periodo_uuid, conta=conta_uuid)
+        saldos = saldo_por_dre(self.queryset, periodo=periodo, conta=conta_uuid)
 
         return Response(saldos, status=status.HTTP_200_OK)
 
@@ -134,7 +134,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            Periodo.objects.get(uuid=periodo_uuid)
+            periodo = Periodo.objects.get(uuid=periodo_uuid)
         except ValidationError:
             erro = {
                 'erro': 'Objeto não encontrado.',
@@ -162,7 +162,7 @@ class SaldosBancariosSMEViewSet(GenericViewSet):
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
-        saldos = saldo_por_ue_dre(self.queryset, periodo=periodo_uuid, conta=conta_uuid)
+        saldos = saldo_por_ue_dre(self.queryset, periodo=periodo, conta=conta_uuid)
 
         return Response(saldos, status=status.HTTP_200_OK)
 

--- a/sme_ptrf_apps/sme/services/saldo_bancario_service.py
+++ b/sme_ptrf_apps/sme/services/saldo_bancario_service.py
@@ -108,7 +108,8 @@ def saldo_por_ue_dre(queryset, periodo, conta):
 
         if Parametros.get().desconsiderar_associacoes_nao_iniciadas:
             saldo_por_tipo_da_dre = queryset.filter(
-                Q(associacao__periodo_inicial__isnull=False) & (
+                Q(associacao__periodo_inicial__isnull=False) & 
+                Q(associacao__periodo_inicial__referencia__lt=periodo.referencia) & (
                     Q(associacao__data_de_encerramento__isnull=True) | Q(associacao__data_de_encerramento__gt=periodo.data_inicio_realizacao_despesas)
                 ),
                 periodo__uuid=periodo.uuid,


### PR DESCRIPTION
Esse PR:

- Altera cálculo para desconsiderar associações não iniciadas e encerradas, conforme período da consulta na Exibição por Tipo de Unidade x Diretor, Unidade e Diretoria.

História: [AB#91686](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91686)