### PR TITLE
feat(91768): Exibir períodos que estejam sem encerramento da associação

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -840,6 +840,15 @@ def prestacao_conta_2019_2_conciliada(periodo_2019_2, associacao):
         status=PrestacaoConta.STATUS_NAO_RECEBIDA
     )
 
+@pytest.fixture
+def prestacao_conta_2019_2_aprovada_associacao_encerrada(periodo_2019_2, associacao_encerrada_2020_1):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_2019_2,
+        associacao=associacao_encerrada_2020_1,
+        status=PrestacaoConta.STATUS_APROVADA
+    )
+
 
 @pytest.fixture
 def prestacao_conta_2020_1_conciliada_outra_conta(periodo_2020_1, associacao):

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_para_prestacao_contas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_get_periodos_para_prestacao_contas.py
@@ -107,3 +107,39 @@ def test_get_periodos_prestacao_de_contas_da_associacao(
         esperados.discard(p['uuid'])
 
     assert esperados == set()
+
+
+@freeze_time('2020-06-15')
+def test_get_periodos_prestacao_de_contas_ate_encerramento_da_associacao_com_prestacao_anterior(
+    jwt_authenticated_client_a,
+    associacao_encerrada_2020_1,
+    periodo_2019_2,
+    prestacao_conta_2019_2_aprovada_associacao_encerrada
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_encerrada_2020_1.uuid}/periodos-para-prestacao-de-contas/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    esperados = {
+        f'{periodo_2019_2.uuid}',
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+
+    for p in result:
+        esperados.discard(p['uuid'])
+
+    assert esperados == set()
+
+@freeze_time('2020-06-15')
+def test_get_periodos_prestacao_de_contas_ate_encerramento_da_associacao_sem_prestacao_anterior(
+    jwt_authenticated_client_a,
+    associacao_encerrada_2020_2
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_encerrada_2020_2.uuid}/periodos-para-prestacao-de-contas/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert result == []


### PR DESCRIPTION
feat(91768): Exibir períodos que estejam sem encerramento da associação

Esse PR:

- Filtra periodos ate data de encerramento associacao
- Adiciona testes relacionados

História: [AB#91768](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91768)