### PR TITLE
build(92877): Atualiza Python para 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.9-buster
 ENV PYTHONUNBUFFERED 1
 ADD . /code
 WORKDIR /code

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,14 +2,19 @@
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.0.14  # https://www.djangoproject.com/
+django==3.0.14
+django-auditlog==1.0.0
 
+
+# Outras
+# ------------------------------------------------------------------------------
+Pillow==9.4.0
 
 # Dependencias não revisadas
 
 pytz==2019.3  # https://github.com/stub42/pytz
 python-slugify==4.0.0  # https://github.com/un33k/python-slugify
-Pillow==7.0.0  # https://github.com/python-pillow/Pillow
+
 rcssmin==1.0.6  # https://github.com/ndparker/rcssmin
 argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
@@ -42,11 +47,6 @@ djangorestframework-jwt==1.11.0  # https://getblimp.github.io/django-rest-framew
 
 django-cors-headers # https://github.com/adamchainz/django-cors-headers
 
-# Para gravação de log de alterações nos modelos
-# https://django-auditlog.readthedocs.io/en/latest/index.html
-# Pegando última versão diretamente do repositório oficial.
-#-e git://github.com/jjkester/django-auditlog.git##egg=django-auditlog
-django-auditlog==1.0.0
 
 # Para validação e formatação de CNPJ e CPF
 # https://github.com/poliquin/brazilnum

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,9 +1,15 @@
 -r ./base.txt
 
+# Dependencias revisadas
+psycopg2-binary==2.9.5
+
+
+
+# Dependencias não revisadas
+
 Werkzeug==1.0.0 # https://github.com/pallets/werkzeug
 ipdb==0.13.1  # https://github.com/gotcha/ipdb
 Sphinx==2.4.3  # https://github.com/sphinx-doc/sphinx
-psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 
 # Testing
 # ------------------------------------------------------------------------------

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,8 +2,12 @@
 
 -r ./base.txt
 
+# Dependencias revisadas
+psycopg2==2.9.5 --no-binary psycopg2
+
+# Dependencias não revisadas
+
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
-psycopg2==2.8.4 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Esse PR:

- Atualiza no Dockerfile a versão do python para 3.9
- Atualiza a versão do pacote Pillow para 9.4.0
- Atualiza a versão do pacote psycopg2 para 2.9.5

Atende [AB#92877](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/92877)
