### PR TITLE
feat(93163): Valida data encerramento e periodo inicial da associacao na carga de repasses realizados

### DIFF
--- a/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
@@ -161,6 +161,16 @@ def processa_repasse(reader, tipo_conta, arquivo):
                 msg_erro = f'Período {periodo.referencia} fechado para alterações na associação. Linha ID:{id_linha}'
                 raise Exception(msg_erro)
 
+            data_referencia = periodo.data_fim_realizacao_despesas if periodo.data_fim_realizacao_despesas else periodo.data_inicio_realizacao_despesas
+
+            if associacao.encerrada and (data_referencia >= associacao.data_de_encerramento):
+                msg_erro = f'A associação foi encerrada em {associacao.data_de_encerramento.strftime("%d/%m/%Y")}. Linha ID:{id_linha}'
+                raise Exception(msg_erro)
+
+            if associacao.periodo_inicial and (data_referencia <= associacao.periodo_inicial.data_fim_realizacao_despesas):
+                msg_erro = f'O período informado é anterior ao período inicial da associação. Linha ID:{id_linha}'
+                raise Exception(msg_erro)
+
             valor_capital = get_valor(row[VALOR_CAPITAL])
             valor_custeio = get_valor(row[VALOR_CUSTEIO])
             valor_livre = get_valor(row[VALOR_LIVRE])


### PR DESCRIPTION
Esse PR:

- Valida se o período do repasse é válido de acordo com o período inicial da associação
- Valida se o período do repasse é válido de acordo com a data de encerramento da associação

História: [AB#93163](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93163)