### PR TITLE
feat(93197): Valida associações na carga de repasses previstos

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -309,6 +309,16 @@ def terceira_unidade(dre):
     )
 
 @pytest.fixture
+def quarta_unidade(dre):
+    return baker.make(
+        'Unidade',
+        nome='Quarta Escola Teste',
+        tipo_unidade='CEU',
+        codigo_eol='999999',
+        dre=dre,
+    )
+
+@pytest.fixture
 def associacao_com_data_de_encerramento(unidade, periodo_anterior):
     return baker.make(
         'Associacao',
@@ -368,12 +378,12 @@ def associacao_encerrada_2020_1(periodo_2019_2, periodo_2020_1, unidade):
     )
 
 @pytest.fixture
-def associacao_encerrada_2020_2(periodo_2019_2, periodo_2020_2, outra_unidade):
+def associacao_encerrada_2020_2(periodo_2019_2, periodo_2020_2, quarta_unidade):
     return baker.make(
         'Associacao',
         nome='Escola Iniciada em 2020.2',
         cnpj='23.500.058/0001-08',
-        unidade=outra_unidade,
+        unidade=quarta_unidade,
         periodo_inicial=periodo_2019_2,
         data_de_encerramento=periodo_2020_2.data_fim_realizacao_despesas,
     )

--- a/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
@@ -183,6 +183,10 @@ def processa_repasse(reader, tipo_conta, arquivo):
                     logger.info(f'O repasse da linha de id {id_linha} já foi importado anteriormente. Anterior apagado.'
                                 f'{id_linha if id_linha else ""}')
 
+                if associacao.encerrada:
+                    msg_erro = f'A associação foi encerrada em {associacao.data_de_encerramento.strftime("%d/%m/%Y")}. Linha ID:{index}'
+                    raise Exception(msg_erro)
+
                 if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
                     Repasse.objects.create(
                         associacao=associacao,


### PR DESCRIPTION
Esse PR:

- Valida se associação está encerrada
- Adiciona teste

História: [AB#93197](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93197)