### PR TITLE
fix(91797): Consolidado das PCs: Geração do Consolidado DRE - Caso de prévia não apagada e que causa erro na geração do bloco 2

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -568,6 +568,11 @@ class PrestacaoConta(ModeloBase):
         self.outros_motivos_reprovacao = ''
         self.recomendacoes = ''
         self.status = self.STATUS_EM_ANALISE
+
+        if self.consolidado_dre:
+            self.consolidado_dre.desvincular_pc_do_consolidado(self)
+            self.consolidado_dre = None
+
         self.save()
         return self
 

--- a/sme_ptrf_apps/dre/models/consolidado_dre.py
+++ b/sme_ptrf_apps/dre/models/consolidado_dre.py
@@ -146,6 +146,10 @@ class ConsolidadoDRE(ModeloBase):
         pc.save()
         self.pcs_do_consolidado.add(pc)
 
+    def desvincular_pc_do_consolidado(self, pc):
+        logger.info(f'Desvinculando PC {pc} do consolidado #{self.id}')
+        self.pcs_do_consolidado.remove(pc)
+
     @property
     def foi_publicado(self):
         return self.status_sme == self.STATUS_SME_PUBLICADO


### PR DESCRIPTION
Esse PR: 

- Corrige caso de prévias não apagadas e gerando documentos zerados

História: [AB#91797](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91797)