### PR TITLE
feat(92322): Altera retorno da API de Unidades

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -374,7 +374,7 @@ def associacao_encerrada_2020_1(periodo_2019_2, periodo_2020_1, unidade):
         cnpj='99.073.449/0001-47',
         unidade=unidade,
         periodo_inicial=periodo_2019_2,
-        data_de_encerramento = periodo_2020_1.data_fim_realizacao_despesas,
+        data_de_encerramento=periodo_2020_1.data_fim_realizacao_despesas,
     )
 
 @pytest.fixture

--- a/sme_ptrf_apps/core/api/serializers/unidade_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/unidade_serializer.py
@@ -64,6 +64,7 @@ class UnidadeListSerializer(serializers.ModelSerializer):
     associacao_uuid = serializers.SerializerMethodField('get_associacao_uuid')
     associacao_nome = serializers.SerializerMethodField('get_associacao_nome')
     visao = serializers.SerializerMethodField('get_visao')
+    data_de_encerramento_associacao = serializers.SerializerMethodField('get_data_de_encerramento_associacao')
 
     def get_associacao_uuid(self, obj):
         return obj.associacoes.first().uuid if obj.associacoes.exists() else ''
@@ -73,6 +74,9 @@ class UnidadeListSerializer(serializers.ModelSerializer):
 
     def get_visao(self, obj):
         return 'DRE' if obj.tipo_unidade == 'DRE' else 'UE'
+
+    def get_data_de_encerramento_associacao(self, obj):
+        return obj.associacoes.first().data_de_encerramento if obj.associacoes.exists() else None
 
     class Meta:
         model = Unidade
@@ -85,7 +89,9 @@ class UnidadeListSerializer(serializers.ModelSerializer):
             'tipo_unidade',
             'associacao_uuid',
             'associacao_nome',
-            'visao'
+            'visao',
+            'data_de_encerramento_associacao',
+            'tooltip_associacao_encerrada'
         )
 
 

--- a/sme_ptrf_apps/core/models/unidade.py
+++ b/sme_ptrf_apps/core/models/unidade.py
@@ -84,6 +84,11 @@ class Unidade(ModeloBase, TemNome):
         censo = self.censos.order_by('-ano').first()
         return censo.quantidade_alunos if censo else 0
 
+    @property
+    def tooltip_associacao_encerrada(self):
+        return self.associacoes.first().tooltip_data_encerramento \
+            if self.associacoes.exists() and self.associacoes.first().encerrada else None
+
     class Meta:
         verbose_name = 'Unidade'
         verbose_name_plural = '06.0) Unidades'

--- a/sme_ptrf_apps/core/tests/tests_api_unidades/test_list_unidades.py
+++ b/sme_ptrf_apps/core/tests/tests_api_unidades/test_list_unidades.py
@@ -87,7 +87,9 @@ def test_api_list_unidades_por_nome(
             'uuid': str(unidade.uuid),
             'associacao_nome': '',
             'associacao_uuid': '',
-            'visao': 'UE'
+            'visao': 'UE',
+            'data_de_encerramento_associacao': None,
+            'tooltip_associacao_encerrada': None,
         },
 
     ]
@@ -116,7 +118,9 @@ def test_api_list_unidades_por_codigo_eol(
             'uuid': str(unidade.uuid),
             'associacao_nome': '',
             'associacao_uuid': '',
-            'visao': 'UE'
+            'visao': 'UE',
+            'data_de_encerramento_associacao': None,
+            'tooltip_associacao_encerrada': None,
         },
 
     ]
@@ -161,8 +165,39 @@ def test_api_list_unidades_por_dre(
             'uuid': str(unidade.uuid),
             'associacao_nome': '',
             'associacao_uuid': '',
-            'visao': 'UE'
+            'visao': 'UE',
+            'data_de_encerramento_associacao': None,
+            'tooltip_associacao_encerrada': None,
         },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == result_esperado
+
+
+def test_api_list_unidades_com_associacao_encerrada(
+    jwt_authenticated_client_a,
+    unidade,
+    associacao_encerrada_2020_1
+):
+    response = jwt_authenticated_client_a.get(f'/api/unidades/?search=Escola', content_type='application/json')
+    result = json.loads(response.content)
+
+    result_esperado = [
+        {
+            'codigo_eol': '123456',
+            'nome_dre': 'DRE teste',
+            'nome': 'Escola Teste',
+            'nome_com_tipo': 'CEU Escola Teste',
+            'tipo_unidade': 'CEU',
+            'uuid': str(unidade.uuid),
+            'associacao_nome': associacao_encerrada_2020_1.nome,
+            'associacao_uuid': f'{associacao_encerrada_2020_1.uuid}',
+            'visao': 'UE',
+            'data_de_encerramento_associacao': f'{associacao_encerrada_2020_1.data_de_encerramento}',
+            'tooltip_associacao_encerrada': unidade.tooltip_associacao_encerrada,
+        },
+
     ]
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
feat(92322): Altera retorno da API de Unidades

Esse PR:

- Adiciona property ao modelo de Unidade para tooltip de associação encerrada
- Adiciona informações de encerramento da associação a API de unidades
- Altera testes relacionados
- Adiciona testes relacionados

História: [AB#92322](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/92322)