### PR TITLE
feat(93200): Valida data encerramento e periodo inicial da associação na carga de devolução tesouro

### DIFF
--- a/sme_ptrf_apps/core/services/carga_devolucoes_tesouro_service.py
+++ b/sme_ptrf_apps/core/services/carga_devolucoes_tesouro_service.py
@@ -92,6 +92,18 @@ class CargaDevolucoesTesouroService:
         except PrestacaoConta.DoesNotExist:
             raise CargaDevolcuoesTesouroException(f'Não encontrada uma PC de id {pc_id}. Devolução não criada.')
 
+        associacao = prestacao_conta.associacao
+        periodo = prestacao_conta.periodo
+        data_referencia = periodo.data_fim_realizacao_despesas if periodo.data_fim_realizacao_despesas else periodo.data_inicio_realizacao_despesas
+
+        if associacao.encerrada and (data_referencia >= associacao.data_de_encerramento):
+            msg_erro = f'A associação foi encerrada em {associacao.data_de_encerramento.strftime("%d/%m/%Y")}'
+            raise Exception(msg_erro)
+
+        if associacao.periodo_inicial and (data_referencia <= associacao.periodo_inicial.data_fim_realizacao_despesas):
+            msg_erro = f'O período informado é anterior ao período inicial da associação'
+            raise Exception(msg_erro)
+
         # Define a Despesa
         try:
             despesa_id = int(linha_conteudo[self.DESPESA_ID].strip())

--- a/sme_ptrf_apps/core/tests/tests_devolucao_ao_tesouro/test_carrega_devolucoes_tesouro.py
+++ b/sme_ptrf_apps/core/tests/tests_devolucao_ao_tesouro/test_carrega_devolucoes_tesouro.py
@@ -1,0 +1,56 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from model_bakery import baker
+
+from sme_ptrf_apps.core.services.carga_devolucoes_tesouro_service import CargaDevolucoesTesouroService
+
+
+from sme_ptrf_apps.core.models.arquivo import (
+    DELIMITADOR_PONTO_VIRGULA,
+    DELIMITADOR_VIRGULA,
+    ERRO)
+
+from sme_ptrf_apps.core.choices.tipos_carga import CARGA_DEVOLUCAO_TESOURO
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def arquivo():
+    return SimpleUploadedFile(
+        f'devolucao_tesouro.csv',
+        bytes(f"""codigo_eol,nome,pc_id,referencia,despesa_id,numero_documento,data_devolucao,valor_devolucao,tipo_devolucao\n000256;MARIA LUIZA MORETTI GENTILE, PROFA.;139;2021.2;3367;-;14/12/2021;7,75;Pagamento de tarifas bancárias em desacordo com a normativa do Programa""", encoding="utf-8"))
+
+
+@pytest.fixture
+def arquivo_carga(arquivo):
+    return baker.make(
+        'Arquivo',
+        identificador='devolucao_ao_tesouro',
+        conteudo=arquivo,
+        tipo_carga=CARGA_DEVOLUCAO_TESOURO,
+        tipo_delimitador=DELIMITADOR_PONTO_VIRGULA
+    )
+
+
+@pytest.fixture
+def arquivo_carga_com_virgula(arquivo):
+    return baker.make(
+        'Arquivo',
+        identificador='devolucao_ao_tesouro',
+        conteudo=arquivo,
+        tipo_carga=CARGA_DEVOLUCAO_TESOURO,
+        tipo_delimitador=DELIMITADOR_VIRGULA
+    )
+
+def test_carga_com_erro_formatacao(arquivo_carga):
+    CargaDevolucoesTesouroService().carrega_devolucoes_tesouro(arquivo_carga)
+    assert arquivo_carga.log == """\nLinha:0 Formato definido (DELIMITADOR_PONTO_VIRGULA) é diferente do formato do arquivo csv (DELIMITADOR_VIRGULA)\n0 linha(s) importada(s) com sucesso. 1 erro(s) reportado(s)."""
+    assert arquivo_carga.status == ERRO
+
+
+def test_carga_com_erro(arquivo_carga_com_virgula):
+    CargaDevolucoesTesouroService().carrega_devolucoes_tesouro(arquivo_carga_com_virgula)
+    msg = """\nLinha:1 Houve um erro na carga dessa linha:O id da PC 75;Pagamento de tarifas bancárias em desacordo com a normativa do Programa é inválido. Devolução não criada.\n0 linha(s) importada(s) com sucesso. 1 erro(s) reportado(s)."""
+    assert arquivo_carga_com_virgula.log == msg
+    assert arquivo_carga_com_virgula.status == ERRO


### PR DESCRIPTION
Esse PR:

- Valida se o período da prestação de contas é válido de acordo com o período inicial da associação
- Valida se o período da prestação de contas é válido de acordo com a data de encerramento da associação
- Implementa testes

História: [AB#93200](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93200)