### PR TITLE
feat(89762): Tags informativas gastos escolas

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -424,7 +424,7 @@ class DespesaListComRateiosSerializer(serializers.ModelSerializer):
         fields = (
         'uuid', 'associacao', 'numero_documento', 'status', 'tipo_documento', 'data_documento', 'cpf_cnpj_fornecedor',
         'nome_fornecedor', 'valor_total', 'valor_ptrf', 'data_transacao', 'tipo_transacao', 'documento_transacao',
-        'rateios', 'receitas_saida_do_recurso', 'despesa_geradora_do_imposto', 'despesas_impostos')
+        'rateios', 'receitas_saida_do_recurso', 'despesa_geradora_do_imposto', 'despesas_impostos', 'tags_de_informacao')
 
 
 class DespesaConciliacaoSerializer(serializers.ModelSerializer):

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -412,19 +412,23 @@ class DespesaListComRateiosSerializer(serializers.ModelSerializer):
     despesa_geradora_do_imposto = serializers.SerializerMethodField(method_name="get_despesa_de_imposto",
                                                                     required=False)
 
+    informacoes = serializers.SerializerMethodField(method_name='get_informacoes', required=False)
+
     def get_despesa_de_imposto(self, despesa):
         despesa_geradora_do_imposto = despesa.despesa_geradora_do_imposto.first()
         return DespesaImpostoSerializer(despesa_geradora_do_imposto, many=False).data if despesa_geradora_do_imposto else None
 
     def get_recurso_externo(self, despesa):
         return despesa.receitas_saida_do_recurso.first().uuid if despesa.receitas_saida_do_recurso.exists() else None
-
+    
+    def get_informacoes(self, despesa):
+        return despesa.tags_de_informacao
     class Meta:
         model = Despesa
         fields = (
         'uuid', 'associacao', 'numero_documento', 'status', 'tipo_documento', 'data_documento', 'cpf_cnpj_fornecedor',
         'nome_fornecedor', 'valor_total', 'valor_ptrf', 'data_transacao', 'tipo_transacao', 'documento_transacao',
-        'rateios', 'receitas_saida_do_recurso', 'despesa_geradora_do_imposto', 'despesas_impostos', 'tags_de_informacao')
+        'rateios', 'receitas_saida_do_recurso', 'despesa_geradora_do_imposto', 'despesas_impostos', 'informacoes')
 
 
 class DespesaConciliacaoSerializer(serializers.ModelSerializer):

--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -156,6 +156,7 @@ class DespesasViewSet(mixins.CreateModelMixin,
 
             qs = qs.exclude(id__in=ids_para_excluir)
 
+        """ Ordenação por soma dos valores dos rateios e numero de documento das despesas:
         ordenar = self.request.query_params.get('ordenar')
         if ordenar:
             if ordenar == 'valor_total':
@@ -163,7 +164,10 @@ class DespesasViewSet(mixins.CreateModelMixin,
             if ordenar == 'numero_documento':
                 qs = qs.order_by(ordenar)
         else:
-            qs = qs.order_by('-data_documento')
+            qs = qs.order_by('-data_documento') 
+        """
+
+        qs = qs.order_by('-data_documento') 
 
         return qs
 

--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -22,7 +22,7 @@ from ..serializers.tipo_documento_serializer import TipoDocumentoSerializer
 from ..serializers.tipo_transacao_serializer import TipoTransacaoSerializer
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.pagination import PageNumberPagination
-from django.db.models import Subquery
+from django.db.models import Subquery, Sum
 from sme_ptrf_apps.core.models import Associacao
 import datetime
 
@@ -120,7 +120,50 @@ class DespesasViewSet(mixins.CreateModelMixin,
         if data_inicio is not None and data_fim is not None and data_inicio != '' and data_fim != '':
             qs = qs.filter(data_documento__range=[data_inicio, data_fim])
 
-        qs = qs.order_by('-data_documento')
+        assoc_uuid = self.request.query_params.get('associacao__uuid')
+        if assoc_uuid is not None:
+            qs = qs.filter(associacao__uuid=assoc_uuid).all()
+
+        filtro_vinculo_atividades = self.request.query_params.get('filtro_vinculo_atividades')
+        filtro_vinculo_atividades_list = filtro_vinculo_atividades.split(',') if filtro_vinculo_atividades else []
+
+        if filtro_vinculo_atividades_list:
+            qs = qs.filter(
+                pk__in=Subquery(
+                    qs.filter(rateios__tag__id__in=filtro_vinculo_atividades_list).distinct("uuid").values('pk')
+                )
+            )
+
+        filtro_informacoes = self.request.query_params.get('filtro_informacoes')
+        filtro_informacoes_list = filtro_informacoes.split(',') if filtro_informacoes else []
+        if filtro_informacoes_list:
+            ids_para_excluir = []
+            for despesa in qs:
+                excluir_despesa = True
+                if Despesa.TAG_ANTECIPADO['id'] in filtro_informacoes_list and despesa.teve_pagamento_antecipado():
+                    excluir_despesa = False
+                if Despesa.TAG_ESTORNADO['id'] in filtro_informacoes_list and despesa.possui_estornos():
+                    excluir_despesa = False
+                if Despesa.TAG_IMPOSTO['id'] in filtro_informacoes_list and despesa.possui_retencao_de_impostos():
+                    excluir_despesa = False
+                if Despesa.TAG_IMPOSTO_PAGO['id'] in filtro_informacoes_list and despesa.e_despesa_de_imposto():
+                    excluir_despesa = False
+                if Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and despesa.tem_pagamento_com_recursos_proprios() or Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and despesa.tem_pagamentos_em_multiplas_contas():
+                    excluir_despesa = False
+
+                if excluir_despesa:
+                    ids_para_excluir.append(despesa.id)
+
+            qs = qs.exclude(id__in=ids_para_excluir)
+
+        ordenar = self.request.query_params.get('ordenar')
+        if ordenar:
+            if ordenar == 'valor_total':
+                qs = qs.annotate(soma_rateios=Sum('rateios__valor_rateio')).order_by('soma_rateios')
+            if ordenar == 'numero_documento':
+                qs = qs.order_by(ordenar)
+        else:
+            qs = qs.order_by('-data_documento')
 
         return qs
 

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_com_filtros.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_get_despesas_com_filtros.py
@@ -164,6 +164,10 @@ def test_api_get_despesas_campos(jwt_authenticated_client_d, associacao, despesa
                 'tem_documento': tipo_transacao.tem_documento
             },
             'documento_transacao': '',
+            'informacoes': [{'tag_hint': 'Parte da despesa foi paga com recursos '
+                                         'próprios ou por mais de uma conta.',
+                             'tag_id': '3',
+                             'tag_nome': 'Parcial'}],
             'rateios': [],
             'receitas_saida_do_recurso': None
         }
@@ -252,3 +256,140 @@ def test_api_get_despesas_filtro_por_tag(jwt_authenticated_client_d, associacao,
 
     assert response.status_code == status.HTTP_200_OK
     assert len(result) == 1, 'Deve encontrar pela tag_teste_filtro_por_tag'
+
+
+@pytest.fixture
+def despesa_teste_filtro_vinculo_atividade_tag_1(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='2131232',
+        data_documento=datetime.date(2020, 3, 11),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='517.870.110-03',
+        nome_fornecedor='Fornecedor Teste Filtro Vinculo Atividade tag 1',
+        tipo_transacao=tipo_transacao,
+        documento_transacao='',
+        data_transacao=datetime.date(2020, 3, 11),
+        valor_total=120.00,
+    )
+
+@pytest.fixture
+def despesa_teste_filtro_vinculo_atividade_tag_2(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='4123123',
+        data_documento=datetime.date(2020, 3, 11),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='31.066.747/0001-76',
+        nome_fornecedor='Fornecedor Teste Filtro Vinculo Atividade tag 2',
+        tipo_transacao=tipo_transacao,
+        documento_transacao='',
+        data_transacao=datetime.date(2020, 3, 11),
+        valor_total=130.00,
+    )
+
+@pytest.fixture
+def despesa_teste_filtro_vinculo_atividade_sem_tag(associacao, tipo_documento, tipo_transacao):
+    return baker.make(
+        'Despesa',
+        associacao=associacao,
+        numero_documento='57454757',
+        data_documento=datetime.date(2020, 3, 11),
+        tipo_documento=tipo_documento,
+        cpf_cnpj_fornecedor='90.032.744/0001-80',
+        nome_fornecedor='Fornecedor Teste Filtro Vinculo Atividade sem tag',
+        tipo_transacao=tipo_transacao,
+        documento_transacao='',
+        data_transacao=datetime.date(2020, 3, 11),
+        valor_total=140.00,
+    )
+
+@pytest.fixture
+def tag_1():
+    return baker.make(
+        'Tag',
+        id=1,
+        nome="TAG TESTE 1",
+        status=StatusTag.ATIVO.name
+    )
+
+@pytest.fixture
+def tag_2():
+    return baker.make(
+        'Tag',
+        id=2,
+        nome="TAG TESTE 2",
+        status=StatusTag.ATIVO.name
+    )
+
+@pytest.fixture
+def rateio_despesa_tag_1(associacao, despesa_teste_filtro_vinculo_atividade_tag_1, conta_associacao, acao, tipo_aplicacao_recurso_custeio, tipo_custeio_servico, especificacao_instalacao_eletrica, acao_associacao_ptrf, tag_1):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_teste_filtro_vinculo_atividade_tag_1,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=120.00,
+        conferido=True,
+        tag=tag_1,
+    )
+
+@pytest.fixture
+def rateio_despesa_tag_2(associacao, despesa_teste_filtro_vinculo_atividade_tag_2, conta_associacao, acao, tipo_aplicacao_recurso_custeio, tipo_custeio_servico, especificacao_instalacao_eletrica, acao_associacao_ptrf, tag_1):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_teste_filtro_vinculo_atividade_tag_2,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=130.00,
+        conferido=True,
+        tag=tag_1,
+    )
+
+@pytest.fixture
+def rateio_despesa_sem_tag(associacao, despesa_teste_filtro_vinculo_atividade_sem_tag, conta_associacao, acao, tipo_aplicacao_recurso_custeio, tipo_custeio_servico, especificacao_instalacao_eletrica, acao_associacao_ptrf):
+    return baker.make(
+        'RateioDespesa',
+        despesa=despesa_teste_filtro_vinculo_atividade_sem_tag,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao_ptrf,
+        aplicacao_recurso=tipo_aplicacao_recurso_custeio,
+        tipo_custeio=tipo_custeio_servico,
+        especificacao_material_servico=especificacao_instalacao_eletrica,
+        valor_rateio=140.00,
+        conferido=True,
+    )
+
+def test_api_get_despesas_filtro_vinculo_de_atividades_vazio(jwt_authenticated_client_d, associacao, despesa_teste_filtro_vinculo_atividade_tag_1, despesa_teste_filtro_vinculo_atividade_tag_2, despesa_teste_filtro_vinculo_atividade_sem_tag, tipo_documento, tipo_transacao, rateio_despesa_tag_1, rateio_despesa_tag_2, rateio_despesa_sem_tag, tag_1, tag_2):
+
+    response = jwt_authenticated_client_d.get(
+        f'/api/despesas/?filtro_vinculo_atividades=',
+        content_type='application/json')
+    result = json.loads(response.content)
+    result = result["results"]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(result) == 3, 'Deve encontrar todas as três despesas.'
+
+
+def test_api_get_despesas_filtro_vinculo_de_atividades_com_tag_1_e_tag_2(jwt_authenticated_client_d, associacao, despesa_teste_filtro_vinculo_atividade_tag_1, despesa_teste_filtro_vinculo_atividade_tag_2, despesa_teste_filtro_vinculo_atividade_sem_tag, tipo_documento, tipo_transacao, rateio_despesa_tag_1, rateio_despesa_tag_2, rateio_despesa_sem_tag, tag_1, tag_2):
+
+    response = jwt_authenticated_client_d.get(
+        f'/api/despesas/?filtro_vinculo_atividades=1,2',
+        content_type='application/json')
+    result = json.loads(response.content)
+    result = result["results"]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(result) == 2, 'Deve encontrar duas despesas a de tag_1 e a de tag_2.'


### PR DESCRIPTION
Esse PR:

- Adiciona os filtros de tags de informação.
- Adiciona os filtros de tags de vínculo de atividades de rateios
- Adiciona ao serializer de despesas o campo informações com as tags de cada rateio, para a apresentação na listagem de despesas da associação.

História: [AB#89762](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/89762)