### PR TITLE
fix(91768): Corrige filtro de periodo seguinte na prestação de contas

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -389,7 +389,7 @@ def associacao_encerrada_2020_2(periodo_2019_2, periodo_2020_2, quarta_unidade):
     )
 
 @pytest.fixture
-def associacao_encerrada_2021_2(periodo_2019_2, periodo_2021_2, outra_unidade):
+def associacao_encerrada_2021_2(periodo_2019_2, outra_unidade):
     return baker.make(
         'Associacao',
         nome='Escola Encerrada em 2021.2',

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -190,7 +190,11 @@ class Associacao(ModeloIdNome):
         ultima_prestacao_feita = prestacoes_da_associacao.last()
         ultimo_periodo_com_prestacao = ultima_prestacao_feita.periodo if ultima_prestacao_feita else None
         if ultimo_periodo_com_prestacao:
-            return ultimo_periodo_com_prestacao.periodo_seguinte.first()
+            periodo_seguinte = ultimo_periodo_com_prestacao.periodo_seguinte.first()
+            if not self.encerrada or (self.encerrada and periodo_seguinte and periodo_seguinte.data_inicio_realizacao_despesas <= self.data_de_encerramento):
+                return periodo_seguinte
+            else:
+                return None
         else:
             return self.periodo_inicial.periodo_seguinte.first() if self.periodo_inicial else None
 


### PR DESCRIPTION
Esse PR:

- Corrige filtro de periodo seguinte na prestação de contas.
- Remove parâmetro sem uso em conftest.

História: [AB#91768](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91768)