### PR TITLE
feat(93756): Não permitir selecionar associação encerrada

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/acao_associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/acao_associacao_serializer.py
@@ -62,7 +62,15 @@ class AcaoAssociacaoCreateSerializer(serializers.ModelSerializer):
 class AcaoAssociacaoRetrieveSerializer(serializers.ModelSerializer):
     associacao = AssociacaoListSerializer()
     acao = AcaoSerializer()
+    data_de_encerramento_associacao = serializers.SerializerMethodField('get_data_de_encerramento_associacao')
+    tooltip_associacao_encerrada = serializers.SerializerMethodField('get_tooltip_associacao_encerrada')
+
+    def get_data_de_encerramento_associacao(self, obj):
+        return obj.associacao.data_de_encerramento
+
+    def get_tooltip_associacao_encerrada(self, obj):
+        return obj.associacao.tooltip_data_encerramento
 
     class Meta:
         model = AcaoAssociacao
-        fields = ('uuid', 'id', 'associacao', 'acao', 'status', 'criado_em')
+        fields = ('uuid', 'id', 'associacao', 'data_de_encerramento_associacao', 'tooltip_associacao_encerrada', 'acao', 'status', 'criado_em')

--- a/sme_ptrf_apps/core/api/serializers/associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/associacao_serializer.py
@@ -120,6 +120,10 @@ class AssociacaoInfoAtaSerializer(serializers.ModelSerializer):
 
 class AssociacaoListSerializer(serializers.ModelSerializer):
     unidade = UnidadeListEmAssociacoesSerializer(many=False)
+    encerrada = serializers.SerializerMethodField('get_encerrada')
+
+    def get_encerrada(self, obj):
+        return obj.encerrada
 
     class Meta:
         model = Associacao
@@ -130,7 +134,8 @@ class AssociacaoListSerializer(serializers.ModelSerializer):
             'status_valores_reprogramados',
             'data_de_encerramento',
             'tooltip_data_encerramento',
-            'unidade'
+            'unidade',
+            'encerrada'
         ]
 
 

--- a/sme_ptrf_apps/core/api/views/acao_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/acao_associacao_viewset.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 
 from sme_ptrf_apps.core.api.serializers import AcaoAssociacaoCreateSerializer, AcaoAssociacaoRetrieveSerializer
+from sme_ptrf_apps.core.choices.filtro_informacoes_associacao import FiltroInformacoesAssociacao
 from sme_ptrf_apps.core.models import AcaoAssociacao, Acao, Associacao
 from sme_ptrf_apps.users.permissoes import PermissaoApiUe, PermissaoAPITodosComGravacao
 
@@ -30,10 +31,25 @@ class AcaoAssociacaoViewSet(mixins.RetrieveModelMixin,
         qs = AcaoAssociacao.objects.all()
 
         nome = self.request.query_params.get('nome')
+        filtro_informacoes = self.request.query_params.get('filtro_informacoes')
+        filtro_informacoes_list = filtro_informacoes.split(',') if filtro_informacoes else []
+
+        encerradas = FiltroInformacoesAssociacao.FILTRO_INFORMACOES_ENCERRADAS
+        nao_encerradas = FiltroInformacoesAssociacao.FILTRO_INFORMACOES_NAO_ENCERRADAS
+
         if nome is not None:
             qs = qs.filter(Q(associacao__nome__unaccent__icontains=nome) | Q(
                 associacao__unidade__nome__unaccent__icontains=nome) | Q(
                 associacao__unidade__codigo_eol__icontains=nome))
+
+        if filtro_informacoes_list:
+            if encerradas in filtro_informacoes_list and nao_encerradas in filtro_informacoes_list:
+                qs = qs
+            elif nao_encerradas in filtro_informacoes_list:
+                qs = qs.filter(associacao__data_de_encerramento__isnull=True)
+
+            elif encerradas in filtro_informacoes_list:
+                qs = qs.filter(associacao__data_de_encerramento__isnull=False)
 
         return qs.order_by('associacao__nome', 'acao__nome')
 

--- a/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
@@ -25,6 +25,7 @@ def test_api_acoes_list_associacoes_nao_vinculadas(jwt_authenticated_client_a,
             'nome': associacao_eco_delta_000087.nome,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False,
             'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
             'unidade': {
                 'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
@@ -56,6 +57,7 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome(jwt_authenticated_cl
             'uuid': f'{associacao_eco_delta_000087.uuid}',
             'nome': associacao_eco_delta_000087.nome,
             'data_de_encerramento': None,
+            'encerrada': False,
             'tooltip_data_encerramento': None,
             'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
             'unidade': {

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from model_bakery import baker
 from datetime import date
 
@@ -47,6 +46,17 @@ def associacao_charli_bravo_000086(unidade_bravo_000086, periodo_anterior):
         periodo_inicial=periodo_anterior,
     )
 
+@pytest.fixture
+def associacao_charli_bingo_000086(unidade_bravo_000086, periodo_anterior):
+    return baker.make(
+        'Associacao',
+        nome='Bingo',
+        cnpj='17.980.696/0001-62',
+        unidade=unidade_bravo_000086,
+        periodo_inicial=periodo_anterior,
+        data_de_encerramento=date(2020, 3, 26),
+    )
+
 
 @pytest.fixture
 def acao_associacao_charli_bravo_000086_x(associacao_charli_bravo_000086, acao_x):
@@ -63,6 +73,14 @@ def acao_associacao_charli_bravo_000086_y(associacao_charli_bravo_000086, acao_y
         'AcaoAssociacao',
         associacao=associacao_charli_bravo_000086,
         acao=acao_y
+    )
+
+@pytest.fixture
+def acao_associacao_charli_bingo_000086_x(associacao_charli_bingo_000086, acao_x):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=associacao_charli_bingo_000086,
+        acao=acao_x
     )
 
 

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
@@ -25,6 +25,7 @@ def test_retrieve_acao_associacao(
             'nome': acao_associacao.associacao.nome,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False,
             'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
             'unidade': {
                 'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -34,6 +35,8 @@ def test_retrieve_acao_associacao(
             },
             'cnpj': acao_associacao.associacao.cnpj
         },
+        'data_de_encerramento_associacao': None,
+        'tooltip_associacao_encerrada': None,
         'acao': {
             'id': acao_associacao.acao.id,
             'uuid': f'{acao_associacao.acao.uuid}',

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -30,6 +30,7 @@ def test_api_list_acoes_associacoes_todas(
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -39,6 +40,8 @@ def test_api_list_acoes_associacoes_todas(
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',
@@ -79,6 +82,7 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -88,6 +92,8 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',
@@ -127,6 +133,7 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -136,6 +143,8 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',
@@ -175,6 +184,7 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -184,6 +194,8 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',
@@ -225,6 +237,7 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -234,6 +247,8 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',
@@ -276,6 +291,7 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
                     'nome': acao_associacao.associacao.nome,
                     'data_de_encerramento': None,
                     'tooltip_data_encerramento': None,
+                    'encerrada': False,
                     'status_valores_reprogramados': acao_associacao.associacao.status_valores_reprogramados,
                     'unidade': {
                         'uuid': f'{acao_associacao.associacao.unidade.uuid}',
@@ -285,6 +301,8 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
                     },
                     'cnpj': acao_associacao.associacao.cnpj
                 },
+                'data_de_encerramento_associacao': None,
+                'tooltip_associacao_encerrada': None,
                 'acao': {
                     'id': acao_associacao.acao.id,
                     'uuid': f'{acao_associacao.acao.uuid}',

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -319,3 +319,178 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
         )
     assert response.status_code == status.HTTP_200_OK
     assert result == resultado_esperado
+
+def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_authenticated_client_a,
+                                                                          acao_associacao_charli_bravo_000086_x,
+                                                                          acao_associacao_charli_bingo_000086_x,
+                                                                          acao_x
+                                                                        ):
+
+    response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=ENCERRADAS,NAO_ENCERRADAS',
+                                              content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{acao_associacao_charli_bingo_000086_x.uuid}',
+            'id': acao_associacao_charli_bingo_000086_x.id,
+            'associacao': {
+                'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
+                'nome': acao_associacao_charli_bingo_000086_x.associacao.nome,
+                'data_de_encerramento': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),
+                'tooltip_data_encerramento': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
+                'encerrada': acao_associacao_charli_bingo_000086_x.associacao.encerrada,
+                'status_valores_reprogramados': acao_associacao_charli_bingo_000086_x.associacao.status_valores_reprogramados,
+                'unidade': {
+                    'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.unidade.uuid}',
+                    'codigo_eol': acao_associacao_charli_bingo_000086_x.associacao.unidade.codigo_eol,
+                    'nome_com_tipo': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_com_tipo,
+                    'nome_dre': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_dre
+                },
+                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj
+            },
+            'data_de_encerramento_associacao': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),
+            'tooltip_associacao_encerrada': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
+            'acao': {
+                'id': acao_associacao_charli_bingo_000086_x.acao.id,
+                'uuid': f'{acao_associacao_charli_bingo_000086_x.acao.uuid}',
+                'nome': acao_associacao_charli_bingo_000086_x.acao.nome,
+                'e_recursos_proprios': acao_associacao_charli_bingo_000086_x.acao.e_recursos_proprios,
+                'posicao_nas_pesquisas': 'ZZZZZZZZZZ',
+                "aceita_capital": acao_associacao_charli_bingo_000086_x.acao.aceita_capital,
+                "aceita_custeio": acao_associacao_charli_bingo_000086_x.acao.aceita_custeio,
+                "aceita_livre": acao_associacao_charli_bingo_000086_x.acao.aceita_livre
+            },
+            'status': acao_associacao_charli_bingo_000086_x.status,
+            'criado_em': acao_associacao_charli_bingo_000086_x.criado_em.isoformat("T"),
+        },
+        {
+            'uuid': f'{acao_associacao_charli_bravo_000086_x.uuid}',
+            'id': acao_associacao_charli_bravo_000086_x.id,
+            'associacao': {
+                'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',
+                'nome': acao_associacao_charli_bravo_000086_x.associacao.nome,
+                'data_de_encerramento': None,
+                'tooltip_data_encerramento': None,
+                'encerrada': acao_associacao_charli_bravo_000086_x.associacao.encerrada,
+                'status_valores_reprogramados': acao_associacao_charli_bravo_000086_x.associacao.status_valores_reprogramados,
+                'unidade': {
+                    'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.unidade.uuid}',
+                    'codigo_eol': acao_associacao_charli_bravo_000086_x.associacao.unidade.codigo_eol,
+                    'nome_com_tipo': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_com_tipo,
+                    'nome_dre': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_dre
+                },
+                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj
+            },
+            'data_de_encerramento_associacao': None,
+            'tooltip_associacao_encerrada': None,
+            'acao': {
+                'id': acao_associacao_charli_bravo_000086_x.acao.id,
+                'uuid': f'{acao_associacao_charli_bravo_000086_x.acao.uuid}',
+                'nome': acao_associacao_charli_bravo_000086_x.acao.nome,
+                'e_recursos_proprios': acao_associacao_charli_bravo_000086_x.acao.e_recursos_proprios,
+                'posicao_nas_pesquisas': 'ZZZZZZZZZZ',
+                "aceita_capital": acao_associacao_charli_bravo_000086_x.acao.aceita_capital,
+                "aceita_custeio": acao_associacao_charli_bravo_000086_x.acao.aceita_custeio,
+                "aceita_livre": acao_associacao_charli_bravo_000086_x.acao.aceita_livre
+            },
+            'status': acao_associacao_charli_bravo_000086_x.status,
+            'criado_em': acao_associacao_charli_bravo_000086_x.criado_em.isoformat("T"),
+        },
+    ]
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticated_client_a,
+                                                                 acao_associacao_charli_bingo_000086_x,
+                                                                 acao_x
+                                                                ):
+
+    response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=ENCERRADAS',
+                                              content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{acao_associacao_charli_bingo_000086_x.uuid}',
+            'id': acao_associacao_charli_bingo_000086_x.id,
+            'associacao': {
+                'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
+                'nome': acao_associacao_charli_bingo_000086_x.associacao.nome,
+                'data_de_encerramento': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),
+                'tooltip_data_encerramento': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
+                'encerrada': acao_associacao_charli_bingo_000086_x.associacao.encerrada,
+                'status_valores_reprogramados': acao_associacao_charli_bingo_000086_x.associacao.status_valores_reprogramados,
+                'unidade': {
+                    'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.unidade.uuid}',
+                    'codigo_eol': acao_associacao_charli_bingo_000086_x.associacao.unidade.codigo_eol,
+                    'nome_com_tipo': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_com_tipo,
+                    'nome_dre': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_dre
+                },
+                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj
+            },
+            'data_de_encerramento_associacao': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),
+            'tooltip_associacao_encerrada': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
+            'acao': {
+                'id': acao_associacao_charli_bingo_000086_x.acao.id,
+                'uuid': f'{acao_associacao_charli_bingo_000086_x.acao.uuid}',
+                'nome': acao_associacao_charli_bingo_000086_x.acao.nome,
+                'e_recursos_proprios': acao_associacao_charli_bingo_000086_x.acao.e_recursos_proprios,
+                'posicao_nas_pesquisas': 'ZZZZZZZZZZ',
+                "aceita_capital": acao_associacao_charli_bingo_000086_x.acao.aceita_capital,
+                "aceita_custeio": acao_associacao_charli_bingo_000086_x.acao.aceita_custeio,
+                "aceita_livre": acao_associacao_charli_bingo_000086_x.acao.aceita_livre
+            },
+            'status': acao_associacao_charli_bingo_000086_x.status,
+            'criado_em': acao_associacao_charli_bingo_000086_x.criado_em.isoformat("T"),
+        }
+    ]
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_list_associacoes_por_associacoes_somente_nao_encerradas(jwt_authenticated_client_a,
+                                                                     acao_associacao_charli_bravo_000086_x,
+                                                                     acao_x
+                                                                    ):
+
+    response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=NAO_ENCERRADAS',
+                                              content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{acao_associacao_charli_bravo_000086_x.uuid}',
+            'id': acao_associacao_charli_bravo_000086_x.id,
+            'associacao': {
+                'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',
+                'nome': acao_associacao_charli_bravo_000086_x.associacao.nome,
+                'data_de_encerramento': None,
+                'tooltip_data_encerramento': None,
+                'encerrada': acao_associacao_charli_bravo_000086_x.associacao.encerrada,
+                'status_valores_reprogramados': acao_associacao_charli_bravo_000086_x.associacao.status_valores_reprogramados,
+                'unidade': {
+                    'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.unidade.uuid}',
+                    'codigo_eol': acao_associacao_charli_bravo_000086_x.associacao.unidade.codigo_eol,
+                    'nome_com_tipo': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_com_tipo,
+                    'nome_dre': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_dre
+                },
+                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj
+            },
+            'data_de_encerramento_associacao': None,
+            'tooltip_associacao_encerrada': None,
+            'acao': {
+                'id': acao_associacao_charli_bravo_000086_x.acao.id,
+                'uuid': f'{acao_associacao_charli_bravo_000086_x.acao.uuid}',
+                'nome': acao_associacao_charli_bravo_000086_x.acao.nome,
+                'e_recursos_proprios': acao_associacao_charli_bravo_000086_x.acao.e_recursos_proprios,
+                'posicao_nas_pesquisas': 'ZZZZZZZZZZ',
+                "aceita_capital": acao_associacao_charli_bravo_000086_x.acao.aceita_capital,
+                "aceita_custeio": acao_associacao_charli_bravo_000086_x.acao.aceita_custeio,
+                "aceita_livre": acao_associacao_charli_bravo_000086_x.acao.aceita_livre
+            },
+            'status': acao_associacao_charli_bravo_000086_x.status,
+            'criado_em': acao_associacao_charli_bravo_000086_x.criado_em.isoformat("T"),
+        },
+    ]
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
@@ -66,6 +66,7 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
         {
             'uuid': f'{associacao_pinheiros_emef_mendes_dre_2.uuid}',
@@ -80,6 +81,7 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'cnpj': associacao_pinheiros_emef_mendes_dre_2.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -108,6 +110,7 @@ def test_api_list_associacoes_de_uma_dre(jwt_authenticated_client_a, associacao_
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -134,6 +137,7 @@ def test_api_list_associacoes_pelo_nome_associacao_ignorando_acentos(jwt_authent
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -160,6 +164,7 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a, assoc
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -186,6 +191,7 @@ def test_api_list_associacoes_pelo_tipo_unidade(jwt_authenticated_client_a, asso
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -212,6 +218,7 @@ def test_api_list_associacoes_pelo_codigo_eol(jwt_authenticated_client_a, associ
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -241,6 +248,7 @@ def test_api_list_associacoes_filtro_somente_encerradas(
             'cnpj': associacao_encerrada_2020_1.cnpj,
             'data_de_encerramento': f'{associacao_encerrada_2020_1.data_de_encerramento}',
             'tooltip_data_encerramento': associacao_encerrada_2020_1.tooltip_data_encerramento,
+            'encerrada': True
         },
         {
             'uuid': f'{associacao_encerrada_2020_2.uuid}',
@@ -255,6 +263,7 @@ def test_api_list_associacoes_filtro_somente_encerradas(
             'cnpj': associacao_encerrada_2020_2.cnpj,
             'data_de_encerramento': f'{associacao_encerrada_2020_2.data_de_encerramento}',
             'tooltip_data_encerramento': associacao_encerrada_2020_2.tooltip_data_encerramento,
+            'encerrada': True
         },
     ]
 
@@ -285,6 +294,7 @@ def test_api_list_associacoes_filtro_somente_nao_encerradas(
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
         {
             'uuid': f'{associacao_pinheiros_emef_mendes_dre_2.uuid}',
@@ -299,6 +309,7 @@ def test_api_list_associacoes_filtro_somente_nao_encerradas(
             'cnpj': associacao_pinheiros_emef_mendes_dre_2.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 
@@ -328,6 +339,7 @@ def test_api_list_associacoes_filtro_encerradas_e_nao_encerradas(
             'cnpj': associacao_encerrada_2020_1.cnpj,
             'data_de_encerramento': f'{associacao_encerrada_2020_1.data_de_encerramento}',
             'tooltip_data_encerramento': associacao_encerrada_2020_1.tooltip_data_encerramento,
+            'encerrada': True
         },
         {
             'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.uuid}',
@@ -342,6 +354,7 @@ def test_api_list_associacoes_filtro_encerradas_e_nao_encerradas(
             'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
         {
             'uuid': f'{associacao_pinheiros_emef_mendes_dre_2.uuid}',
@@ -356,6 +369,7 @@ def test_api_list_associacoes_filtro_encerradas_e_nao_encerradas(
             'cnpj': associacao_pinheiros_emef_mendes_dre_2.cnpj,
             'data_de_encerramento': None,
             'tooltip_data_encerramento': None,
+            'encerrada': False
         },
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes_status_regularidade_ano.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes_status_regularidade_ano.py
@@ -105,6 +105,7 @@ def test_api_list_status_associacoes_dre_1(
                 'nome': associacao_valenca_ceu_vassouras_dre_1.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_valenca_ceu_vassouras_dre_1.status_valores_reprogramados,
                 'unidade': {
                     'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
@@ -144,6 +145,7 @@ def test_api_list_status_associacoes_pelo_nome_associacao_ignorando_acentos(
                 'nome': associacao_valenca_ceu_vassouras_dre_1.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_valenca_ceu_vassouras_dre_1.status_valores_reprogramados,
                 'unidade': {
                     'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
@@ -182,6 +184,7 @@ def test_api_list_status_associacoes_pelo_nome_escola(
                 'nome': associacao_valenca_ceu_vassouras_dre_1.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_valenca_ceu_vassouras_dre_1.status_valores_reprogramados,
                 'unidade': {
                     'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
@@ -222,6 +225,7 @@ def test_api_list_status_associacoes_pelo_tipo_unidade(
                 'nome': associacao_valenca_ceu_vassouras_dre_1.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_valenca_ceu_vassouras_dre_1.status_valores_reprogramados,
                 'unidade': {
                     'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',
@@ -261,6 +265,7 @@ def test_api_list_status_associacoes_pelo_status(
                 'nome': associacao_valenca_ceu_vassouras_dre_1.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_valenca_ceu_vassouras_dre_1.status_valores_reprogramados,
                 'unidade': {
                     'uuid': f'{associacao_valenca_ceu_vassouras_dre_1.unidade.uuid}',

--- a/sme_ptrf_apps/dre/tests/tests_api_valores_reprogramados_dre/test_valores_reprogramados_filtros.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_valores_reprogramados_dre/test_valores_reprogramados_filtros.py
@@ -28,6 +28,7 @@ def test_api_valores_reprogramados_filtro_nome_unidade(
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_2.status_valores_reprogramados,
                 'unidade': {
                     'codigo_eol': unidade_valores_reprogramados.codigo_eol,
@@ -76,6 +77,7 @@ def test_api_valores_reprogramados_filtro_nome_associacao(
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_2.status_valores_reprogramados,
                 'unidade': {
                     'codigo_eol': unidade_valores_reprogramados.codigo_eol,
@@ -124,6 +126,7 @@ def test_api_valores_reprogramados_filtro_codigo_eol(
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_2.status_valores_reprogramados,
                 'unidade': {
                     'codigo_eol': unidade_valores_reprogramados.codigo_eol,
@@ -172,6 +175,7 @@ def test_api_valores_reprogramados_filtro_tipo_unidade(
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
                 'tooltip_data_encerramento': None,
+                'encerrada': False,
                 'status_valores_reprogramados': associacao_2.status_valores_reprogramados,
                 'unidade': {
                     'codigo_eol': unidade_valores_reprogramados.codigo_eol,


### PR DESCRIPTION
Esse PR:

- Adiciona informação sobre associação encerrada no retorno de ações da associação.
- Implementa filtro por informações
- Atualiza testes
- Implementa testes do filtro

História: [AB#93756](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93756)