### PR TITLE
feat(94326): Adiciona etiquetas nos gastos da escola

### DIFF
--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -150,6 +150,10 @@ class DespesasViewSet(mixins.CreateModelMixin,
                     excluir_despesa = False
                 if Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and despesa.tem_pagamento_com_recursos_proprios() or Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and despesa.tem_pagamentos_em_multiplas_contas():
                     excluir_despesa = False
+                if Despesa.TAG_NAO_RECONHECIDA['id'] in filtro_informacoes_list and despesa.e_despesa_nao_reconhecida():
+                    excluir_despesa = False
+                if Despesa.TAG_SEM_COMPROVACAO_FISCAL['id'] in filtro_informacoes_list and despesa.e_despesa_sem_comprovacao_fiscal():
+                    excluir_despesa = False
 
                 if excluir_despesa:
                     ids_para_excluir.append(despesa.id)

--- a/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/rateios_despesas_viewset.py
@@ -180,6 +180,10 @@ class RateiosDespesasViewSet(mixins.CreateModelMixin,
                     excluir_rateio = False
                 if Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and rateio.despesa.tem_pagamento_com_recursos_proprios() or Despesa.TAG_PARCIAL['id'] in filtro_informacoes_list and rateio.despesa.tem_pagamentos_em_multiplas_contas():
                     excluir_rateio = False
+                if Despesa.TAG_NAO_RECONHECIDA['id'] in filtro_informacoes_list and rateio.despesa.e_despesa_nao_reconhecida():
+                    excluir_rateio = False
+                if Despesa.TAG_SEM_COMPROVACAO_FISCAL['id'] in filtro_informacoes_list and rateio.despesa.e_despesa_sem_comprovacao_fiscal():
+                    excluir_rateio = False
 
                 if excluir_rateio:
                     ids_para_excluir.append(rateio.id)

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -27,6 +27,8 @@ class Despesa(ModeloBase):
     TAG_IMPOSTO = {"id": "4", "nome": "Imposto", "descricao": "Despesa com recolhimento de imposto."}
     TAG_IMPOSTO_PAGO = {"id": "5", "nome": "Imposto Pago", "descricao": "Imposto recolhido relativo a uma despesa de serviço."}
     TAG_INATIVA = {"id": "6", "nome": "Excluído", "descricao": "Lançamento excluído."}
+    TAG_NAO_RECONHECIDA = {"id": "7", "nome": "Não Reconhecida", "descricao": "Despesa não reconhecida pela associação."}
+    TAG_SEM_COMPROVACAO_FISCAL = {"id": "8", "nome": "Sem comprovação fiscal", "descricao": "Despesa sem comprovação fiscal."}
 
     history = AuditlogHistoryField()
 
@@ -138,6 +140,18 @@ class Despesa(ModeloBase):
             tags.append(tag_informacao(
                 self.TAG_INATIVA,
                 f"Este gasto foi excluído em {self.data_e_hora_de_inativacao.strftime('%d/%m/%Y %H:%M:%S')}"
+            ))
+
+        if self.e_despesa_nao_reconhecida():
+            tags.append(tag_informacao(
+                self.TAG_NAO_RECONHECIDA,
+                f"Essa despesa não é reconhecida pela associação."
+            ))
+
+        if self.e_despesa_sem_comprovacao_fiscal():
+            tags.append(tag_informacao(
+                self.TAG_SEM_COMPROVACAO_FISCAL,
+                f"Essa despesa não possui comprovação fiscal."
             ))
         return tags
 
@@ -267,7 +281,13 @@ class Despesa(ModeloBase):
 
     def e_despesa_inativa(self):
         return self.status == STATUS_INATIVO
-
+    
+    def e_despesa_nao_reconhecida(self):
+        return not self.eh_despesa_reconhecida_pela_associacao
+    
+    def e_despesa_sem_comprovacao_fiscal(self):
+        return self.eh_despesa_sem_comprovacao_fiscal
+    
     def inativar_despesa(self):
         self.status = STATUS_INATIVO
         self.data_e_hora_de_inativacao = datetime.now()
@@ -289,7 +309,7 @@ class Despesa(ModeloBase):
 
     @classmethod
     def get_tags_informacoes_list(cls):
-        return [cls.TAG_ANTECIPADO, cls.TAG_ESTORNADO, cls.TAG_PARCIAL, cls.TAG_IMPOSTO, cls.TAG_IMPOSTO_PAGO, cls.TAG_INATIVA]
+        return [cls.TAG_ANTECIPADO, cls.TAG_ESTORNADO, cls.TAG_PARCIAL, cls.TAG_IMPOSTO, cls.TAG_IMPOSTO_PAGO, cls.TAG_INATIVA, cls.TAG_NAO_RECONHECIDA, cls.TAG_SEM_COMPROVACAO_FISCAL]
 
     class Meta:
         verbose_name = "Documento comprobatório da despesa"

--- a/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
+++ b/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_tags_informacoes.py
@@ -14,4 +14,6 @@ def test_get_tags_informacoes_list():
         {"id": "4", "nome": "Imposto", "descricao": "Despesa com recolhimento de imposto."},
         {"id": "5", "nome": "Imposto Pago", "descricao": "Imposto recolhido relativo a uma despesa de serviço."},
         {"id": "6", "nome": "Excluído", "descricao": "Lançamento excluído."},
+        {"id": "7", "nome": "Não Reconhecida", "descricao": "Despesa não reconhecida pela associação."},
+        {"id": "8", "nome": "Sem comprovação fiscal", "descricao": "Despesa sem comprovação fiscal."},
     ]


### PR DESCRIPTION
Esse PR:

- Adiciona as etiquetas de despesas não reconhecidas e sem comprovação fiscal.

História: [AB#94326](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/94326)