### PR TITLE
feat(92324): Adicionar filtro por informações nas rotas de associações não vinculadas

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_acoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-
+from datetime import date
 from model_bakery import baker
 
 
@@ -81,6 +81,17 @@ def unidade_delta_000087(dre_alfa):
         dre=dre_alfa,
     )
 
+@pytest.fixture
+def unidade_delta_000088(dre_alfa):
+    return baker.make(
+        'Unidade',
+        codigo_eol="000088",
+        tipo_unidade="EMEI",
+        nome="Delta",
+        sigla="",
+        dre=dre_alfa,
+    )
+
 
 @pytest.fixture
 def associacao_eco_delta_000087(unidade_delta_000087, periodo_anterior):
@@ -90,6 +101,17 @@ def associacao_eco_delta_000087(unidade_delta_000087, periodo_anterior):
         cnpj='94.175.194/0001-00',
         unidade=unidade_delta_000087,
         periodo_inicial=periodo_anterior,
+    )
+
+@pytest.fixture
+def associacao_eco_delta_000088(unidade_delta_000088, periodo_anterior):
+    return baker.make(
+        'Associacao',
+        nome='Eco Delta 000088',
+        cnpj='49.218.902/0001-98',
+        unidade=unidade_delta_000088,
+        periodo_inicial=periodo_anterior,
+        data_de_encerramento=date(2023, 5, 1)
     )
 
 
@@ -109,4 +131,12 @@ def acao_associacao_eco_delta_000087_y_inativa(associacao_eco_delta_000087, acao
         associacao=associacao_eco_delta_000087,
         acao=acao_y,
         status='INATIVA'
+    )
+
+@pytest.fixture
+def acao_associacao_eco_delta_000087_z(associacao_eco_delta_000088, acao_x):
+    return baker.make(
+        'AcaoAssociacao',
+        associacao=associacao_eco_delta_000088,
+        acao=acao_x
     )

--- a/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
@@ -34,6 +34,123 @@ def test_api_acoes_list_associacoes_nao_vinculadas(jwt_authenticated_client_a,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
             'cnpj': associacao_eco_delta_000087.cnpj
+        }
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_encerradas_e_nao_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas/?filtro_informacoes=ENCERRADAS,NAO_ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000087.uuid}',
+            'nome': associacao_eco_delta_000087.nome,
+            'data_de_encerramento': None,
+            'tooltip_data_encerramento': None,
+            'encerrada': False,
+            'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000087.cnpj
+        },
+        {
+            'uuid': f'{associacao_eco_delta_000088.uuid}',
+            'nome': associacao_eco_delta_000088.nome,
+            'data_de_encerramento': associacao_eco_delta_000088.data_de_encerramento.strftime("%Y-%m-%d"),
+            'tooltip_data_encerramento': associacao_eco_delta_000088.tooltip_data_encerramento,
+            'encerrada': associacao_eco_delta_000088.encerrada,
+            'status_valores_reprogramados': associacao_eco_delta_000088.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000088.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000088.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000088.cnpj
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_somente_nao_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas/?filtro_informacoes=NAO_ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000087.uuid}',
+            'nome': associacao_eco_delta_000087.nome,
+            'data_de_encerramento': None,
+            'tooltip_data_encerramento': None,
+            'encerrada': False,
+            'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000087.cnpj
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_somente_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas/?filtro_informacoes=NAO_ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000087.uuid}',
+            'nome': associacao_eco_delta_000087.nome,
+            'data_de_encerramento': None,
+            'tooltip_data_encerramento': None,
+            'encerrada': False,
+            'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000087.cnpj
         },
     ]
 
@@ -67,6 +184,123 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome(jwt_authenticated_cl
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
             'cnpj': associacao_eco_delta_000087.cnpj
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_encerradas_e_nao_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas-por-nome/delta/?filtro_informacoes=ENCERRADAS,NAO_ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000087.uuid}',
+            'nome': associacao_eco_delta_000087.nome,
+            'data_de_encerramento': None,
+            'tooltip_data_encerramento': None,
+            'encerrada': False,
+            'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000087.cnpj
+        },
+        {
+            'uuid': f'{associacao_eco_delta_000088.uuid}',
+            'nome': associacao_eco_delta_000088.nome,
+            'data_de_encerramento': associacao_eco_delta_000088.data_de_encerramento.strftime("%Y-%m-%d"),
+            'tooltip_data_encerramento': associacao_eco_delta_000088.tooltip_data_encerramento,
+            'encerrada': associacao_eco_delta_000088.encerrada,
+            'status_valores_reprogramados': associacao_eco_delta_000088.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000088.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000088.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000088.cnpj
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_somente_nao_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas-por-nome/delta/?filtro_informacoes=NAO_ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000087.uuid}',
+            'nome': associacao_eco_delta_000087.nome,
+            'data_de_encerramento': None,
+            'tooltip_data_encerramento': None,
+            'encerrada': False,
+            'status_valores_reprogramados': associacao_eco_delta_000087.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000087.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000087.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000087.cnpj
+        },
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == resultado_esperado
+
+def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_somente_encerradas(jwt_authenticated_client_a,
+                                                   acao_x,
+                                                   acao_y,
+                                                   associacao_charli_bravo_000086,
+                                                   associacao_eco_delta_000087,
+                                                   associacao_eco_delta_000088,
+                                                   acao_associacao_charli_bravo_000086_y,
+                                                   acao_associacao_charli_bravo_000086_x,
+                                                   acao_associacao_eco_delta_000087_x
+                                                   ):
+    response = jwt_authenticated_client_a.get(f'/api/acoes/{acao_y.uuid}/associacoes-nao-vinculadas-por-nome/delta/?filtro_informacoes=ENCERRADAS', content_type='application/json')
+    result = json.loads(response.content)
+
+    resultado_esperado = [
+        {
+            'uuid': f'{associacao_eco_delta_000088.uuid}',
+            'nome': associacao_eco_delta_000088.nome,
+            'data_de_encerramento': associacao_eco_delta_000088.data_de_encerramento.strftime("%Y-%m-%d"),
+            'tooltip_data_encerramento': associacao_eco_delta_000088.tooltip_data_encerramento,
+            'encerrada': associacao_eco_delta_000088.encerrada,
+            'status_valores_reprogramados': associacao_eco_delta_000088.status_valores_reprogramados,
+            'unidade': {
+                'uuid': f'{associacao_eco_delta_000088.unidade.uuid}',
+                'codigo_eol': associacao_eco_delta_000088.unidade.codigo_eol,
+                'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
+                'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
+            },
+            'cnpj': associacao_eco_delta_000088.cnpj
         },
     ]
 


### PR DESCRIPTION
Esse PR:

- Implementa filtro por informações 
- Adiciona testes

Históia: [AB#92324](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/92324)