### PR TITLE
feat(89001): Validar pendências de cadastro em concluir acerto/concluir período

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -459,6 +459,21 @@ def associacao_com_presidente_ausente(unidade, periodo_anterior):
         cargo_substituto_presidente_ausente=MembroEnum.VICE_PRESIDENTE_DIRETORIA_EXECUTIVA.name
     )
 
+@pytest.fixture
+def associacao_sem_nome(unidade, periodo_anterior):
+    return baker.make(
+        'Associacao',
+        nome='',
+        cnpj='52.302.275/0001-83',
+        unidade=unidade,
+        periodo_inicial=periodo_anterior,
+        ccm='0.000.00-0',
+        email="ollyverottoboni@gmail.com",
+        processo_regularidade='123456',
+        status_presidente='AUSENTE',
+        cargo_substituto_presidente_ausente=MembroEnum.VICE_PRESIDENTE_DIRETORIA_EXECUTIVA.name
+    )
+
 
 @pytest.fixture
 def outra_associacao(unidade, periodo_anterior):
@@ -502,6 +517,26 @@ def conta_associacao(associacao, tipo_conta):
         agencia='12345',
         numero_conta='123456-x',
         numero_cartao='534653264523'
+    )
+
+@pytest.fixture
+def conta_associacao_tipo_cheque(associacao, tipo_conta_cheque):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=tipo_conta_cheque,
+        banco_nome='Banco do Brasil',
+        agencia='12345',
+        numero_conta='123456-x',
+        numero_cartao='534653264523'
+    )
+
+@pytest.fixture
+def conta_associacao_incompleta(associacao_sem_nome, tipo_conta_cartao):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao_sem_nome,
+        tipo_conta=tipo_conta_cartao,
     )
 
 
@@ -2022,6 +2057,39 @@ def observacao_conciliacao(periodo, conta_associacao):
         texto="Uma bela observação.",
         data_extrato = date(2020, 7, 1),
         saldo_extrato = 1000
+    )
+
+@pytest.fixture
+def observacao_conciliacao_campos_nao_preenchidos(periodo_2020_1, conta_associacao):
+    return baker.make(
+        'ObservacaoConciliacao',
+        periodo=periodo_2020_1,
+        associacao=conta_associacao.associacao,
+        conta_associacao=conta_associacao,
+        texto="Observação com campos não preenchidos.",
+    )
+
+@pytest.fixture
+def observacao_conciliacao_campos_nao_preenchidos_002(periodo_2020_1, conta_associacao_tipo_cheque):
+    return baker.make(
+        'ObservacaoConciliacao',
+        periodo=periodo_2020_1,
+        associacao=conta_associacao_tipo_cheque.associacao,
+        conta_associacao=conta_associacao_tipo_cheque,
+        texto="Observação com campos não preenchidos 002.",
+    )
+
+@pytest.fixture
+def observacao_conciliacao_campos_preenchidos(periodo_2020_1, conta_associacao):
+    return baker.make(
+        'ObservacaoConciliacao',
+        periodo=periodo_2020_1,
+        associacao=conta_associacao.associacao,
+        conta_associacao=conta_associacao,
+        texto="Observação com campos não preenchidos.",
+        data_extrato = date(2020, 7, 1),
+        saldo_extrato = 1000,
+        comprovante_extrato=None
     )
 
 @pytest.fixture

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -234,6 +234,16 @@ class AssociacoesViewSet(ModelViewSet):
         if prestacao_conta:
             gerar_previas = pc_requer_geracao_documentos(prestacao_conta)
 
+        pendencias_dados = associacao.pendencias_dados_da_associacao_para_geracao_de_documentos()
+        pendencias_conciliacao = associacao.pendencias_conciliacao_bancaria_por_periodo_para_geracao_de_documentos(periodo)
+        if pendencias_dados or pendencias_conciliacao:
+            pendencias_cadastrais = {
+                'dados_associacao': pendencias_dados,
+                'conciliacao_bancaria': pendencias_conciliacao,
+            }
+        else:
+            pendencias_cadastrais = None
+
         result = {
             'associacao': f'{uuid}',
             'periodo_referencia': periodo_referencia,
@@ -243,6 +253,7 @@ class AssociacoesViewSet(ModelViewSet):
             'gerar_ou_editar_ata_apresentacao': gerar_ou_editar_ata_apresentacao,
             'gerar_ou_editar_ata_retificacao': gerar_ou_editar_ata_retificacao,
             'gerar_previas': gerar_previas,
+            'pendencias_cadastrais': pendencias_cadastrais
         }
 
         return Response(result)
@@ -707,7 +718,7 @@ class AssociacoesViewSet(ModelViewSet):
         status_response = response.pop("status")
 
         return Response(response, status=status_response)
-    
+
     @action(detail=False, url_path='tags-informacoes',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def tags_informacoes_list(self, request):

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -37,7 +37,14 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
             'tem_acertos_pendentes': False,
         },
         'prestacao_conta': '',
-
+        'pendencias_cadastrais': {
+            'conciliacao_bancaria': None,
+            'dados_associacao': {
+                'pendencia_cadastro': False,
+                'pendencia_contas': False,
+                'pendencia_membros': True
+            }
+        }
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -69,6 +76,14 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
             'tem_acertos_pendentes': False,
         },
         'prestacao_conta': '',
+        'pendencias_cadastrais': {
+            'conciliacao_bancaria': None,
+            'dados_associacao': {
+                'pendencia_cadastro': False,
+                'pendencia_contas': False,
+                'pendencia_membros': True
+            }
+        }
 
     }
 
@@ -104,6 +119,14 @@ def test_chamada_data_sem_periodo(jwt_authenticated_client_a, associacao, period
         'aceita_alteracoes': True,
         'prestacao_contas_status': {},
         'prestacao_conta': '',
+        'pendencias_cadastrais': {
+            'conciliacao_bancaria': None,
+            'dados_associacao': {
+                'pendencia_cadastro': False,
+                'pendencia_contas': False,
+                'pendencia_membros': True
+            }
+        }
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -137,6 +160,14 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
             'tem_acertos_pendentes': False,
         },
         'prestacao_conta': f'{prestacao_conta_2020_1_conciliada.uuid}',
+        'pendencias_cadastrais': {
+            'conciliacao_bancaria': None,
+            'dados_associacao': {
+                'pendencia_cadastro': False,
+                'pendencia_contas': False,
+                'pendencia_membros': True
+            }
+        }
 
     }
 
@@ -185,8 +216,113 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
             'tem_acertos_pendentes': False,
         },
         'prestacao_conta': f'{_prestacao_conta_devolvida.uuid}',
+        'pendencias_cadastrais': {
+            'conciliacao_bancaria': None,
+            'dados_associacao': {
+                'pendencia_cadastro': False,
+                'pendencia_contas': False,
+                'pendencia_membros': True
+            }
+        }
 
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_pendencias_cadastrais_com_contas_pendentes(
+    jwt_authenticated_client_a, associacao,
+    observacao_conciliacao_campos_nao_preenchidos,
+    observacao_conciliacao_campos_nao_preenchidos_002,
+    periodo_2020_1
+):
+
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    pendencias_cadastrais_esperado = {
+        'conciliacao_bancaria': {
+            'contas_pendentes': [f'{observacao_conciliacao_campos_nao_preenchidos.conta_associacao.uuid}', f'{observacao_conciliacao_campos_nao_preenchidos_002.conta_associacao.uuid}',],
+        },
+        'dados_associacao': {
+            'pendencia_cadastro': False,
+            'pendencia_contas': False,
+            'pendencia_membros': True
+        }
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['pendencias_cadastrais'] == pendencias_cadastrais_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_pendencias_cadastrais_sem_contas_pendentes(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_2020_1,
+):
+
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    pendencias_cadastrais_esperado = {
+        'conciliacao_bancaria': None,
+        'dados_associacao': {
+            'pendencia_cadastro': False,
+            'pendencia_contas': False,
+            'pendencia_membros': True
+        }
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['pendencias_cadastrais'] == pendencias_cadastrais_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_pendencias_cadastrais_somente_dados_associacao_com_pendencia_cadastro_e_pendencia_membros(
+    jwt_authenticated_client_a,
+    associacao_sem_nome,
+    periodo_2020_1,
+):
+
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_sem_nome.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    pendencias_cadastrais_esperado = {
+        'conciliacao_bancaria': None,
+        'dados_associacao': {
+            'pendencia_cadastro': True,
+            'pendencia_contas': False,
+            'pendencia_membros': True
+        }
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['pendencias_cadastrais'] == pendencias_cadastrais_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_todas_as_pendencias_cadastrais(
+    jwt_authenticated_client_a,
+    conta_associacao_incompleta,
+    periodo_2020_1,
+):
+
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    pendencias_cadastrais_esperado = {
+        'dados_associacao': {
+            'pendencia_cadastro': True,
+            'pendencia_membros': True,
+            'pendencia_contas': True,
+        },
+        'conciliacao_bancaria': {
+            'contas_pendentes': [f'{conta_associacao_incompleta.uuid}']
+        },
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['pendencias_cadastrais'] == pendencias_cadastrais_esperado


### PR DESCRIPTION
Esse PR:

- Implementa métodos para validar os cadastros e altera a rota de 'status-periodo' para retornar informação
- Modifica e adiciona testes

História: [AB#89001](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/95819)