### PR TITLE
fix(95108): Corrige __str__ de AnaliseLancamentoPrestacaoConta

### DIFF
--- a/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_lancamento_prestacao_conta.py
@@ -113,7 +113,7 @@ class AnaliseLancamentoPrestacaoConta(ModeloBase):
     houve_considerados_corretos_automaticamente = models.BooleanField("Houve considerados corretos automaticamente?", default=False)
 
     def __str__(self):
-        return f"{self.analise_prestacao_conta} - Resultado:{self.resultado}"
+        return f"#{self.id} - Resultado:{self.resultado}"
 
     @classmethod
     def status_realizacao_choices_to_json(cls):

--- a/sme_ptrf_apps/core/tests/tests_analise_lancamento_prestacao_conta/test_analise_lancamento_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_lancamento_prestacao_conta/test_analise_lancamento_prestacao_conta_model.py
@@ -18,7 +18,7 @@ def test_instance_model(analise_lancamento_receita_prestacao_conta_2020_1):
 
 
 def test_srt_model(analise_lancamento_receita_prestacao_conta_2020_1):
-    assert analise_lancamento_receita_prestacao_conta_2020_1.__str__() == f'2020.1 - 2020-01-01 a 2020-06-30 - Análise #{analise_lancamento_receita_prestacao_conta_2020_1.analise_prestacao_conta.id} - Resultado:CORRETO'
+    assert analise_lancamento_receita_prestacao_conta_2020_1.__str__() == f'#{analise_lancamento_receita_prestacao_conta_2020_1.id} - Resultado:CORRETO'
 
 
 def test_admin():


### PR DESCRIPTION
Esse PR:
- Corrige __str__ de AnaliseLancamentoPrestacaoConta que fazia referência à AnaliseLancamento o que provocava um erro quando ela tinha sido excluída na reabertura da PC.

Corrige AB#95108