### PR TITLE
fix(93404): Altera criação/remoção de acessos de suporte

### DIFF
--- a/sme_ptrf_apps/users/services/criar_acesso_de_suporte_service.py
+++ b/sme_ptrf_apps/users/services/criar_acesso_de_suporte_service.py
@@ -1,6 +1,10 @@
 import logging
 
-from ..models import UnidadeEmSuporte
+from django.contrib.auth import get_user_model
+
+from sme_ptrf_apps.core.models import Unidade
+
+from ..models import UnidadeEmSuporte, User
 
 logger = logging.getLogger(__name__)
 
@@ -9,10 +13,7 @@ class CriaAcessoSuporteException(Exception):
     pass
 
 
-def criar_acesso_de_suporte(unidade_do_suporte, usuario_do_suporte):
-    from sme_ptrf_apps.core.models import Unidade
-    from django.contrib.auth import get_user_model
-
+def criar_acesso_de_suporte(unidade_do_suporte: Unidade, usuario_do_suporte: User):
     logger.info('Criação de acesso de suporte.')
 
     if not unidade_do_suporte or not isinstance(unidade_do_suporte, Unidade):
@@ -36,9 +37,6 @@ def criar_acesso_de_suporte(unidade_do_suporte, usuario_do_suporte):
     else:
         usuario_do_suporte.add_visao_se_nao_existir(visao='UE')
 
-    novo_unidade_em_suporte = UnidadeEmSuporte.objects.create(
-        unidade=unidade_do_suporte,
-        user=usuario_do_suporte,
-    )
-    logger.info(f'Criado novo acesso de suporte usuário {novo_unidade_em_suporte.user.username} unidade {novo_unidade_em_suporte.unidade.codigo_eol}')
+    novo_unidade_em_suporte = UnidadeEmSuporte.criar_acesso_suporte_se_nao_existir(unidade=unidade_do_suporte, user=usuario_do_suporte)
+
     return novo_unidade_em_suporte

--- a/sme_ptrf_apps/users/services/encerrar_acesso_de_suporte_service.py
+++ b/sme_ptrf_apps/users/services/encerrar_acesso_de_suporte_service.py
@@ -33,9 +33,6 @@ def encerrar_acesso_de_suporte(unidade_do_suporte, usuario_do_suporte):
     if unidade_do_suporte.tipo_unidade == 'UE' and not usuario_do_suporte.unidades.exclude(tipo_unidade='DRE').exists():
         usuario_do_suporte.remove_visao_se_existir(visao='UE')
 
-    unidade_em_suporte = UnidadeEmSuporte.objects.filter(unidade=unidade_do_suporte, user=usuario_do_suporte).first()
-    if unidade_em_suporte:
-        unidade_em_suporte.delete()
-        logger.info(f'Apagado acesso de suporte usuário {usuario_do_suporte.username} unidade {unidade_do_suporte.codigo_eol}')
+    UnidadeEmSuporte.remover_acesso_suporte_se_existir(unidade=unidade_do_suporte, user=usuario_do_suporte)
 
     return


### PR DESCRIPTION
- A forma de criação dos acessos de suporte foi alterada para checar se o acesso de suporte já existia.
- Foram incluídos logs das operações
- Foram criados novos métodos de classe para a criação e remoção dos acessos
- O modelo de Unidades em Suporte passa a registrar suas mudanças no AuditLog

Resolve [AB#93404](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93404)