### PR TITLE
feat(95557): Implementa rota status-cadastro

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -460,16 +460,16 @@ def associacao_com_presidente_ausente(unidade, periodo_anterior):
     )
 
 @pytest.fixture
-def associacao_sem_nome(unidade, periodo_anterior):
+def associacao_cadastro_incompleto(unidade, periodo_anterior):
     return baker.make(
         'Associacao',
         nome='',
-        cnpj='52.302.275/0001-83',
+        cnpj='52.302.275/0001-84',
         unidade=unidade,
         periodo_inicial=periodo_anterior,
         ccm='0.000.00-0',
-        email="ollyverottoboni@gmail.com",
-        processo_regularidade='123456',
+        email="associacaosemnome@gmail.com",
+        processo_regularidade='000000',
         status_presidente='AUSENTE',
         cargo_substituto_presidente_ausente=MembroEnum.VICE_PRESIDENTE_DIRETORIA_EXECUTIVA.name
     )
@@ -532,13 +532,20 @@ def conta_associacao_tipo_cheque(associacao, tipo_conta_cheque):
     )
 
 @pytest.fixture
-def conta_associacao_incompleta(associacao_sem_nome, tipo_conta_cartao):
+def conta_associacao_incompleta(associacao_cadastro_incompleto, tipo_conta_cartao):
     return baker.make(
         'ContaAssociacao',
-        associacao=associacao_sem_nome,
+        associacao=associacao_cadastro_incompleto,
         tipo_conta=tipo_conta_cartao,
     )
 
+@pytest.fixture
+def conta_associacao_incompleta_002(associacao, tipo_conta_cartao):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=tipo_conta_cartao,
+    )
 
 @pytest.fixture
 def conta_associacao_cheque(associacao, tipo_conta_cheque):

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -727,3 +727,9 @@ class AssociacoesViewSet(ModelViewSet):
 
         return Response(result)
 
+    @action(detail=True, url_path='status-cadastro',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def status_cadastro(self, request, uuid=None):
+        associacao = self.get_object()
+        response = associacao.pendencias_dados_da_associacao_para_geracao_de_documentos()
+        return Response(response)

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/conftest.py
@@ -1,0 +1,342 @@
+import pytest
+from model_bakery import baker
+from sme_ptrf_apps.core.models.membro_associacao import MembroEnum, RepresentacaoCargo
+
+@pytest.fixture
+def membro_associacao_001(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 001',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.PRESIDENTE_DIRETORIA_EXECUTIVA.name,
+        cargo_educacao='Coordenador',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        email='membroassociacao001@gmail.com',
+        codigo_identificacao='001'
+    )
+
+@pytest.fixture
+def membro_associacao_002(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 002',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VICE_PRESIDENTE_DIRETORIA_EXECUTIVA.name,
+        email='membroassociacao002@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='002'
+    )
+
+@pytest.fixture
+def membro_associacao_003(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 003',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.SECRETARIO.name,
+        email='membroassociacao003@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='003'
+    )
+
+@pytest.fixture
+def membro_associacao_004(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 004',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.TESOUREIRO.name,
+        email='membroassociacao004@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='004'
+    )
+
+@pytest.fixture
+def membro_associacao_005(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 005',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VOGAL_1.name,
+        email='membroassociacao005@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='005'
+    )
+
+@pytest.fixture
+def membro_associacao_006(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 006',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VOGAL_2.name,
+        email='membroassociacao006@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='006'
+    )
+
+@pytest.fixture
+def membro_associacao_007(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 007',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VOGAL_3.name,
+        email='membroassociacao007@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='007'
+    )
+
+@pytest.fixture
+def membro_associacao_008(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 008',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VOGAL_4.name,
+        email='membroassociacao008@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='008'
+    )
+
+@pytest.fixture
+def membro_associacao_009(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 009',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.VOGAL_5.name,
+        email='membroassociacao009@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='009'
+    )
+
+@pytest.fixture
+def membro_associacao_010(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 010',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.PRESIDENTE_CONSELHO_FISCAL.name,
+        email='membroassociacao010@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0010'
+    )
+
+@pytest.fixture
+def membro_associacao_011(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 011',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.CONSELHEIRO_1.name,
+        email='membroassociacao011@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0011'
+    )
+
+@pytest.fixture
+def membro_associacao_012(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 012',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.CONSELHEIRO_2.name,
+        email='membroassociacao012@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0012'
+    )
+
+@pytest.fixture
+def membro_associacao_013(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 013',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.CONSELHEIRO_3.name,
+        email='membroassociacao013@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0013'
+    )
+
+@pytest.fixture
+def membro_associacao_014(associacao):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao 014',
+        associacao=associacao,
+        cargo_associacao=MembroEnum.CONSELHEIRO_4.name,
+        email='membroassociacao014@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0014'
+    )
+
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_001(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 001',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.PRESIDENTE_DIRETORIA_EXECUTIVA.name,
+        cargo_educacao='Coordenador',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        email='membroassociacao001@gmail.com',
+        codigo_identificacao='001'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_002(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 002',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VICE_PRESIDENTE_DIRETORIA_EXECUTIVA.name,
+        email='membroassociacao002@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='002'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_003(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 003',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.SECRETARIO.name,
+        email='membroassociacao003@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='003'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_004(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 004',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.TESOUREIRO.name,
+        email='membroassociacao004@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='004'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_005(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 005',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VOGAL_1.name,
+        email='membroassociacao005@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='005'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_006(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 006',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VOGAL_2.name,
+        email='membroassociacao006@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='006'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_007(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 007',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VOGAL_3.name,
+        email='membroassociacao007@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='007'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_008(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 008',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VOGAL_4.name,
+        email='membroassociacao008@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='008'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_009(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 009',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.VOGAL_5.name,
+        email='membroassociacao009@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='009'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_010(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 010',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.PRESIDENTE_CONSELHO_FISCAL.name,
+        email='membroassociacao010@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0010'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_011(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 011',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.CONSELHEIRO_1.name,
+        email='membroassociacao011@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0011'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_012(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 012',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.CONSELHEIRO_2.name,
+        email='membroassociacao012@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0012'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_013(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 013',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.CONSELHEIRO_3.name,
+        email='membroassociacao013@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0013'
+    )
+
+@pytest.fixture
+def membro_associacao_cadastro_incompleto_014(associacao_cadastro_incompleto):
+    return baker.make(
+        'MembroAssociacao',
+        nome='Membro Associacao Cadastro Incompleto 014',
+        associacao=associacao_cadastro_incompleto,
+        cargo_associacao=MembroEnum.CONSELHEIRO_4.name,
+        email='membroassociacao014@gmail.com',
+        representacao=RepresentacaoCargo.SERVIDOR.name,
+        codigo_identificacao='0014'
+    )

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_cadastro.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_cadastro.py
@@ -1,0 +1,108 @@
+import json
+import pytest
+
+from freezegun import freeze_time
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_cadastro_somente_pendencia_cadastro(
+    jwt_authenticated_client_a,
+    associacao_cadastro_incompleto,
+    membro_associacao_cadastro_incompleto_001,
+    membro_associacao_cadastro_incompleto_002,
+    membro_associacao_cadastro_incompleto_003,
+    membro_associacao_cadastro_incompleto_004,
+    membro_associacao_cadastro_incompleto_005,
+    membro_associacao_cadastro_incompleto_006,
+    membro_associacao_cadastro_incompleto_007,
+    membro_associacao_cadastro_incompleto_008,
+    membro_associacao_cadastro_incompleto_009,
+    membro_associacao_cadastro_incompleto_010,
+    membro_associacao_cadastro_incompleto_011,
+    membro_associacao_cadastro_incompleto_012,
+    membro_associacao_cadastro_incompleto_013,
+    membro_associacao_cadastro_incompleto_014,
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-cadastro/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    status_cadastro_esperado = {
+        'pendencia_cadastro': True,
+        'pendencia_contas': False,
+        'pendencia_membros': False
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == status_cadastro_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_cadastro_somente_pendencia_contas(
+    jwt_authenticated_client_a,
+    membro_associacao_001,
+    membro_associacao_002,
+    membro_associacao_003,
+    membro_associacao_004,
+    membro_associacao_005,
+    membro_associacao_006,
+    membro_associacao_007,
+    membro_associacao_008,
+    membro_associacao_009,
+    membro_associacao_010,
+    membro_associacao_011,
+    membro_associacao_012,
+    membro_associacao_013,
+    membro_associacao_014,
+    conta_associacao_incompleta_002,
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_incompleta_002.associacao.uuid}/status-cadastro/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    status_cadastro_esperado = {
+        'pendencia_cadastro': False,
+        'pendencia_contas': True,
+        'pendencia_membros': False
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == status_cadastro_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_cadastro_somente_pendencia_membros(
+    jwt_authenticated_client_a,
+    associacao,
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-cadastro/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    status_cadastro_esperado = {
+        'pendencia_cadastro': False,
+        'pendencia_contas': False,
+        'pendencia_membros': True
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == status_cadastro_esperado
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_cadastro_todas_as_pendencias(
+    jwt_authenticated_client_a,
+    conta_associacao_incompleta,
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-cadastro/',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    status_cadastro_esperado = {
+        'pendencia_cadastro': True,
+        'pendencia_contas': True,
+        'pendencia_membros': True
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result == status_cadastro_esperado
+

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -282,11 +282,11 @@ def test_status_periodo_pendencias_cadastrais_sem_contas_pendentes(
 @freeze_time('2020-07-10 10:20:00')
 def test_status_periodo_pendencias_cadastrais_somente_dados_associacao_com_pendencia_cadastro_e_pendencia_membros(
     jwt_authenticated_client_a,
-    associacao_sem_nome,
+    associacao_cadastro_incompleto,
     periodo_2020_1,
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_sem_nome.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
                           content_type='application/json')
     result = json.loads(response.content)
 


### PR DESCRIPTION
Esse PR:

- Implementa rota para retorno de status do cadastro(dados da associação, membros e contas)
- Implementa testes

História: [AB#95557](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/95557)