### PR TITLE
feat(95845): Adiciona membros ausentes pdf ata de pcs

### DIFF
--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -384,7 +384,10 @@
 
 
   {% comment %} Comentários {% endcomment %}
-  <p class="mt-4 texto-justificado">{{ dados.dados_texto_da_ata.comentarios }}</p>
+  {% if dados.dados_texto_da_ata.comentarios %}
+    <p class="font-12 mt-5 titulo-membros-conselho-fiscal">Manifestações, comentários e justificativas</p>
+    <p class="mt-4 texto-justificado">{{ dados.dados_texto_da_ata.comentarios }}</p>
+  {% endif %}
 
   {% if not dados.dados_texto_da_ata.comentarios %}
     <p class="mt-4 texto-justificado">Esgotados os assuntos o(a) senhor(a) presidente ofereceu a palavra a quem dela
@@ -405,7 +408,7 @@
       de {{ dados.dados_da_ata.data_reuniao|date:"F"|lower }} de {{ dados.dados_da_ata.data_reuniao|date:"Y" }}</p>
   {% endlanguage %}
 
-  <p class="font-12 mt-5 titulo-membros-conselho-fiscal">Presentes</p>
+  <p class="font-12 mt-5 titulo-membros-conselho-fiscal">Membros da Diretoria Executiva e do Conselho Fiscal</p>
   <table class="table table-bordered tabela-assinaturas">
     <thead>
     <tr>
@@ -420,7 +423,11 @@
           <p class='mb-0'><strong>{{ info.nome }}</strong></p>
           <p class='mb-0'>{{ info.cargo }}</p>
         </td>
-        <td></td>
+        {% if info.presente %}
+          <td></td>
+        {% else %}
+          <td>Ausente</td>
+        {% endif %}
       </tr>
       </tbody>
     {% endfor %}


### PR DESCRIPTION
Esse PR:

- Modifia layout do pdf da ata de pcs para adicionar as informações de membros ausentes.

História: [AB#95845](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/95845)