### PR TITLE
feat(95653): Adiciona indicativo de membros conselho fiscal ausentes

### DIFF
--- a/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
+++ b/sme_ptrf_apps/core/api/views/presentes_ata_viewset.py
@@ -56,8 +56,28 @@ class PresentesAtaViewSet(mixins.CreateModelMixin,
         presentes_ata_nao_membros = Participante.objects.filter(ata=ata).filter(membro=False).order_by('nome').values()
 
         associacao = ata.associacao
-        # presentes_ata_conselho_fiscal = Participante.objects.filter(ata=ata).filter(membro=True).filter(conselho_fiscal=True).values()
-        presentes_ata_conselho_fiscal = retorna_membros_do_conselho_fiscal_por_associacao(associacao)
+
+        if not presentes_ata_membros:
+            membros_associacao = ata.associacao.membros_por_cargo()
+            presentes_ata_membros = []
+            for membro in membros_associacao:
+
+                dado = {
+                    "ata": ata_uuid,
+                    "cargo": remove_digitos(MembroEnum[membro.cargo_associacao].value),
+                    "identificacao": membro.codigo_identificacao if membro.codigo_identificacao != "" else membro.cpf,
+                    "nome": membro.nome,
+                    "editavel": False,
+                    "membro": True,
+                    "presente": True
+                }
+
+                presentes_ata_membros.append(dado)
+                
+            presentes_ata_conselho_fiscal = retorna_membros_do_conselho_fiscal_por_associacao(associacao)
+        else:
+           presentes_ata_conselho_fiscal = Participante.objects.filter(ata=ata).filter(membro=True, conselho_fiscal=True).values()
+        
 
         result = {
             'presentes_membros': presentes_ata_membros,

--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -475,16 +475,22 @@
         <th scope="col">Assinatura</th>
       </tr>
       </thead>
-      {% for info in dados.presentes_na_ata.presentes_ata_conselho_fiscal %}
+      {% for info in dados.presentes_na_ata.presentes_ata_membros %}
+        {% if info.conselho_fiscal %}
         <tbody>
-        <tr>
-          <td>
-            <p class='mb-0'><strong>{{ info.nome }}</strong></p>
-            <p class='mb-0'>{{ info.cargo }}</p>
-          </td>
-          <td></td>
-        </tr>
+          <tr>
+            <td>
+              <p class='mb-0'><strong>{{ info.nome }}</strong></p>
+              <p class='mb-0'>{{ info.cargo }}</p>
+            </td>
+            {% if info.presente %}
+              <td></td>
+            {% else %}
+              <td>Ausente</td>
+            {% endif %}
+          </tr>
         </tbody>
+        {% endif %}
       {% endfor %}
     </table>
 


### PR DESCRIPTION
Esse PR:

- Modifica o viewset de participantes na ata para apresentar os presentes em atas legados.
- Adiciona no PDF da ata o indicativo de ausência no conselho fiscal.

História: [AB#95653](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/95653)