### PR TITLE
fix(91168): SME - Relatório Consolidado das DREs - Notificação só é enviada para um técnico DRE

### DIFF
--- a/sme_ptrf_apps/dre/services/notificacao_service/class_notificacao_comentario_de_analise_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/services/notificacao_service/class_notificacao_comentario_de_analise_consolidado_dre.py
@@ -49,7 +49,7 @@ class NotificacaoComentarioDeAnaliseConsolidadoDre(NotificacaoService):
                         comentario.set_comentario_notificado()
 
                     logger.info("Notificações criadas com sucesso.")
-                    return True
+                return True
             else:
                 logger.info("Não existem usuários a serem notificados.")
                 return False


### PR DESCRIPTION
Esse PR:

-  Resolve notificação enviada apenas para um técnico em Relatório Consolidado das DREs

História: [AB#91168](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91168)