### PR TITLE
Feature/96046 Update python para 3.10.*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster
+FROM python:3.10-buster
 ENV PYTHONUNBUFFERED 1
 ADD . /code
 WORKDIR /code

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,6 +7,9 @@ psycopg2-binary==2.9.5
 # ------------------------------------------------------------------------------
 mypy==1.3.0  # https://github.com/python/mypy
 django-stubs==4.2.1  # https://github.com/typeddjango/django-stubs
+pytest==7.3.2  # https://github.com/pytest-dev/pytest
+pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
+pytest-sugar==0.9.7  # https://github.com/Frozenball/pytest-sugar
 
 # Dependencias não revisadas
 
@@ -16,8 +19,6 @@ Sphinx==2.4.3  # https://github.com/sphinx-doc/sphinx
 
 # Testing
 # ------------------------------------------------------------------------------
-pytest==5.3.5  # https://github.com/pytest-dev/pytest
-pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 model-bakery==1.1.0 # https://model-bakery.readthedocs.io/en/latest/index.html
 freezegun==0.3.12 # https://github.com/spulec/freezegun
 
@@ -37,4 +38,4 @@ factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
 django-debug-toolbar==2.2  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==2.2.8  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==1.8.0  # https://github.com/nedbat/django_coverage_plugin
-pytest-django==3.8.0  # https://github.com/pytest-dev/pytest-django
+

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,7 +3,10 @@
 # Dependencias revisadas
 psycopg2-binary==2.9.5
 
-
+# Testing
+# ------------------------------------------------------------------------------
+mypy==1.3.0  # https://github.com/python/mypy
+django-stubs==4.2.1  # https://github.com/typeddjango/django-stubs
 
 # Dependencias não revisadas
 
@@ -13,8 +16,6 @@ Sphinx==2.4.3  # https://github.com/sphinx-doc/sphinx
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.761  # https://github.com/python/mypy
-django-stubs==1.4.0  # https://github.com/typeddjango/django-stubs
 pytest==5.3.5  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 model-bakery==1.1.0 # https://model-bakery.readthedocs.io/en/latest/index.html


### PR DESCRIPTION
Esse PR:
- Atualiza Dockerfile para usar a versão 3.10
- Atualiza dependências impactadas: mypy, django-stubs, pytest, pytest-django e pytest-sugar


AB#96048