### PR TITLE
feat(91327): Altera devolução PC para apagar fechamentos

### DIFF
--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -322,11 +322,11 @@ class AnalisePrestacaoConta(ModeloBase):
                     analises_de_documentos_requerem_alteracoes = True
                     break
 
-        """ logger.info(f'Prestação de conta: {self.prestacao_conta.id}')
-        logger.info(f'Análise de Prestação de conta: {self.id}')K
-        logger.info(f'analises_de_lancamentos_requerem_alteracoes: {analises_de_lancamentos_requerem_alteracoes}')
-        logger.info(f'analises_de_documentos_requerem_alteracoes: {analises_de_documentos_requerem_alteracoes}')
-        logger.info(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}') """
+        logger.debug(f'Prestação de conta: {self.prestacao_conta.id}')
+        logger.debug(f'Análise de Prestação de conta: {self.id}')
+        logger.debug(f'analises_de_lancamentos_requerem_alteracoes: {analises_de_lancamentos_requerem_alteracoes}')
+        logger.debug(f'analises_de_documentos_requerem_alteracoes: {analises_de_documentos_requerem_alteracoes}')
+        logger.debug(f'É necessário recalcular fechamentos e documentos? {analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes}')
         return analises_de_lancamentos_requerem_alteracoes or analises_de_documentos_requerem_alteracoes
 
     @classmethod

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -303,6 +303,7 @@ class PrestacaoConta(ModeloBase):
         return self
 
     def apaga_fechamentos(self):
+        logging.info('Apagando fechamentos da prestação de contas')
         for fechamento in self.fechamentos_da_prestacao.all():
             fechamento.delete()
 
@@ -529,6 +530,9 @@ class PrestacaoConta(ModeloBase):
         self.analise_atual = None
         self.justificativa_pendencia_realizacao = ""
         self.save()
+
+        logging.info('A devolução de PC apaga os seus fechamentos.')
+        self.apaga_fechamentos()
 
         notificar_prestacao_de_contas_devolvida_para_acertos(self, data_limite_ue)
         return self

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -523,7 +523,10 @@ class PrestacaoConta(ModeloBase):
             data_limite_ue=data_limite_ue
         )
 
+        devolucao_requer_alteracoes = False
+
         if self.analise_atual:
+            devolucao_requer_alteracoes = self.analise_atual.verifica_se_requer_alteracao_em_lancamentos(considera_realizacao=False)
             self.analise_atual.devolucao_prestacao_conta = devolucao
             self.analise_atual.save()
 
@@ -531,8 +534,9 @@ class PrestacaoConta(ModeloBase):
         self.justificativa_pendencia_realizacao = ""
         self.save()
 
-        logging.info('A devolução de PC apaga os seus fechamentos.')
-        self.apaga_fechamentos()
+        if devolucao_requer_alteracoes:
+            logging.info('A devolução de PC requer alterações e por isso deve apagar os seus fechamentos.')
+            self.apaga_fechamentos()
 
         notificar_prestacao_de_contas_devolvida_para_acertos(self, data_limite_ue)
         return self


### PR DESCRIPTION
Esse PR:

- Altera a devolução de PC para apagar os fechamentos caso a devolução demande alterações em lançamentos.

História: AB#91327