### PR TITLE
feat(96965): Adiciona marca d'água na prévia de devoluções para acertos

### DIFF
--- a/sme_ptrf_apps/dre/services/dados_relatorio_devolucao_acertos_sme_service.py
+++ b/sme_ptrf_apps/dre/services/dados_relatorio_devolucao_acertos_sme_service.py
@@ -135,7 +135,8 @@ class DadosRelatorioDevolucaoAcertosSme:
             'dados_comentarios': self.dados_comentarios,
             'dados_responsavel_analise': self.dados_responsavel_analise,
             'blocos': self.blocos,
-            'info_rodape': self.info_rodape
+            'info_rodape': self.info_rodape,
+            'previa': self.previa
         }
 
 

--- a/sme_ptrf_apps/static/css/pdf-relatorio-devolucao-acertos-sme.css
+++ b/sme_ptrf_apps/static/css/pdf-relatorio-devolucao-acertos-sme.css
@@ -252,3 +252,25 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
   word-wrap: break-word !important;
   word-break: break-all !important;
 }
+
+.container-watermark {
+  position: relative;
+  height: 100vh;
+}
+
+.watermark1 {
+  position: fixed;
+  top: 25%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.5;
+  z-index: 99;
+}
+.watermark2 {
+  position: fixed;
+  top: 75%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.5;
+  z-index: 99;
+}

--- a/sme_ptrf_apps/templates/pdf/relatorio_devolucao_acertos_sme/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_devolucao_acertos_sme/pdf.html
@@ -12,6 +12,12 @@
   <title>Relatório de acertos</title>
 </head>
 <body>
+  {% if dados.previa == True %}
+  <div class="container-watermark">
+      <img class="watermark1" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
+      <img class="watermark2" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
+  </div>
+  {% endif %}
   {# ************************* Cabecalho das páginas *************************  #}
 
 


### PR DESCRIPTION
Esse PR:

- Adiciona marca d'água na prévia de devoluções para acertos

História: [AB#96965](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/96965)