### PR TITLE
feat(96758): Adiciona marca dagua na prévia de relação bens

### DIFF
--- a/sme_ptrf_apps/core/services/relacao_bens_dados_service.py
+++ b/sme_ptrf_apps/core/services/relacao_bens_dados_service.py
@@ -26,7 +26,8 @@ def gerar_dados_relacao_de_bens(usuario, conta_associacao=None, periodo=None, pr
             "identificacao_apm": identificacao_apm,
             "data_geracao": data_geracao,
             "relacao_de_bens_adquiridos_ou_produzidos": relacao_de_bens_adquiridos_ou_produzidos,
-            "data_geracao_documento": data_geracao_documento
+            "data_geracao_documento": data_geracao_documento,
+            "previa": previa
         }
     finally:
         LOGGER.info("DADOS RELAÇÃO DE BENS GERADO")

--- a/sme_ptrf_apps/static/css/relacao-de-bens-pdf.css
+++ b/sme_ptrf_apps/static/css/relacao-de-bens-pdf.css
@@ -167,3 +167,25 @@ html body .conteudo .tabela-relacao-de-bens tbody td {
 .data-geracao{
   letter-spacing: 1px;
 }
+
+.container-watermark {
+  position: relative;
+  height: 100vh;
+}
+
+.watermark1 {
+  position: fixed;
+  top: 25%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.5;
+  z-index: 99;
+}
+.watermark2 {
+  position: fixed;
+  top: 75%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.5;
+  z-index: 99;
+}

--- a/sme_ptrf_apps/templates/pdf/relacao_de_bens/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relacao_de_bens/pdf.html
@@ -14,6 +14,12 @@
   <title>Relação de Bens PTRF</title>
 </head>
 <body>
+{% if dados.previa %}
+<div class="container-watermark">
+    <img class="watermark1" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
+    <img class="watermark2" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
+</div>
+{% endif %}
 
 {# ************************* Cabecalho das páginas *************************  #}
 <header>
@@ -117,29 +123,31 @@
     </table>
   </article>
 
-  <article id="bloco-3" class="mt-3">
-    <p class="font-14 border-bottom pb-1"><strong>Bloco 3 - Autenticação</strong>
-    </p>
-    <div class="col-12 border mt-3">
-      <p class="pt-2 mb-1">Declaro, sob as penas de Lei, que os bens acima relacionados, adquiridos ou produzidos com
-        recursos do PTRF foram doados à Prefeitura do Município de São Paulo/ Secretaria Municipal de Educação, para
-        serem incorporados ao patrimônio público e destinados à
-        (ao) {{ dados.identificacao_apm.tipo_unidade }} {{ dados.identificacao_apm.nome_unidade }}, responsável por sua
-        guarda e conservação.</p>
-      <p class="mt-0">Data: <strong class="data-geracao">{{ dados.data_geracao }}</strong></p>
-    </div>
-    <div class="col-12 border-right border-left border-bottom pt-5 pb-1">
-      <div class="row">
-        <div class="col">
-          <p class="mb-0 text-center">
-            __________________________________________________________________________________</p>
-          <p class="font-12 text-center mb-0">Assinatura
-            do {{ dados.identificacao_apm.cargo_substituto_presidente_ausente }} da Associação</p>
-          <p class="text-center pb-2"><strong>{{ dados.identificacao_apm.presidente_diretoria_executiva }}</strong></p>
+  {% if not dados.previa %}
+    <article id="bloco-3" class="mt-3">
+      <p class="font-14 border-bottom pb-1"><strong>Bloco 3 - Autenticação</strong>
+      </p>
+      <div class="col-12 border mt-3">
+        <p class="pt-2 mb-1">Declaro, sob as penas de Lei, que os bens acima relacionados, adquiridos ou produzidos com
+          recursos do PTRF foram doados à Prefeitura do Município de São Paulo/ Secretaria Municipal de Educação, para
+          serem incorporados ao patrimônio público e destinados à
+          (ao) {{ dados.identificacao_apm.tipo_unidade }} {{ dados.identificacao_apm.nome_unidade }}, responsável por sua
+          guarda e conservação.</p>
+        <p class="mt-0">Data: <strong class="data-geracao">{{ dados.data_geracao }}</strong></p>
+      </div>
+      <div class="col-12 border-right border-left border-bottom pt-5 pb-1">
+        <div class="row">
+          <div class="col">
+            <p class="mb-0 text-center">
+              __________________________________________________________________________________</p>
+            <p class="font-12 text-center mb-0">Assinatura
+              do {{ dados.identificacao_apm.cargo_substituto_presidente_ausente }} da Associação</p>
+            <p class="text-center pb-2"><strong>{{ dados.identificacao_apm.presidente_diretoria_executiva }}</strong></p>
+          </div>
         </div>
       </div>
-    </div>
-  </article>
+    </article>
+  {% endif %}
 
 </section>
 


### PR DESCRIPTION
Esse PR:

- Adiciona a marca d'agua na prévia de relação de bens.
- Remove bloco de autenticação quando é uma prévia.

História: [AB#96758](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/96758)