### PR TITLE
Hotfix/8.3.1

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "8.3.0"
+__version__ = "8.3.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -291,7 +291,7 @@ class Associacao(ModeloIdNome):
         return True
 
     def pendencias_dados_da_associacao_para_geracao_de_documentos(self):
-        pendencia_cadastro = not self.nome or not self.ccm or not self.unidade.email
+        pendencia_cadastro = not self.nome or not self.ccm
         pendencia_membros = not self.membros_diretoria_executiva_e_conselho_fiscal_cadastrados
         pendencia_contas =  self.contas.filter(Q(banco_nome__exact='') | Q(agencia__exact='') | Q(numero_conta__exact='',
                                                status=ContaAssociacao.STATUS_ATIVA)).exists()


### PR DESCRIPTION
### 8.3.1 - 28/06/2023 - sprint 68
* (97983) - Remove obrigatoriedade do email de unidade para geração de PC.


Atente [AB#97983](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/97983)