### PR TITLE
test(97748): Corrige teste que estava quebrando o deploy

### DIFF
--- a/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_devolver_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_devolver_consolidado_dre.py
@@ -12,7 +12,7 @@ def test_devolver_consolidado(
     consolidado_dre_teste_api_consolidado_dre,
 ):
     payload = {
-        'data_limite': '2023-07-01',
+        'data_limite': '2123-07-01',
     }
 
     with patch('sme_ptrf_apps.dre.models.consolidado_dre.ConsolidadoDRE.devolver_consolidado') as mock_devolver_consolidado:


### PR DESCRIPTION
Esse PR:

- Corrige um teste que estava quebrando o build 8.4.0

O teste usava uma data fixa que passou a quebrar o teste em 01/07/2023. Foi feita a correção mais simples, jogar a data de teste para um futuro que não será atingido.

[AB#97748](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/97748)