### PR TITLE
feat(97899): Acompanhamento de PC: Incluir acerto para o Comprovante do Saldo da Conta

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -554,6 +554,8 @@ class AnaliseContaPrestacaoContaAdmin(admin.ModelAdmin):
     search_fields = ('prestacao_conta__associacao__unidade__codigo_eol', 'prestacao_conta__associacao__unidade__nome',
                      'prestacao_conta__associacao__nome')
 
+    raw_id_fields = ['prestacao_conta', 'analise_prestacao_conta', 'conta_associacao']
+
     actions = ['vincula_analise_prestacao_contas', ]
 
     def vincula_analise_prestacao_contas(self, request, queryset):

--- a/sme_ptrf_apps/core/api/views/analise_conta_prestacao_conta_viewset.py
+++ b/sme_ptrf_apps/core/api/views/analise_conta_prestacao_conta_viewset.py
@@ -85,8 +85,8 @@ class AnaliseContaPrestacaoContaViewSet(viewsets.ModelViewSet):
         prestacao_conta_uuid = dados_analise_saldo['prestacao_conta']
         data_extrato = dados_analise_saldo['data_extrato']
         saldo_extrato = dados_analise_saldo['saldo_extrato']
-        solicitar_envio_do_comprovante_do_saldo_da_conta = dados_analise_saldo['solicitar_envio_do_comprovante_do_saldo_da_conta']
-        observacao_solicitar_envio_do_comprovante_do_saldo_da_conta = dados_analise_saldo['observacao_solicitar_envio_do_comprovante_do_saldo_da_conta']
+        solicitar_envio_do_comprovante_do_saldo_da_conta = dados_analise_saldo.get('solicitar_envio_do_comprovante_do_saldo_da_conta', False)
+        observacao_solicitar_envio_do_comprovante_do_saldo_da_conta = dados_analise_saldo.get('observacao_solicitar_envio_do_comprovante_do_saldo_da_conta', None)
 
         try:
             analise_prestacao_conta = AnalisePrestacaoConta.by_uuid(analise_prestacao_conta_uuid)


### PR DESCRIPTION
Esse PR:

- Ajusta recebimento paramentros AnaliseContaPC e implementa raw_id_fields em admin de AnaliseContaPC

História: [AB#97899](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/97899)