### PR TITLE
feat(98127): Análise DRE: Relatório de apresentação após acertos: Exibir no bloco 2 informações sobre solicitação do comprovante de saldo da conta (Prévia e Final)

### DIFF
--- a/sme_ptrf_apps/core/services/dados_relatorio_apos_acertos_service.py
+++ b/sme_ptrf_apps/core/services/dados_relatorio_apos_acertos_service.py
@@ -57,6 +57,8 @@ class DadosRelatorioAposAcertos:
                     'nome_conta': analise_conta.conta_associacao.tipo_conta.nome,
                     'data_extrato': analise_conta.data_extrato,
                     'saldo_extrato': analise_conta.saldo_extrato,
+                    'solicitar_envio_do_comprovante_do_saldo_da_conta': analise_conta.solicitar_envio_do_comprovante_do_saldo_da_conta,
+                    'observacao_solicitar_envio_do_comprovante_do_saldo_da_conta': analise_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta,
                 }
                 dados_extratos.append(dados)
 

--- a/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-extratos-bancarios.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_apos_acertos/partials/tabela-acertos-em-extratos-bancarios.html
@@ -3,47 +3,61 @@
 {% load formata_string %}
 
 {% if dados.dados_extratos_bancarios %}
-    <article class="mt-4">
-        {% for ajuste_conta in dados.dados_extratos_bancarios %}
-            <table class="table table-bordered tabela-resumo-por-acao ">
-              <thead class="">
-                <tr class="">
-                  <th colSpan="1">
-                    <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_extratos_bancarios }}</strong>
-                  </th>
-                </tr>
+  <article class="mt-4">
+    {% for ajuste_conta in dados.dados_extratos_bancarios %}
+      <table class="table table-bordered tabela-resumo-por-acao ">
+        <thead class="">
+        <tr class="">
+          <th colSpan="1">
+            <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_extratos_bancarios }}</strong>
+          </th>
+        </tr>
 
-                <tr>
-                  <th colSpan="1">
-                    <strong class="font-12 titulo-bloco">Conta {{ ajuste_conta.nome_conta }}</strong>
-                  </th>
-                </tr>
-              </thead>
+        <tr>
+          <th colSpan="1">
+            <strong class="font-12 titulo-bloco">Conta {{ ajuste_conta.nome_conta }}</strong>
+          </th>
+        </tr>
+        </thead>
 
-              <tbody>
-                <tr>
-                    <td>
-                      <div class="row mt-2 mb-2">
-                        {% if ajuste_conta.data_extrato %}
-                          <div class="col-4">
-                              <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste da data do extrato</span></strong>
-                              <br>
-                              <span class="font-12 ml-4">{{ ajuste_conta.data_extrato|date:'d/m/Y' }}</span>
-                          </div>
-                        {% endif %}
+        <tbody>
+        <tr>
+          <td>
+            <div class="row mt-2 mb-2">
+              {% if ajuste_conta.data_extrato %}
+                <div class="col-4">
+                  <strong class="font-12 ml-4"><span
+                    class="text-saldo-reprogramado">Ajuste da data do extrato</span></strong>
+                  <br>
+                  <span class="font-12 ml-4">{{ ajuste_conta.data_extrato|date:'d/m/Y' }}</span>
+                </div>
+              {% endif %}
 
-                        {% if ajuste_conta.saldo_extrato is not None %}
-                          <div class="col-4">
-                              <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste no saldo do extrato</span></strong>
-                              <br>
-                              <span class="font-12 ml-4">R$ {{ ajuste_conta.saldo_extrato|formata_valor }}</span>
-                          </div>
-                        {% endif %}
-                      </div>
-                    </td>
-                  </tr>
-              </tbody>
-            </table>
-        {% endfor %}
-    </article>
+              {% if ajuste_conta.saldo_extrato is not None %}
+                <div class="col-4">
+                  <strong class="font-12 ml-4"><span
+                    class="text-saldo-reprogramado">Ajuste no saldo do extrato</span></strong>
+                  <br>
+                  <span class="font-12 ml-4">R$ {{ ajuste_conta.saldo_extrato|formata_valor }}</span>
+                </div>
+              {% endif %}
+            </div>
+            {% if ajuste_conta.solicitar_envio_do_comprovante_do_saldo_da_conta %}
+            <div class="row">
+              <div class="col-12 ml-4">
+                <p class="mb-1 text-saldo-reprogramado font-12"><strong>Enviar arquivo de Comprovante do saldo da conta</strong></p>
+              </div>
+              {% if ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta and ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta != "" %}
+                <div class="col-12 ml-4">
+                  <p class="font-12">{{ ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta }}</p>
+                </div>
+              {% endif %}
+            </div>
+          {% endif %}
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    {% endfor %}
+  </article>
 {% endif %}


### PR DESCRIPTION
Esse PR:

- Inclui exibição de info comprovante saldo em relatório após acertos

História: [AB#98127](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/98127)