### PR TITLE
feat(98124): Acompanhamento de PC: Relatório de devoluções para acertos: Exibir no bloco 2 informações sobre solicitação do comprovante de saldo da conta (Prévia e Final)

### DIFF
--- a/sme_ptrf_apps/core/services/dados_relatorio_acertos_service.py
+++ b/sme_ptrf_apps/core/services/dados_relatorio_acertos_service.py
@@ -33,6 +33,8 @@ def gerar_dados_relatorio_acertos(analise_prestacao_conta, previa, usuario=""):
                 'nome_conta': analise_conta.conta_associacao.tipo_conta.nome,
                 'data_extrato': analise_conta.data_extrato,
                 'saldo_extrato': analise_conta.saldo_extrato,
+                'solicitar_envio_do_comprovante_do_saldo_da_conta': analise_conta.solicitar_envio_do_comprovante_do_saldo_da_conta,
+                'observacao_solicitar_envio_do_comprovante_do_saldo_da_conta': analise_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta,
             }
             logger.info(f'Ajuste em conta:{dados["nome_conta"]} data:{dados["data_extrato"]} saldo:{dados["saldo_extrato"]}')
             dados_ajustes_contas.append(dados)

--- a/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_dos_acertos/pdf.html
@@ -14,10 +14,12 @@
 <body>
 
 {% if dados.previa %}
-<div class="container-watermark">
-    <img class="watermark1" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
-    <img class="watermark2" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg" alt="Marca da água visão prévia">
-</div>
+  <div class="container-watermark">
+    <img class="watermark1" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg"
+         alt="Marca da água visão prévia">
+    <img class="watermark2" src="{{ base_static_url }}/images/watermark-visualizacao-previa.svg"
+         alt="Marca da água visão prévia">
+  </div>
 {% endif %}
 {# ************************* Cabecalho das páginas *************************  #}
 
@@ -31,7 +33,9 @@
       <div class="row">
         <div class="col-auto borda-box-cabecalho-right ml-5 ml-auto">
           <p class="font-10 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-10 mb-0 pb-0">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
+          <p class="subtitulo font-10 mb-0 pb-0">{{ dados.info_cabecalho.periodo_referencia }}
+            - {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }}
+            até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
         </div>
       </div>
     </div>
@@ -65,7 +69,9 @@
       <div class="row">
         <div class="col-auto borda-box-cabecalho-right ml-5 ml-auto">
           <p class="font-12 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-12">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
+          <p class="subtitulo font-12">{{ dados.info_cabecalho.periodo_referencia }}
+            - {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }}
+            até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
         </div>
       </div>
     </div>
@@ -82,41 +88,57 @@
       {% for ajuste_conta in dados.dados_ajustes_contas %}
         <table class="table table-bordered tabela-resumo-por-acao ">
           <thead class="">
-            <tr class="">
-              <th colSpan="1">
-                <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_contas }}</strong>
-              </th>
-            </tr>
+          <tr class="">
+            <th colSpan="1">
+              <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.acertos_contas }}</strong>
+            </th>
+          </tr>
 
-            <tr>
-              <th colSpan="1">
-                <strong class="font-12 titulo-bloco">Conta {{ ajuste_conta.nome_conta }}</strong>
-              </th>
-            </tr>
+          <tr>
+            <th colSpan="1">
+              <strong class="font-12 titulo-bloco">Conta {{ ajuste_conta.nome_conta }}</strong>
+            </th>
+          </tr>
           </thead>
 
           <tbody>
-            <tr>
-                <td>
-                  <div class="row mt-2 mb-2">
-                    {% if ajuste_conta.data_extrato %}
-                      <div class="col-4">
-                          <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste da data do extrato</span></strong>
-                          <br>
-                          <span class="font-12 ml-4">{{ ajuste_conta.data_extrato|date:'d/m/Y' }}</span>
-                      </div>
-                    {% endif %}
-
-                    {% if ajuste_conta.saldo_extrato is not None %}
-                      <div class="col-4">
-                          <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste no saldo do extrato</span></strong>
-                          <br>
-                          <span class="font-12 ml-4">R$ {{ ajuste_conta.saldo_extrato|formata_valor }}</span>
-                      </div>
-                    {% endif %}
+          <tr>
+            <td>
+              <div class="row mt-2 mb-2">
+                {% if ajuste_conta.data_extrato %}
+                  <div class="col-4">
+                    <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste da data do extrato</span></strong>
+                    <br>
+                    <span class="font-12 ml-4">{{ ajuste_conta.data_extrato|date:'d/m/Y' }}</span>
                   </div>
-                </td>
-              </tr>
+                {% endif %}
+
+                {% if ajuste_conta.saldo_extrato is not None %}
+                  <div class="col-4">
+                    <strong class="font-12 ml-4"><span class="text-saldo-reprogramado">Ajuste no saldo do extrato</span></strong>
+                    <br>
+                    <span class="font-12 ml-4">R$ {{ ajuste_conta.saldo_extrato|formata_valor }}</span>
+                  </div>
+                {% endif %}
+              </div>
+
+
+              {% if ajuste_conta.solicitar_envio_do_comprovante_do_saldo_da_conta %}
+                <div class="row">
+                  <div class="col-12 ml-4">
+                    <p class="mb-1 font-12 text-saldo-reprogramado"><strong>Enviar arquivo de Comprovante do saldo da conta</strong></p>
+                  </div>
+                  {% if ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta and ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta != "" %}
+                    <div class="col-12 ml-4">
+                      <p class="font-12">{{ ajuste_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta }}</p>
+                    </div>
+                  {% endif %}
+                </div>
+              {% endif %}
+
+
+            </td>
+          </tr>
           </tbody>
         </table>
       {% endfor %}
@@ -134,23 +156,23 @@
     <article class="mt-4">
       <table class="table table-bordered tabela-resumo-por-acao">
         <thead class="">
-          <tr class="">
-            <th colSpan="1">
-              <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.responsavel_analise }}</strong>
-            </th>
-          </tr>
+        <tr class="">
+          <th colSpan="1">
+            <strong class="font-16 titulo-bloco ml-2">{{ dados.blocos.responsavel_analise }}</strong>
+          </th>
+        </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>
-              <div class="row pb-4">
-                <div class="col-6">
-                  <p class="pt-2 mb-0 ml-2 pb-0 mt-4 border-bottom font-12">{{ dados.dados_tecnico.responsavel }}</p>
-                  <span class="mt-2 ml-2 mb-2 font-12"><strong>Nome do responsável</strong></span>
-                </div>
+        <tr>
+          <td>
+            <div class="row pb-4">
+              <div class="col-6">
+                <p class="pt-2 mb-0 ml-2 pb-0 mt-4 border-bottom font-12">{{ dados.dados_tecnico.responsavel }}</p>
+                <span class="mt-2 ml-2 mb-2 font-12"><strong>Nome do responsável</strong></span>
               </div>
-            </td>
-          </tr>
+            </div>
+          </td>
+        </tr>
         </tbody>
       </table>
     </article>


### PR DESCRIPTION
Esse PR:

- Inclui info comprovante saldo em relatório devoluções para acerto

História: [AB#98124](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/98124)