### PR TITLE
feat(95910): Remove solicitações antigas da extração de devolução

### DIFF
--- a/sme_ptrf_apps/sme/tasks.py
+++ b/sme_ptrf_apps/sme/tasks.py
@@ -228,7 +228,7 @@ def exportar_status_prestacoes_contas_async(data_inicio, data_final, username):
 def exportar_devolucoes_ao_tesouro_async(data_inicio, data_final, username):
     logger.info("Exportando csv em processamento...")
 
-    queryset = SolicitacaoDevolucaoAoTesouro.objects.all().order_by('criado_em')
+    queryset = SolicitacaoDevolucaoAoTesouro.objects.order_by('solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__periodo_id', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta_id', 'solicitacao_acerto_lancamento__analise_lancamento__despesa_id', '-criado_em').distinct('solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta__periodo_id', 'solicitacao_acerto_lancamento__analise_lancamento__analise_prestacao_conta__prestacao_conta_id', 'solicitacao_acerto_lancamento__analise_lancamento__despesa_id')
 
     try:
         logger.info("Criando arquivo %s pcs_devolucoes_tesouro.csv")


### PR DESCRIPTION
Esse PR:

- Adiciona um filtro para remover as solicitações da mesma despesa que se repetem nas devoluções subsequentes da prestação de conta.

História: [AB#95910](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/95910)