### PR TITLE
feat(99318): Histórico de contas encerradas

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -11,6 +11,7 @@ from .core.choices import MembroEnum, RepresentacaoCargo, StatusTag
 from .core.models import (
     AcaoAssociacao,
     ContaAssociacao,
+    SolicitacaoEncerramentoContaAssociacao,
     STATUS_FECHADO, STATUS_ABERTO, STATUS_IMPLANTACAO,
     TipoAcertoDocumento
 )
@@ -574,6 +575,14 @@ def conta_associacao_inativa(associacao, tipo_conta):
         status=ContaAssociacao.STATUS_INATIVA
     )
 
+@pytest.fixture
+def solicitacao_encerramento_conta_associacao(conta_associacao_inativa):
+    return baker.make(
+        'SolicitacaoEncerramentoContaAssociacao',
+        conta_associacao=conta_associacao_inativa,
+        data_de_encerramento_na_agencia='2019-09-02',
+        status=SolicitacaoEncerramentoContaAssociacao.STATUS_APROVADA
+    )
 
 @pytest.fixture
 def acao_associacao(associacao, acao):

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -312,7 +312,15 @@ class AssociacoesViewSet(ModelViewSet):
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def contas(self, request, uuid=None):
         associacao = self.get_object()
-        contas = ContaAssociacao.objects.filter(associacao=associacao).all()
+        contas = ContaAssociacao.ativas.filter(associacao=associacao).all()
+        contas_data = ContaAssociacaoDadosSerializer(contas, many=True).data
+        return Response(contas_data)
+
+    @action(detail=True, url_path='contas/encerradas', methods=['get'],
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def contas_encerradas(self, request, uuid=None):
+        associacao = self.get_object()
+        contas = ContaAssociacao.encerradas.filter(associacao=associacao).all()
         contas_data = ContaAssociacaoDadosSerializer(contas, many=True).data
         return Response(contas_data)
 

--- a/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_viewset.py
+++ b/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_viewset.py
@@ -29,6 +29,13 @@ def test_get_contas_associacoes(jwt_authenticated_client_a, associacao, conta_as
     assert str(conta_associacao_cartao.uuid) in [c['uuid'] for c in result]
     assert str(conta_associacao_cheque.uuid) in [c['uuid'] for c in result]
 
+def test_get_contas_associacoes_encerradas(jwt_authenticated_client_a, associacao, conta_associacao_inativa, solicitacao_encerramento_conta_associacao):
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/contas/encerradas/', content_type='application/json')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert str(conta_associacao_inativa.uuid) in [c['uuid'] for c in result]
 
 def test_update_contas_associacoes(jwt_authenticated_client_a, associacao, tipo_conta_cartao, tipo_conta_cheque, conta_associacao, conta_associacao_cartao, conta_associacao_cheque):
     payload =  [


### PR DESCRIPTION
Esse PR:

-  Implementa managers para contas ativas e encerradas e adiciona rota de contas encerradas
- Adiciona teste

História: [AB#99318](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/99318)