### PR TITLE
fix(93854): Adiciona atribuição status análise dentro da transaction

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -528,6 +528,7 @@ class PrestacaoConta(ModeloBase):
         if self.analise_atual:
             devolucao_requer_alteracoes = self.analise_atual.verifica_se_requer_alteracao_em_lancamentos(considera_realizacao=False)
             self.analise_atual.devolucao_prestacao_conta = devolucao
+            self.analise_atual.status = self.STATUS_DEVOLVIDA
             self.analise_atual.save()
 
         self.analise_atual = None


### PR DESCRIPTION
Esse PR:

- Implementa uma modificação no status da análise para "devolvida" antes de salvar a referência da analise_atual.  Removendo qualquer possibilidade de conflitos de referências utilizadas em um eventual rollback.

História: [AB#93854](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93854)