### PR TITLE
feat(48770): Tratamento contas encerradas em gastos

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/rateio_despesa_serializer.py
@@ -72,6 +72,13 @@ class RateioDespesaCreateSerializer(serializers.ModelSerializer):
         model = RateioDespesa
         exclude = ('id', 'despesa')
 
+    def validate(self, data):
+        conta_associacao = data['conta_associacao']
+
+        if conta_associacao and conta_associacao.inativa:
+            raise serializers.ValidationError({"mensagem": "Não é permitido criar/editar rateio com conta inativada."})
+
+        return data
 
 class RateioDespesaListaSerializer(serializers.ModelSerializer):
     despesa = serializers.SlugRelatedField(

--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -226,9 +226,15 @@ class DespesasViewSet(mixins.CreateModelMixin,
 
     def destroy(self, request, *args, **kwargs):
         from django.db.models.deletion import ProtectedError
-        from ....core.models import DevolucaoAoTesouro
-
+        from ....core.models import DevolucaoAoTesouro, ContaAssociacao
         despesa = self.get_object()
+
+        if despesa.rateios.filter(conta_associacao__status=ContaAssociacao.STATUS_INATIVA).exists():
+            erro = {
+                'erro': 'rateio_com_conta_status_inativa',
+                'mensagem': f'Não é permitido deletar despesa com rateios com conta associação status {ContaAssociacao.STATUS_INATIVA}'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         if not despesa.inativar_em_vez_de_excluir:
             # Em caso de inativação, a inativação dos impostos é feita pelo próprio método inativar_despesa.

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/conftest.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/conftest.py
@@ -221,6 +221,47 @@ def payload_despesa_status_completo_eh_despesa_sem_comprovacao_fiscal(
     }
     return payload
 
+@pytest.fixture
+def payload_despesa_com_conta_associacao_inativa(
+    associacao,
+    tipo_documento,
+    tipo_transacao,
+    conta_associacao_inativa,
+    acao_associacao,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    especificacao_material_servico,
+):
+    payload = {
+        "associacao": f'{associacao.uuid}',
+        "tipo_documento": tipo_documento.id,
+        "tipo_transacao": tipo_transacao.id,
+        "documento_transacao": "123456789",
+        "numero_documento": "634767",
+        "data_documento": "2020-03-10",
+        "cpf_cnpj_fornecedor": "36.352.197/0001-75",
+        "nome_fornecedor": "FORNECEDOR TESTE SA",
+        "data_transacao": "2020-03-10",
+        "valor_total": 11000.50,
+        "valor_recursos_proprios": 1000.50,
+        "motivos_pagamento_antecipado": [],
+        "outros_motivos_pagamento_antecipado": "",
+        "rateios": [
+            {
+                "associacao": f'{associacao.uuid}',
+                "conta_associacao": f'{conta_associacao_inativa.uuid}',
+                "acao_associacao": f'{acao_associacao.uuid}',
+                "aplicacao_recurso": tipo_aplicacao_recurso,
+                "tipo_custeio": tipo_custeio.id,
+                "especificacao_material_servico": especificacao_material_servico.id,
+                "valor_rateio": 1000.00,
+                "quantidade_itens_capital": 2,
+                "valor_item_capital": 500.00,
+                "numero_processo_incorporacao_capital": "6234673223462364632"
+            }
+        ]
+    }
+    return payload
 
 @pytest.fixture
 def tapi_periodo_2019_2():
@@ -374,6 +415,24 @@ def tapi_rateio_despesa_com_imposto(associacao, tapi_despesa_com_imposto, conta_
         despesa=tapi_despesa_com_imposto,
         associacao=associacao,
         conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso=tipo_aplicacao_recurso,
+        tipo_custeio=tipo_custeio,
+        especificacao_material_servico=especificacao_material_servico,
+        valor_rateio=100.00,
+        quantidade_itens_capital=2,
+        valor_item_capital=50.00,
+        numero_processo_incorporacao_capital='Teste123456'
+
+    )
+
+@pytest.fixture
+def tapi_rateio_despesa_com_conta_associacao_inativa(associacao, tapi_despesa, conta_associacao_inativa, tipo_aplicacao_recurso, tipo_custeio, especificacao_material_servico, acao_associacao):
+    return baker.make(
+        'RateioDespesa',
+        despesa=tapi_despesa,
+        associacao=associacao,
+        conta_associacao=conta_associacao_inativa,
         acao_associacao=acao_associacao,
         aplicacao_recurso=tipo_aplicacao_recurso,
         tipo_custeio=tipo_custeio,

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_delete_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_delete_despesas.py
@@ -124,3 +124,17 @@ def test_api_delete_despesas_com_estorno_com_pc(
     assert RateioDespesa.by_uuid(tapi_rateio_despesa_capital.uuid).status == 'INATIVO', "Rateio deveria estar inativo."
 
     assert Receita.objects.get(id=tapi_receita_estorno.id).status == 'INATIVO', "Estorno deveria estar inativo."
+
+
+def test_validacao_api_delete_despesas_com_conta_associacao_inativa(
+    jwt_authenticated_client_d,
+    tapi_despesa,
+    tapi_rateio_despesa_com_conta_associacao_inativa,
+    tapi_periodo_2019_2,
+):
+    assert Despesa.objects.filter(uuid=tapi_despesa.uuid).exists()
+    assert RateioDespesa.objects.filter(uuid=tapi_rateio_despesa_com_conta_associacao_inativa.uuid).exists()
+
+    response = jwt_authenticated_client_d.delete(f'/api/despesas/{tapi_despesa.uuid}/', content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_post_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_post_despesas.py
@@ -62,3 +62,21 @@ def test_api_post_despesas_com_rateio_com_tag(
 
     assert despesa.associacao.uuid == associacao.uuid
     assert despesa.documento_transacao == '123456789'
+
+def test_validacao_post_despesas_com_rateio_com_conta_inativa(
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao_inativa,
+    tag_ativa,
+    payload_despesa_com_conta_associacao_inativa
+):
+    response = jwt_authenticated_client_d.post('/api/despesas/', data=json.dumps(payload_despesa_com_conta_associacao_inativa), content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_put_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_put_despesas.py
@@ -33,3 +33,23 @@ def test_api_post_despesas(
     despesa = Despesa.objects.get(uuid=result["uuid"])
 
     assert despesa.cpf_cnpj_fornecedor == payload_despesa_valida['cpf_cnpj_fornecedor']
+
+def test_validacao_put_despesas_com_rateio_com_conta_inativa(
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao_inativa,
+    despesa,
+    rateio_despesa_capital,
+    payload_despesa_com_conta_associacao_inativa
+):
+    response = jwt_authenticated_client_d.put(f'/api/despesas/{despesa.uuid}/', data=json.dumps(payload_despesa_com_conta_associacao_inativa),
+                          content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Esse PR:

- Valida rateios com conta inativa
- Valida deletar despesa
- Atualiza testes 

História: AB#48770