### PR TITLE
feat(48776): Acompanhamento PC, tratamento de contas encerradas

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -375,13 +375,20 @@ class PrestacaoConta(ModeloBase):
         comentarios_de_analise_relacionados_sem_pc.update(prestacao_conta=self, associacao=None, periodo=None)
 
     def get_contas_com_movimento(self, add_sem_movimento_com_saldo=False):
-        from sme_ptrf_apps.core.models import ContaAssociacao
+        from sme_ptrf_apps.core.models import ContaAssociacao, SolicitacaoEncerramentoContaAssociacao
         from sme_ptrf_apps.receitas.models import Receita
         from sme_ptrf_apps.despesas.models import RateioDespesa
         contas = ContaAssociacao.objects.filter(associacao=self.associacao).order_by('id')
 
         contas_com_movimento = []
         for conta in contas:
+            if hasattr(conta, 'solicitacao_encerramento'):
+                if conta.solicitacao_encerramento.status != SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA:
+                    data_encerramento = conta.solicitacao_encerramento.data_de_encerramento_na_agencia
+
+                    if data_encerramento < self.periodo.data_inicio_realizacao_despesas:
+                        continue
+
             tem_receitas_no_periodo = Receita.receitas_da_conta_associacao_no_periodo(
                 conta_associacao=conta,
                 periodo=self.periodo,
@@ -611,6 +618,26 @@ class PrestacaoConta(ModeloBase):
             periodo__referencia__gt=self.periodo.referencia
         ).exists()
         return pode_rebrir_pc
+
+    def contas_ativas_no_periodo(self):
+        from sme_ptrf_apps.core.models import SolicitacaoEncerramentoContaAssociacao, Periodo
+
+        contas_a_exibir = []
+
+        for conta in self.associacao.contas.all():
+            if hasattr(conta, 'solicitacao_encerramento'):
+                if conta.solicitacao_encerramento.status != SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA:
+                    data_encerramento = conta.solicitacao_encerramento.data_de_encerramento_na_agencia
+
+                    if data_encerramento < self.periodo.data_inicio_realizacao_despesas:
+                        continue
+
+                    # NESSE CASO PODE EXIBIR A CONTA
+                    contas_a_exibir.append(conta)
+            else:
+                contas_a_exibir.append(conta)
+
+        return contas_a_exibir
 
     @classmethod
     @transaction.atomic

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -322,7 +322,7 @@ def informacoes_financeiras_para_atas(prestacao_contas):
         f'Get info financeiras para ata. Associacao:{prestacao_contas.associacao.uuid} Período:{prestacao_contas.periodo}')
 
     info_contas = []
-    for conta_associacao in prestacao_contas.associacao.contas.all():
+    for conta_associacao in prestacao_contas.contas_ativas_no_periodo():
         logger.info(
             f'Get info financeiras por conta para a ata. Associacao:{prestacao_contas.associacao.uuid} Conta:{conta_associacao}')
         info_acoes = info_acoes_associacao_no_periodo(associacao_uuid=prestacao_contas.associacao.uuid,


### PR DESCRIPTION
feat(48776): Acompanhamento PC, tratamento de contas encerradas

Esse PR:

- Adiciona função ao modelo de PC para retornar contas ativas no periodo dessa PC
- Altera função get_contas_com_movimento para não retornar contas inativas no periodo dessa PC

História: AB#48776