### PR TITLE
feat(48775): Encerramento conta, geração de documentos PC

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -771,3 +771,29 @@ class AssociacoesViewSet(ModelViewSet):
         associacao = self.get_object()
         response = associacao.pendencias_dados_da_associacao_para_geracao_de_documentos()
         return Response(response)
+
+    @action(detail=True, url_path='contas-do-periodo', methods=['get'],
+            permission_classes=[IsAuthenticated, PermissaoAPITodosComLeituraOuGravacao])
+    def contas_do_periodo(self, request, uuid=None):
+        associacao = self.get_object()
+        periodo_uuid = request.query_params.get('periodo_uuid')
+
+        if not periodo_uuid:
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': 'É necessário informar o uuid do periodo'
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            Periodo.objects.filter(uuid=periodo_uuid).get()
+            periodo = Periodo.objects.filter(uuid=periodo_uuid).first()
+        except (ValidationError, Exception):
+            erro = {
+                'erro': 'parametro_invalido',
+                'mensagem': f"Não foi encontrado o objeto periodo para o uuid {periodo_uuid}"
+            }
+            return Response(erro, status=status.HTTP_404_NOT_FOUND)
+
+        lista_contas = associacao.contas_ativas_do_periodo_selecionado(periodo)
+        return Response(lista_contas)

--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -355,6 +355,21 @@ class Associacao(ModeloIdNome):
 
         return pendencias
 
+    def contas_ativas_do_periodo_selecionado(self, periodo):
+        contas_a_retornar = []
+
+        for conta in self.contas.all():
+            if conta.ativa_no_periodo(periodo=periodo):
+                obj_conta = {
+                    "nome": conta.tipo_conta.nome,
+                    "status": conta.status,
+                    "uuid": conta.uuid
+                }
+
+                contas_a_retornar.append(obj_conta)
+
+        return contas_a_retornar
+
     objects = models.Manager()  # Manager Padrão
     ativas = AssociacoesAtivasManager()
 

--- a/sme_ptrf_apps/core/models/conta_associacao.py
+++ b/sme_ptrf_apps/core/models/conta_associacao.py
@@ -90,6 +90,21 @@ class ContaAssociacao(ModeloBase):
 
         return saldo_conta
 
+    def ativa_no_periodo(self, periodo):
+        from sme_ptrf_apps.core.models import SolicitacaoEncerramentoContaAssociacao
+
+        if hasattr(self, 'solicitacao_encerramento'):
+            if self.solicitacao_encerramento.status != SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA:
+                data_encerramento = self.solicitacao_encerramento.data_de_encerramento_na_agencia
+
+                if data_encerramento < periodo.data_inicio_realizacao_despesas:
+                    return False
+
+                return True
+        else:
+            return True
+
+
     @classmethod
     def get_valores(cls, user=None, associacao_uuid=None):
         query = cls.objects.all()

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -620,21 +620,10 @@ class PrestacaoConta(ModeloBase):
         return pode_rebrir_pc
 
     def contas_ativas_no_periodo(self):
-        from sme_ptrf_apps.core.models import SolicitacaoEncerramentoContaAssociacao, Periodo
-
         contas_a_exibir = []
 
         for conta in self.associacao.contas.all():
-            if hasattr(conta, 'solicitacao_encerramento'):
-                if conta.solicitacao_encerramento.status != SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA:
-                    data_encerramento = conta.solicitacao_encerramento.data_de_encerramento_na_agencia
-
-                    if data_encerramento < self.periodo.data_inicio_realizacao_despesas:
-                        continue
-
-                    # NESSE CASO PODE EXIBIR A CONTA
-                    contas_a_exibir.append(conta)
-            else:
+            if conta.ativa_no_periodo(periodo=self.periodo):
                 contas_a_exibir.append(conta)
 
         return contas_a_exibir

--- a/sme_ptrf_apps/core/tasks.py
+++ b/sme_ptrf_apps/core/tasks.py
@@ -64,7 +64,7 @@ def concluir_prestacao_de_contas_async(
         from sme_ptrf_apps.core.services.falha_geracao_pc_service import FalhaGeracaoPcService
 
         acoes = associacao.acoes.filter(status=AcaoAssociacao.STATUS_ATIVA)
-        contas = associacao.contas.filter(status=ContaAssociacao.STATUS_ATIVA)
+        contas = prestacao.contas_ativas_no_periodo()
 
         # Aqui grava observacao da conciliacao bancaria. Grava o campo observacao.justificativa_original com observacao.texto
         for conta_associacao in contas:

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_associacoes_endpoint.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_associacoes_endpoint.py
@@ -11,3 +11,11 @@ def test_url_retrieve(jwt_authenticated_client_a, associacao):
 def test_url_painel_por_acoes(jwt_authenticated_client_a, associacao, periodo):
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/')
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_action_contas_do_periodo(jwt_authenticated_client_a, associacao, periodo):
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/contas-do-periodo/?periodo_uuid={periodo.uuid}',
+    )
+
+    assert response.status_code == status.HTTP_200_OK

--- a/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_contas_ativas_no_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_prestacao_conta/test_prestacao_conta_contas_ativas_no_periodo.py
@@ -1,0 +1,77 @@
+import pytest
+from model_bakery import baker
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def prestacao_conta_teste_conta_ativa_no_periodo_19_02(periodo, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo,
+        associacao=associacao,
+        status="EM_ANALISE"
+    )
+
+
+@pytest.fixture
+def prestacao_conta_teste_conta_ativa_no_periodo_20_1(periodo_2020_1, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        status="EM_ANALISE"
+    )
+
+
+def test_contas_ativas_no_periodo_com_conta_encerrada_no_periodo_da_pc(
+    conta_associacao_cheque,
+    conta_associacao_cartao,
+    conta_associacao_inativa,
+    solicitacao_encerramento_conta_associacao,
+    prestacao_conta_teste_conta_ativa_no_periodo_19_02
+):
+
+    # Todas as contas devem ser retornadas, pois a 'conta_associacao_inativa' foi inativada no periodo dessa PC
+    contas_ativas_nesse_periodo = prestacao_conta_teste_conta_ativa_no_periodo_19_02.contas_ativas_no_periodo()
+
+    assert len(contas_ativas_nesse_periodo) == 3
+    assert conta_associacao_cheque in contas_ativas_nesse_periodo
+    assert conta_associacao_cartao in contas_ativas_nesse_periodo
+    assert conta_associacao_inativa in contas_ativas_nesse_periodo
+
+
+def test_contas_ativas_no_periodo_com_conta_encerrada_no_periodo_anterior_da_pc(
+    conta_associacao_cheque,
+    conta_associacao_cartao,
+    conta_associacao_inativa,
+    solicitacao_encerramento_conta_associacao,
+    prestacao_conta_teste_conta_ativa_no_periodo_20_1
+):
+
+    # A conta 'conta_associacao_inativa' não deve ser retornada, pois foi encerrada no periodo anterior a PC
+    contas_ativas_nesse_periodo = prestacao_conta_teste_conta_ativa_no_periodo_20_1.contas_ativas_no_periodo()
+
+    assert len(contas_ativas_nesse_periodo) == 2
+    assert conta_associacao_cheque in contas_ativas_nesse_periodo
+    assert conta_associacao_cartao in contas_ativas_nesse_periodo
+    assert conta_associacao_inativa not in contas_ativas_nesse_periodo
+
+
+def test_contas_ativas_no_periodo_com_conta_encerrada_no_periodo_posterior_da_pc(
+    conta_associacao_cheque,
+    conta_associacao_cartao,
+    conta_associacao_inativa_x,
+    solicitacao_encerramento_conta_associacao_no_periodo_2020_1,
+    prestacao_conta_teste_conta_ativa_no_periodo_19_02
+):
+
+    # Todas as contas devem ser retornadas, a 'conta_associacao_inativa' foi inativada no periodo posterior dessa PC
+    contas_ativas_nesse_periodo = prestacao_conta_teste_conta_ativa_no_periodo_19_02.contas_ativas_no_periodo()
+
+    assert len(contas_ativas_nesse_periodo) == 3
+    assert conta_associacao_cheque in contas_ativas_nesse_periodo
+    assert conta_associacao_cartao in contas_ativas_nesse_periodo
+    assert conta_associacao_inativa_x in contas_ativas_nesse_periodo
+


### PR DESCRIPTION
feat(48775): Encerramento conta, geração de documentos PC

Esse PR:

- Adiciona endpoint para retornar contas ativas no periodo
- Altera método de concluir prestação de contas para não considerar contas inativas anterior ao periodo
- Adiciona testes relacionados

História: AB#48775