### PR TITLE
feat(101137): Encerramento conta, valores reprogramados

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1338,6 +1338,7 @@ class ValoresReprogramadosAdmin(admin.ModelAdmin):
         'aplicacao_recurso'
     )
     readonly_fields = ('uuid', 'id', 'criado_em', 'alterado_em')
+    raw_id_fields = ('associacao', 'periodo', 'conta_associacao', 'acao_associacao',)
 
 
 @admin.register(DevolucaoAoTesouro)

--- a/sme_ptrf_apps/core/models/conta_associacao.py
+++ b/sme_ptrf_apps/core/models/conta_associacao.py
@@ -104,6 +104,125 @@ class ContaAssociacao(ModeloBase):
         else:
             return True
 
+    def todos_valores_reprogramados_foram_preenchidos(self, valida_valor_dre=False):
+        from sme_ptrf_apps.core.models import ValoresReprogramados, Associacao
+        from sme_ptrf_apps.receitas.tipos_aplicacao_recurso_receitas import \
+            APLICACAO_CAPITAL, APLICACAO_CUSTEIO, APLICACAO_LIVRE
+
+        valores_reprogramados = ValoresReprogramados.objects.filter(
+            associacao=self.associacao, conta_associacao=self).all()
+
+        lista_de_valores_reprogramados = []
+
+        # Levando em consideração que deve haver um registro de valor reprogramado
+        # para cada aplicação (Custeio, Capital, Livre) que a ação aceite
+        qtde_esperado = 0
+
+        for acao_associacao in self.associacao.acoes.exclude(acao__e_recursos_proprios=True):
+            valores_reprogramados_da_acao = valores_reprogramados.filter(acao_associacao=acao_associacao)
+
+            if acao_associacao.acao.aceita_custeio:
+                qtde_esperado = qtde_esperado + 1
+
+                valor_reprogramado_por_aplicacao = valores_reprogramados_da_acao.filter(
+                    aplicacao_recurso=APLICACAO_CUSTEIO)
+
+                if valor_reprogramado_por_aplicacao.exists():
+                    lista_de_valores_reprogramados.append(valor_reprogramado_por_aplicacao.first())
+
+            if acao_associacao.acao.aceita_capital:
+                qtde_esperado = qtde_esperado + 1
+
+                valor_reprogramado_por_aplicacao = valores_reprogramados_da_acao.filter(
+                    aplicacao_recurso=APLICACAO_CAPITAL)
+
+                if valor_reprogramado_por_aplicacao.exists():
+                    lista_de_valores_reprogramados.append(valor_reprogramado_por_aplicacao.first())
+
+            if acao_associacao.acao.aceita_livre:
+                qtde_esperado = qtde_esperado + 1
+
+                valor_reprogramado_por_aplicacao = valores_reprogramados_da_acao.filter(
+                    aplicacao_recurso=APLICACAO_LIVRE)
+
+                if valor_reprogramado_por_aplicacao.exists():
+                    lista_de_valores_reprogramados.append(valor_reprogramado_por_aplicacao.first())
+
+        if valida_valor_dre:
+            valores_reprogramados_preenchidos = valores_reprogramados.exclude(valor_ue=None).exclude(valor_dre=None)
+        else:
+            valores_reprogramados_preenchidos = valores_reprogramados.exclude(valor_ue=None)
+
+        qtde_lista_valores = len(lista_de_valores_reprogramados)
+
+        if qtde_esperado == qtde_lista_valores and qtde_esperado == valores_reprogramados_preenchidos.count():
+            return True
+
+        return False
+
+    def valida_se_algum_valor_reprogramado_foi_preenchido(self):
+        from sme_ptrf_apps.core.models import ValoresReprogramados
+
+        valores_reprogramados = ValoresReprogramados.objects.filter(
+            associacao=self.associacao, conta_associacao=self).exists()
+
+        return valores_reprogramados
+
+    def valida_status_valores_reprogramados(self):
+        from sme_ptrf_apps.core.models import Associacao
+
+        resultado = {
+            "pode_encerrar_conta": False,
+            "mensagem": None
+        }
+
+        pc_do_primeiro_periodo_de_uso_do_sistema = self.associacao.prestacoes_de_conta_da_associacao.filter(
+            periodo=self.associacao.periodo_inicial)
+
+        if pc_do_primeiro_periodo_de_uso_do_sistema.exists():
+            resultado["pode_encerrar_conta"] = True
+            return resultado
+
+        # Esse trecho só é executado caso a primeira PC não exista
+        status_atual = self.associacao.status_valores_reprogramados
+        status_nao_finalizado = Associacao.STATUS_VALORES_REPROGRAMADOS_NAO_FINALIZADO
+        status_correcao_ue = Associacao.STATUS_VALORES_REPROGRAMADOS_EM_CORRECAO_UE
+        status_conferencia_dre = Associacao.STATUS_VALORES_REPROGRAMADOS_EM_CONFERENCIA_DRE
+        status_corretos = Associacao.STATUS_VALORES_REPROGRAMADOS_VALORES_CORRETOS
+
+        if status_atual == status_nao_finalizado:
+            if not self.valida_se_algum_valor_reprogramado_foi_preenchido():
+                resultado["pode_encerrar_conta"] = True
+                resultado["mensagem"] = None
+            else:
+                if not self.todos_valores_reprogramados_foram_preenchidos():
+                    resultado["pode_encerrar_conta"] = False
+                    resultado["mensagem"] = "Existem valores reprogramados preenchidos, mas não concluídos. É necessário finalizar o preenchimento dos Valores reprogramados para solicitar o encerramento da conta bancária."
+                else:
+                    resultado["pode_encerrar_conta"] = True
+                    resultado["mensagem"] = None
+
+        elif status_atual == status_correcao_ue or status_atual == status_conferencia_dre:
+            if self.todos_valores_reprogramados_foram_preenchidos(valida_valor_dre=True):
+                resultado["pode_encerrar_conta"] = True
+                resultado["mensagem"] = "O pedido de solicitação de encerramento de conta bancária foi efetuado com sucesso. Existem valores reprogramados concluídos e o encerramento definitivo da conta será realizado após a geração da PC e a conclusão da análise pela DRE."
+            else:
+                resultado["pode_encerrar_conta"] = False
+                resultado["mensagem"] = "Existem valores reprogramados que não foram preenchidos pela DRE. É necessário aguardar a finalização do preenchimento para solicitar o encerramento da conta bancária."
+
+        elif status_atual == status_corretos:
+            if self.todos_valores_reprogramados_foram_preenchidos(valida_valor_dre=True):
+                resultado["pode_encerrar_conta"] = True
+                resultado["mensagem"] = "O pedido de solicitação de encerramento de conta bancária foi efetuado com sucesso. O encerramento definitivo da conta será realizado após a geração da PC e a conclusão da análise pela DRE."
+
+        return resultado
+
+    @property
+    def msg_sucesso_ao_encerrar(self):
+        mensagem = self.valida_status_valores_reprogramados()["mensagem"]
+
+        return mensagem
+
 
     @classmethod
     def get_valores(cls, user=None, associacao_uuid=None):


### PR DESCRIPTION
feat(101137): Encerramento conta, valores reprogramados

Esse PR:

- Adiciona funções para validar valores reprogramados ao solicitar encerramento de conta
- Adiciona validação ao serializer da API de encerramento de conta
- Adiciona mensagem de sucesso a API de encerramento de conta

História: AB#101137