### PR TITLE
feat(100076): Utiliza a data da reunião na assinatura da ata

### DIFF
--- a/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
@@ -111,7 +111,7 @@
 
     <p class="mt-3 mb-3 titulo-assinaturas font-12">
       {% language 'pt-br' %}
-        São Paulo, dia {% now "j" %} de {% now "F" %} de {% now "Y" %}
+        São Paulo, dia {{ dados.dados_texto_da_ata.data_reuniao|date:"d" }} de {{ dados.dados_texto_da_ata.data_reuniao|date:"F"|lower }} de {{ dados.dados_texto_da_ata.data_reuniao|date:"Y" }}
       {% endlanguage %}
     </p>
   </article>


### PR DESCRIPTION
Esse PR:

- Modifica no downlaod da ata a data da assinatura para a data de preenchimento da reunião.

História: AB#100076