### PR TITLE
feat(102480): Incluir info pcs retificadas ao demonstrativo

### DIFF
--- a/sme_ptrf_apps/core/models/conta_associacao.py
+++ b/sme_ptrf_apps/core/models/conta_associacao.py
@@ -255,6 +255,23 @@ class ContaAssociacao(ModeloBase):
 
         return info
 
+    def conta_criada_no_periodo_ou_periodo_anteriores(self, periodo):
+        from sme_ptrf_apps.core.models import Periodo
+
+        if not self.data_inicio:
+            return False
+
+        periodo_da_data = Periodo.da_data(self.data_inicio)
+        if periodo_da_data == periodo:
+            return True
+
+        periodos_anteriores = Periodo.objects.filter(
+            data_inicio_realizacao_despesas__lt=periodo.data_inicio_realizacao_despesas).order_by('-referencia')
+        if periodo_da_data in list(periodos_anteriores):
+            return True
+
+        return False
+
     @property
     def msg_sucesso_ao_encerrar(self):
         mensagem = self.valida_status_valores_reprogramados()["mensagem"]

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -482,6 +482,8 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
         quantidade_nao_aprovada = prestacoes_do_consolidado.filter(status="REPROVADA", publicada=publicada).count()
         # Fim Dados do Consolidado DRE Retificacao
 
+        quantidade_retificadas = consolidado_dre.pcs_do_consolidado.all().count()
+
     # Se não for o Consolidado de Publicações Parciais
     elif not eh_consolidado_de_publicacoes_parciais:
         # Dados do Consolidado DRE
@@ -505,6 +507,8 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
         quantidade_aprovada_ressalva = prestacoes_do_consolidado.filter(status="APROVADA_RESSALVA", publicada=publicada).count()
         quantidade_nao_aprovada = prestacoes_do_consolidado.filter(status="REPROVADA", publicada=publicada).count()
         # Fim Dados do Consolidado DRE
+
+        quantidade_retificadas = 0
     else:
         quantidade_publicacoes_anteriores = ConsolidadoDRE.objects.filter(
             dre=dre,
@@ -515,11 +519,9 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
         quantidade_aprovada_ressalva = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'APROVADA_RESSALVA'][0]
         quantidade_nao_aprovada = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'REPROVADA'][0]
 
+        quantidade_retificadas = 0
 
     quantidade_em_analise = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'EM_ANALISE'][0]
-    quantidade_recebida = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'RECEBIDA'][0]
-    quantidade_devolvida = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'DEVOLVIDA'][0]
-    quantidade_nao_recebida = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'NAO_RECEBIDA'][0]
 
     if consolidado_dre and consolidado_dre.eh_retificacao:
         quantidade_nao_apresentada = \
@@ -528,7 +530,8 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
             - quantidade_aprovada_ressalva \
             - quantidade_nao_aprovada \
             - quantidade_em_analise \
-            - quantidade_publicacoes_anteriores
+            - quantidade_publicacoes_anteriores \
+            - quantidade_retificadas
 
     # (-) todos os outros status com exceção dos quantidade_recebida e quantidade_devolvida (Porque não aparecem nesse bloco)
     elif not eh_consolidado_de_publicacoes_parciais:
@@ -548,13 +551,12 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
             - quantidade_em_analise
 
     total = \
-        quantidade_nao_recebida \
-        + quantidade_aprovada \
+        quantidade_aprovada \
         + quantidade_aprovada_ressalva \
         + quantidade_nao_aprovada \
         + quantidade_em_analise \
-        + quantidade_recebida \
-        + quantidade_devolvida
+        + quantidade_nao_apresentada \
+        + quantidade_publicacoes_anteriores
 
     execucao_fisica = {
         "ues_da_dre": dre.unidades_da_dre.count(),
@@ -566,6 +568,7 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
         "analise": quantidade_em_analise,
         "nao_apresentadas": quantidade_nao_apresentada,
         "publicadas_anteriormente": quantidade_publicacoes_anteriores,
+        "ues_retificadas": quantidade_retificadas,
         "total": total
     }
 

--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -351,6 +351,11 @@ def informacoes_execucao_financeira(dre, periodo, tipo_conta, apenas_nao_publica
             )
 
         for fechamento in fechamentos:
+            conta_associacao = fechamento.conta_associacao
+
+            if not conta_associacao.conta_criada_no_periodo_ou_periodo_anteriores(periodo=periodo):
+                continue
+
             totais = _soma_fechamento(totais, fechamento)
             totais = _soma_receitas_tipo_rendimento(
                 periodo=periodo,
@@ -395,6 +400,10 @@ def informacoes_execucao_financeira(dre, periodo, tipo_conta, apenas_nao_publica
             ).distinct()
 
         for previsao in previsoes:
+            conta_associacao = previsao.conta_associacao
+            if not conta_associacao.conta_criada_no_periodo_ou_periodo_anteriores(periodo=periodo):
+                continue
+
             totais['repasses_previstos_sme_custeio'] += previsao.valor_custeio
             totais['repasses_previstos_sme_capital'] += previsao.valor_capital
             totais['repasses_previstos_sme_livre'] += previsao.valor_livre
@@ -430,6 +439,10 @@ def informacoes_execucao_financeira(dre, periodo, tipo_conta, apenas_nao_publica
             ).distinct("pk")
 
         for devolucao in devolucoes:
+            conta_associacao = devolucao.despesa__rateios__conta_associacao
+            if not conta_associacao.conta_criada_no_periodo_ou_periodo_anteriores(periodo=periodo):
+                continue
+
             totais['devolucoes_ao_tesouro_no_periodo_total'] += devolucao.valor
 
         return totais
@@ -1109,6 +1122,9 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
         objeto_tipo_de_conta = []
 
         for conta_associacao in associacao.contas.all():
+
+            if not conta_associacao.conta_criada_no_periodo_ou_periodo_anteriores(periodo=periodo):
+                continue
 
             totais = _totalizador_zerado()
 

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
@@ -17,6 +17,7 @@ def conta_associacao_cheque(associacao, tipo_conta_cheque):
         'ContaAssociacao',
         associacao=associacao,
         tipo_conta=tipo_conta_cheque,
+        data_inicio=date(2019, 9, 1)
     )
 
 
@@ -26,6 +27,7 @@ def conta_associacao_cartao(associacao, tipo_conta_cartao):
         'ContaAssociacao',
         associacao=associacao,
         tipo_conta=tipo_conta_cartao,
+        data_inicio=date(2019, 9, 1)
     )
 
 

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
@@ -3,41 +3,43 @@
 <table class="table table-bordered tabela-relatorio-dre">
   <thead>
       <tr>
-      <th colspan="10" class="th-fundo-branco py-2 pl-2">
-        <p class="font-14 titulo mb-0 mt-0 px-0"><strong>Bloco 3: Execução Física</strong></p>
-      </th>
-    </tr>
-    <tr>
-      <th class="titulo" colspan="3"><strong>Atendimento</strong></th>
-      <th rowspan="2" class="separacao-de-colunas-da-tabela"> </th>
-      <th class="titulo" colspan="7"><strong>Prestação de contas das Associações</strong></th>
-    </tr>
+        <th colspan="16" class="th-fundo-branco py-2 pl-2">
+          <p class="font-14 titulo mb-0 mt-0 px-0"><strong>Bloco 3: Execução Física</strong></p>
+        </th>
+      </tr>
 
-    <tr>
-      <th class="th-fundo-branco">09 - UEs da DRE</th>
-      <th class="th-fundo-branco">10 - UEs com Associação</th>
+      <tr>
+        <th class="titulo" colspan="3"><strong>Atendimento</strong></th>
+        <th rowspan="2" class="separacao-de-colunas-da-tabela"> </th>
+        <th class="titulo" colspan="7"><strong>Prestação de contas das Associações</strong></th>
+        <th rowspan="2" class="separacao-de-colunas-da-tabela"> </th>
+        <th class="titulo" colspan="1"></th>
+      </tr>
 
-      <th class="th-fundo-branco">11 - Associações regulares</th>
+      <tr>
+        <th class="th-fundo-branco">09 - UEs da DRE</th>
+        <th class="th-fundo-branco">10 - UEs com Associação</th>
+        <th class="th-fundo-branco">11 - Associações regulares</th>
 
-      <th class="th-fundo-branco">12 - Aprovadas</th>
-      <th class="th-fundo-branco">13 - Aprovadas com ressalva</th>
-      <th class="th-fundo-branco">14 - Rejeitadas</th>
+        <th class="th-fundo-branco">12 - Aprovadas</th>
+        <th class="th-fundo-branco">13 - Aprovadas com ressalva</th>
+        <th class="th-fundo-branco">14 - Rejeitadas</th>
+        <th class="th-fundo-branco">15 - Em análise</th>
+        <th class="th-fundo-branco">16 - Não apresentadas</th>
+        <th class="th-fundo-branco">17 - UEs publicadas anteriormente</th>
+        <th class="th-fundo-branco">18 - Total</th>
 
-      <th class="th-fundo-branco">15 - Em análise</th>
+        <th class="th-fundo-branco">19 - UEs Retificadas</th>
+      </tr>
 
-
-      <th class="th-fundo-branco">16 - Não apresentadas</th>
-      <th class="th-fundo-branco">17 - Publicadas anteriormente</th>
-      <th class="th-fundo-branco">18 - Total</th>
-    </tr>
   </thead>
 
   <tbody>
     <tr>
       <td class="text-right">{{ dados.execucao_fisica.ues_da_dre }}</td>
       <td class="text-right">{{ dados.execucao_fisica.ues_com_associacao }}</td>
-
       <td class="text-right">{{ dados.execucao_fisica.associacoes_regulares }}</td>
+
       <td rowspan="1" class="separacao-de-colunas-da-tabela"> </td>
 
       <td class="text-right">{{ dados.execucao_fisica.aprovada }}</td>
@@ -47,6 +49,26 @@
       <td class="text-right">{{ dados.execucao_fisica.nao_apresentadas }}</td>
       <td class="text-right">{{ dados.execucao_fisica.publicadas_anteriormente}}</td>
       <td class="text-right">{{ dados.execucao_fisica.total }}</td>
+
+      <td rowspan="1" class="separacao-de-colunas-da-tabela"> </td>
+
+      <td class="text-right">{{ dados.execucao_fisica.ues_retificadas }}</td>
+    </tr>
+
+    <tr>
+      <td colspan="16">
+        <div class="d-flex flex-row p-2">
+          <div class="pr-2">
+            <span class="font-10 titulo pt-2 pb-2"><strong>Nota explicativa:</strong></span>
+          </div>
+          <div>
+            <span class="font-10 pt-2 pb-2">Coluna 18 - É a soma das colunas 12 a 17.</span>
+            <br/>
+            <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada na referida publicação.</span>
+          </div>
+        </div>
+
+      </td>
     </tr>
   </tbody>
 </table>

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisico-financeira.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisico-financeira.html
@@ -9,17 +9,17 @@
     </th>
   </tr>
   <tr>
-    <th style="width: 3%">19 - Ordem</th>
-    <th style="width: 15%">20 - Unidade</th>
-    <th style="width: 7%">21 - Conta</th>
-    <th colspan="2">22 - Reprogramado do período anterior</th>
-    <th colspan="2">23 - Transferido pela DRE</th>
-    <th colspan="2">24 - Outros créditos</th>
-    <th colspan="2">25 - Valor total disponível</th>
-    <th colspan="2">26 - Despesa realizada</th>
-    <th colspan="2">27 - Saldo reprogramado para<br/>o próximo período</th>
-    <th colspan="2">28 - Devolução ao Tesouro</th>
-    <th>29 - Situação da PC</th>
+    <th style="width: 3%">20 - Ordem</th>
+    <th style="width: 15%">21 - Unidade</th>
+    <th style="width: 7%">22 - Conta</th>
+    <th colspan="2">23 - Reprogramado do período anterior</th>
+    <th colspan="2">24 - Transferido pela DRE</th>
+    <th colspan="2">25 - Outros créditos</th>
+    <th colspan="2">26 - Valor total disponível</th>
+    <th colspan="2">27 - Despesa realizada</th>
+    <th colspan="2">28 - Saldo reprogramado para<br/>o próximo período</th>
+    <th colspan="2">29 - Devolução ao Tesouro</th>
+    <th>30 - Situação da PC</th>
   </tr>
   </thead>
 


### PR DESCRIPTION
feat(102480): Incluir info pcs retificadas ao demonstrativo

Esse PR:

- Altera template do bloco 3 Execução fisica
- Altera calculo do bloco 3 Execução fisica
- Cria função no modelo de ContaAssociacao para validar data-inicio da conta
- Altera calculo do bloco 2 para desconsiderar contas criadas porteriormente ao periodo selecionado
- Altera lista do bloco 4 para desconsiderar contas criadas porteriormente ao periodo selecionado

História: AB#102480