### PR TITLE
feat(102525): Incluir info pcs retificadas ao consolidado geral

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_conta_associacao/test_conta_associacao_conta_criada_no_periodo_ou_periodo_anteriores_metodo.py
+++ b/sme_ptrf_apps/core/tests/tests_conta_associacao/test_conta_associacao_conta_criada_no_periodo_ou_periodo_anteriores_metodo.py
@@ -1,0 +1,64 @@
+import pytest
+from model_bakery import baker
+from datetime import date
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def conta_associacao_com_data_inicio_periodo_2019_2(associacao, tipo_conta_cheque):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=tipo_conta_cheque,
+        data_inicio=date(2019, 9, 1)
+    )
+
+
+@pytest.fixture
+def conta_associacao_com_data_inicio_periodo_2019_1(associacao, tipo_conta_cheque):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=tipo_conta_cheque,
+        data_inicio=date(2019, 1, 1)
+    )
+
+
+@pytest.fixture
+def conta_associacao_com_data_inicio_periodo_2020_1(associacao, tipo_conta_cheque):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao,
+        tipo_conta=tipo_conta_cheque,
+        data_inicio=date(2020, 1, 1)
+    )
+
+
+def test_conta_criada_no_periodo(
+    conta_associacao_com_data_inicio_periodo_2019_2,
+    periodo
+):
+    result = conta_associacao_com_data_inicio_periodo_2019_2.conta_criada_no_periodo_ou_periodo_anteriores(periodo)
+
+    assert result is True
+
+
+def test_conta_criada_no_periodo_anterior(
+    conta_associacao_com_data_inicio_periodo_2019_1,
+    periodo
+):
+    result = conta_associacao_com_data_inicio_periodo_2019_1.conta_criada_no_periodo_ou_periodo_anteriores(periodo)
+
+    assert result is True
+
+
+def test_conta_criada_no_periodo_posterior(
+    conta_associacao_com_data_inicio_periodo_2020_1,
+    periodo
+):
+    # Essa conta foi criada no periodo posterior ao periodo informado
+    result = conta_associacao_com_data_inicio_periodo_2020_1.conta_criada_no_periodo_ou_periodo_anteriores(periodo)
+
+    assert result is False

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -472,7 +472,7 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
             dre=dre,
             periodo=periodo
         ).exclude(
-            id__gt=consolidado_dre.id
+            id__gte=consolidado_dre.id
         ).aggregate(qtde_publicacoes_anteriores=Coalesce(Count('prestacoes_de_conta_do_consolidado_dre'), Value(0)))[
             'qtde_publicacoes_anteriores']
 
@@ -510,11 +510,7 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
 
         quantidade_retificadas = 0
     else:
-        quantidade_publicacoes_anteriores = ConsolidadoDRE.objects.filter(
-            dre=dre,
-            periodo=periodo
-        ).aggregate(qtde_publicacoes_anteriores=Coalesce(Count('prestacoes_de_conta_do_consolidado_dre'), Value(0)))['qtde_publicacoes_anteriores']
-
+        quantidade_publicacoes_anteriores = 0
         quantidade_aprovada = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'APROVADA'][0]
         quantidade_aprovada_ressalva = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'APROVADA_RESSALVA'][0]
         quantidade_nao_aprovada = [c['quantidade_prestacoes'] for c in cards if c['status'] == 'REPROVADA'][0]
@@ -531,7 +527,6 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
             - quantidade_nao_aprovada \
             - quantidade_em_analise \
             - quantidade_publicacoes_anteriores \
-            - quantidade_retificadas
 
     # (-) todos os outros status com exceção dos quantidade_recebida e quantidade_devolvida (Porque não aparecem nesse bloco)
     elif not eh_consolidado_de_publicacoes_parciais:


### PR DESCRIPTION
feat(102525): Incluir info pcs retificadas ao consolidado geral

Esse PR:

- Altera calculo para definir quantidade de pc publicadas anteriormente quando for consolidado geral
- Adiciona testes para a função de validar data de inicio da conta

História: AB#102525