### PR TITLE
feat(101655): Ativa conta na solicitacao encerramento rejeitada

### DIFF
--- a/sme_ptrf_apps/core/api/views/solicitacao_encerramento_conta_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/solicitacao_encerramento_conta_associacao_viewset.py
@@ -106,6 +106,7 @@ class SolicitacaoEncerramentoContaAssociacaoViewset(mixins.ListModelMixin,
         solicitacao.motivos_rejeicao.set(motivos)
         solicitacao.outros_motivos_rejeicao = outros_motivos_rejeicao
         solicitacao.reprovar()
+        solicitacao.conta_associacao.ativar()
 
         serializer = self.get_serializer(solicitacao)
 

--- a/sme_ptrf_apps/core/tests/tests_api_solicitacao_encerramento_conta_associacao/test_solicitacao_encerramento_update.py
+++ b/sme_ptrf_apps/core/tests/tests_api_solicitacao_encerramento_conta_associacao/test_solicitacao_encerramento_update.py
@@ -3,6 +3,7 @@ import pytest
 from rest_framework import status
 
 from sme_ptrf_apps.core.models import SolicitacaoEncerramentoContaAssociacao
+from sme_ptrf_apps.core.models.conta_associacao import ContaAssociacao
 pytestmark = pytest.mark.django_db
 
 def test_reenviar_solicitacao_encerramento_conta_associacao(jwt_authenticated_client_a, solicitacao_encerramento_reprovada, payload_reenviar_solicitacao):
@@ -41,11 +42,14 @@ def test_rejeitar_solicitacao_encerramento_conta_associacao(jwt_authenticated_cl
         f'/api/solicitacoes-encerramento-conta/{solicitacao_encerramento.uuid}/rejeitar/',
         data=json.dumps(payload_rejeitar_solicitacao),
         content_type='application/json')
+    
+    conta = ContaAssociacao.objects.get(uuid=response.json()['conta_associacao'])
 
     assert response.json()['status'] == SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA
     assert response.json()['motivos_rejeicao']
     assert response.json()['outros_motivos_rejeicao'] == 'UE com pendências cadastrais.'
     assert response.status_code == status.HTTP_200_OK
+    assert conta.status == ContaAssociacao.STATUS_ATIVA
 
 def test_validacao_rejeitar_solicitacao_encerramento_conta_associacao(jwt_authenticated_client_a, solicitacao_encerramento_reprovada):
     response = jwt_authenticated_client_a.patch(


### PR DESCRIPTION
Esse PR:

- Ativa novamente a conta quando a solicitação de encerramento é rejeitada.
- Adiciona teste.