### PR TITLE
feat(101828): Atualização para Django 3.2.21 e preparação para Django 4.1

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -140,6 +140,7 @@ MIDDLEWARE = [
     "sme_ptrf_apps.jwt_middleware.JWTAuthenticationMiddleware",
     "auditlog.middleware.AuditlogMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "allauth.account.middleware.AccountMiddleware",  # Requerido na versão 0.56.1 do django-allauth, necessária para o Django 4
 ]
 
 # STATIC (DJANGO)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,22 +9,38 @@ django-auditlog==2.0.0
 # ------------------------------------------------------------------------------
 drf-spectacular==0.26.2                 # Auto-generate OpenAPI 3.0 schemas from Django Rest Framework code
 
+# Django Admin Interface
+# Para melhoria da aparência do Django Admin
+# ------------------------------------------------------------------------------
+django-admin-interface==0.26.1
+
 # Celery
 # ------------------------------------------------------------------------------
 celery==5.2.1
 flower==1.2.0  # https://github.com/mher/flower
 
-# Outras
+# Solução para features flags
 # ------------------------------------------------------------------------------
-Pillow==8.4.0
 django-waffle==4.0.0
+
+# Outras dependências
+# ------------------------------------------------------------------------------
+Pillow==9.5.0
+python-slugify==8.0.1
+django-allauth==0.56.1
+django-ckeditor==6.7.0
+django-compressor==4.4
+rcssmin==1.1.1
+
+# Django DES - EmailBackend that allows email configuration to be changed while the server is running.
+# Fork do django-des para suportar o Django 4
+git+https://github.com/prefeiturasp/django-des-fork.git#egg=django-des
+
 
 # DEPENDENCIAS AINDA NÃO REVISTAS
 
 pytz==2019.3  # https://github.com/stub42/pytz
-python-slugify==4.0.0  # https://github.com/un33k/python-slugify
 
-rcssmin==1.0.6  # https://github.com/ndparker/rcssmin
 argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 redis==3.4.1 # https://github.com/andymccurdy/redis-py
@@ -36,13 +52,10 @@ openpyxl==3.0.3
 # ------------------------------------------------------------------------------
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
-django-allauth==0.41.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==1.9.0  # https://github.com/django-crispy-forms/django-crispy-forms
-django-compressor==2.4  # https://github.com/django-compressor/django-compressor
+
 django-redis==4.11.0  # https://github.com/niwinz/django-redis
 django-admin-rangefilter==0.5.4 # https://github.com/silentsokolov/django-admin-rangefilter
-django-des==2.4.1  # https://github.com/jamiecounsell/django-des
-django-ckeditor==5.9.0
 
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
@@ -60,9 +73,6 @@ django-cors-headers # https://github.com/adamchainz/django-cors-headers
 # https://github.com/poliquin/brazilnum
 brazilnum==0.8.8
 
-# Para melhoria da aparência do Django Admin
-# https://github.com/fabiocaccamo/django-admin-interface
-django-admin-interface==0.12.2
 sentry-sdk==0.14.2  # https://github.com/getsentry/sentry-python
 
 # Gerador de PDF

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.2.20
+django==3.2.21
 django-auditlog==2.0.0
 
 # Dependências do Django Rest Framework

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,6 +3,7 @@
 # Dependencias revisadas
 psycopg2-binary==2.9.5
 
+django-extensions==3.2.3
 
 
 # Dependencias não revisadas
@@ -36,5 +37,4 @@ pre-commit==2.1.1  # https://github.com/pre-commit/pre-commit
 factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==2.2  # https://github.com/jazzband/django-debug-toolbar
-django-extensions==2.2.8  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==1.8.0  # https://github.com/nedbat/django_coverage_plugin

--- a/sme_ptrf_apps/users/forms.py
+++ b/sme_ptrf_apps/users/forms.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model, forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext as _
 
 User = get_user_model()
 

--- a/sme_ptrf_apps/users/models.py
+++ b/sme_ptrf_apps/users/models.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
 from django.db.models import CharField
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext as _
 
 from sme_ptrf_apps.core.models import Unidade
 from sme_ptrf_apps.core.models_abstracts import ModeloIdNome, ModeloBase


### PR DESCRIPTION
Esse PR:

- Atualiza a versão do Django para o último patch de segurança (3.2.21)
- Atualiza a versão de vários pacotes em preparação para a atualização para o Django 4.1.
- Altera usos da lib django.utils.translation deprecados no Django 3 e removidos no Django 4.

Atende AB#101828