### PR TITLE
feat(104193): Adiciona informação de conta encerrada com saldo no retorno de status período

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -261,6 +261,12 @@ class AssociacoesViewSet(ModelViewSet):
         else:
             pendencias_cadastrais = None
 
+        tem_conta_encerrada_com_saldo = False
+        contas = ContaAssociacao.encerradas.filter(associacao=associacao).all()
+        for conta in contas:
+            if conta.get_saldo_atual_conta() != 0:
+                tem_conta_encerrada_com_saldo = True
+
         result = {
             'associacao': f'{uuid}',
             'periodo_referencia': periodo_referencia,
@@ -270,7 +276,8 @@ class AssociacoesViewSet(ModelViewSet):
             'gerar_ou_editar_ata_apresentacao': gerar_ou_editar_ata_apresentacao,
             'gerar_ou_editar_ata_retificacao': gerar_ou_editar_ata_retificacao,
             'gerar_previas': gerar_previas,
-            'pendencias_cadastrais': pendencias_cadastrais
+            'pendencias_cadastrais': pendencias_cadastrais,
+            'tem_conta_encerrada_com_saldo': tem_conta_encerrada_com_saldo
         }
 
         return Response(result)

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from model_bakery import baker
 from sme_ptrf_apps.core.models.membro_associacao import MembroEnum, RepresentacaoCargo
+from sme_ptrf_apps.core.models import ContaAssociacao, SolicitacaoEncerramentoContaAssociacao
 
 @pytest.fixture
 def membro_associacao_001(associacao):
@@ -339,4 +340,73 @@ def membro_associacao_cadastro_incompleto_014(associacao_cadastro_incompleto):
         email='membroassociacao014@gmail.com',
         representacao=RepresentacaoCargo.SERVIDOR.name,
         codigo_identificacao='0014'
+    )
+
+@pytest.fixture
+def tipo_conta_encerramento_conta():
+    return baker.make(
+        'TipoConta',
+        nome='Cheque encerramento conta',
+        banco_nome='Banco do Inter',
+        agencia='67945',
+        numero_conta='935556-x',
+        numero_cartao='987644164221',
+        permite_inativacao=True
+    )
+
+@pytest.fixture
+def unidade_encerramento_conta(dre):
+    return baker.make(
+        'Unidade',
+        nome='Escola encerramento conta',
+        tipo_unidade='EMEI',
+        codigo_eol='270009',
+        dre=dre,
+        sigla='EA'
+    )
+
+
+@pytest.fixture
+def associacao_encerramento_conta(unidade_encerramento_conta, periodo_2020_1):
+    return baker.make(
+        'Associacao',
+        nome='Associacao 271170',
+        cnpj='62.738.735/0001-74',
+        unidade=unidade_encerramento_conta,
+        periodo_inicial=periodo_2020_1
+    )
+
+@pytest.fixture
+def conta_associacao_encerramento_conta(associacao_encerramento_conta, tipo_conta_encerramento_conta):
+    return baker.make(
+        'ContaAssociacao',
+        associacao=associacao_encerramento_conta,
+        tipo_conta=tipo_conta_encerramento_conta,
+        banco_nome='Banco do Brasil',
+        agencia='12345',
+        numero_conta='123456-x',
+        numero_cartao='534653264523',
+        status=ContaAssociacao.STATUS_INATIVA
+    )
+@pytest.fixture
+def solicitacao_encerramento_conta_aprovada(conta_associacao_encerramento_conta, periodo_2020_1):
+    return baker.make(
+        'SolicitacaoEncerramentoContaAssociacao',
+        conta_associacao=conta_associacao_encerramento_conta,
+        status=SolicitacaoEncerramentoContaAssociacao.STATUS_APROVADA,
+        data_de_encerramento_na_agencia=periodo_2020_1.data_inicio_realizacao_despesas,
+        data_aprovacao=periodo_2020_1.data_inicio_realizacao_despesas
+    )
+
+
+@pytest.fixture
+def receita_conta_encerrada(associacao_encerramento_conta, conta_associacao_encerramento_conta, acao_associacao, tipo_receita, periodo_2020_1):
+    return baker.make(
+        'Receita',
+        associacao=associacao_encerramento_conta,
+        data=periodo_2020_1.data_inicio_realizacao_despesas,
+        valor=100.00,
+        conta_associacao=conta_associacao_encerramento_conta,
+        acao_associacao=acao_associacao,
+        tipo_receita=tipo_receita,
     )

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -44,7 +44,8 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
                 'pendencia_contas': False,
                 'pendencia_membros': True
             }
-        }
+        },
+        'tem_conta_encerrada_com_saldo': False
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -83,7 +84,8 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
                 'pendencia_contas': False,
                 'pendencia_membros': True
             }
-        }
+        },
+        'tem_conta_encerrada_com_saldo': False
 
     }
 
@@ -126,7 +128,8 @@ def test_chamada_data_sem_periodo(jwt_authenticated_client_a, associacao, period
                 'pendencia_contas': False,
                 'pendencia_membros': True
             }
-        }
+        },
+        'tem_conta_encerrada_com_saldo': False
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -167,7 +170,8 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
                 'pendencia_contas': False,
                 'pendencia_membros': True
             }
-        }
+        },
+        'tem_conta_encerrada_com_saldo': False
 
     }
 
@@ -223,7 +227,8 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
                 'pendencia_contas': False,
                 'pendencia_membros': True
             }
-        }
+        },
+        'tem_conta_encerrada_com_saldo': False
 
     }
 
@@ -363,3 +368,22 @@ def test_status_periodo_todas_as_pendencias_cadastrais(
 
     assert response.status_code == status.HTTP_200_OK
     assert result['pendencias_cadastrais'] == pendencias_cadastrais_esperado
+
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_com_conta_encerrada_com_saldo(
+    jwt_authenticated_client_a,
+    periodo_2020_1,
+    conta_associacao_encerramento_conta,
+    solicitacao_encerramento_conta_aprovada,
+    receita_conta_encerrada
+):
+    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+                          content_type='application/json')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'tem_conta_encerrada_com_saldo' in result
+    assert result['tem_conta_encerrada_com_saldo'] == True
+
+


### PR DESCRIPTION
Esse PR:

- Adiciona informação de conta encerrada com saldo no retorno de status período
- Adiciona teste

História: AB#104193