### PR TITLE
feat(103823): Tratamento data inicial conta no crédito da escola

### DIFF
--- a/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
+++ b/sme_ptrf_apps/receitas/api/serializers/receita_serializer.py
@@ -65,6 +65,9 @@ class ReceitaCreateSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         conta_associacao = data['conta_associacao']
+        
+        if conta_associacao and (data['conta_associacao'].data_inicio > data['data']):
+            raise serializers.ValidationError({"mensagem": "A conta possui data de início posterior a data do crédito."})
 
         if conta_associacao.inativa:
             raise serializers.ValidationError({"mensagem": "Não é permitido criar/editar receita com conta inativada."})


### PR DESCRIPTION
Esse PR:

- Adiciona a validação para não permitir adicionar créditos em contas que não foram iniciadas ainda.

História: AB#103823