### PR TITLE
feat(104192): Não permite concluir analise pc com conta não zerada

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -262,11 +262,13 @@ class AssociacoesViewSet(ModelViewSet):
             pendencias_cadastrais = None
 
         tem_conta_encerrada_com_saldo = False
+        tipos_das_contas_encerradas_com_saldo = []
         contas = ContaAssociacao.encerradas.filter(associacao=associacao).all()
         for conta in contas:
             if conta.get_saldo_atual_conta() != 0:
                 tem_conta_encerrada_com_saldo = True
-
+                tipos_das_contas_encerradas_com_saldo.append(conta.tipo_conta.nome)
+                
         result = {
             'associacao': f'{uuid}',
             'periodo_referencia': periodo_referencia,
@@ -277,7 +279,8 @@ class AssociacoesViewSet(ModelViewSet):
             'gerar_ou_editar_ata_retificacao': gerar_ou_editar_ata_retificacao,
             'gerar_previas': gerar_previas,
             'pendencias_cadastrais': pendencias_cadastrais,
-            'tem_conta_encerrada_com_saldo': tem_conta_encerrada_com_saldo
+            'tem_conta_encerrada_com_saldo': tem_conta_encerrada_com_saldo,
+            'tipos_das_contas_encerradas_com_saldo': tipos_das_contas_encerradas_com_saldo
         }
 
         return Response(result)

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -45,7 +45,8 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
                 'pendencia_membros': True
             }
         },
-        'tem_conta_encerrada_com_saldo': False
+        'tem_conta_encerrada_com_saldo': False,
+        'tipos_das_contas_encerradas_com_saldo': []
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -85,8 +86,8 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
                 'pendencia_membros': True
             }
         },
-        'tem_conta_encerrada_com_saldo': False
-
+        'tem_conta_encerrada_com_saldo': False,
+        'tipos_das_contas_encerradas_com_saldo': []
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -129,7 +130,8 @@ def test_chamada_data_sem_periodo(jwt_authenticated_client_a, associacao, period
                 'pendencia_membros': True
             }
         },
-        'tem_conta_encerrada_com_saldo': False
+        'tem_conta_encerrada_com_saldo': False,
+        'tipos_das_contas_encerradas_com_saldo': []
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -171,8 +173,8 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
                 'pendencia_membros': True
             }
         },
-        'tem_conta_encerrada_com_saldo': False
-
+        'tem_conta_encerrada_com_saldo': False,
+        'tipos_das_contas_encerradas_com_saldo': []
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -228,8 +230,8 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
                 'pendencia_membros': True
             }
         },
-        'tem_conta_encerrada_com_saldo': False
-
+        'tem_conta_encerrada_com_saldo': False,
+        'tipos_das_contas_encerradas_com_saldo': []
     }
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Esse PR:

- Adiciona o retorno dos tipos de contas que estão encerradas e com saldos diferentes de zero.

História: AB#104192