### PR TITLE
feat(104709): Substitui a lib de autenticação JWT por outra compatível com Django 4

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -282,8 +282,7 @@ STATICFILES_FINDERS += ["compressor.finders.CompressorFinder"]
 # -------------------------------------------------------------------------------
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_jwt.authentication.JSONWebTokenAuthentication",
-        # "rest_framework.authentication.TokenAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
@@ -300,13 +299,11 @@ SPECTACULAR_SETTINGS = {
     'WARNINGS': False,
 }
 
-# JWT settings
+# SIMPLE JWT settings
 # ------------------------------------------------------------------------------
-JWT_AUTH = {
-    # TODO: rever a configuração...
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=100),
-    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(hours=100),
-    'JWT_ALLOW_REFRESH': True,
+SIMPLE_JWT = {
+    'AUTH_HEADER_TYPES': ('JWT',),
+    'ACCESS_TOKEN_LIFETIME': datetime.timedelta(hours=100),
 }
 
 # CORS SETTINGS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,96 +1,57 @@
-# DEPENDENCIAS JÁ REVISTAS
-
 # Django
 # ------------------------------------------------------------------------------
 django==3.2.21
-django-auditlog==2.0.0
-
-# Dependências do Django Rest Framework
-# ------------------------------------------------------------------------------
-drf-spectacular==0.26.2                 # Auto-generate OpenAPI 3.0 schemas from Django Rest Framework code
-
-# Django Admin Interface
-# Para melhoria da aparência do Django Admin
-# ------------------------------------------------------------------------------
 django-admin-interface==0.26.1
-
-# Celery
-# ------------------------------------------------------------------------------
-celery==5.2.1
-flower==1.2.0  # https://github.com/mher/flower
-
-# Solução para features flags
-# ------------------------------------------------------------------------------
-django-waffle==4.0.0
-
-# Outras dependências
-# ------------------------------------------------------------------------------
-Pillow==9.5.0
-python-slugify==8.0.1
+django-admin-rangefilter==0.5.4
 django-allauth==0.56.1
+django-auditlog==2.0.0
 django-ckeditor==6.7.0
 django-compressor==4.4
-rcssmin==1.1.1
+django-cors-headers
+django-crispy-forms==1.9.0
+django-environ==0.4.5
+django-filter==2.4.0
+django-mathfilters==1.0.0
+django-model-utils==4.0.0
+django-waffle==4.0.0                    # Solução para features flags
 
 # Django DES - EmailBackend that allows email configuration to be changed while the server is running.
 # Fork do django-des para suportar o Django 4
 git+https://github.com/prefeiturasp/django-des-fork.git#egg=django-des
 
-# Django REST Framework e plugins
+# Django Rest Framework
 # ------------------------------------------------------------------------------
-djangorestframework-simplejwt==5.3.0
+djangorestframework==3.11.0
+djangorestframework-simplejwt==5.3.0    # JWT authentication for DRF
+drf-spectacular==0.26.2                 # Auto-generate OpenAPI 3.0 schemas from Django Rest Framework code
 
-
-# DEPENDENCIAS AINDA NÃO REVISTAS
-
-pytz==2019.3  # https://github.com/stub42/pytz
-
-argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
-whitenoise==5.0.1  # https://github.com/evansd/whitenoise
-redis==3.4.1 # https://github.com/andymccurdy/redis-py
-
-django-celery-beat==2.1.0  # https://github.com/celery/django-celery-beat
-openpyxl==3.0.3
-
-# Django
+# Celery e Redis
 # ------------------------------------------------------------------------------
-django-environ==0.4.5  # https://github.com/joke2k/django-environ
-django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
-django-crispy-forms==1.9.0  # https://github.com/django-crispy-forms/django-crispy-forms
-
-django-redis==4.11.0  # https://github.com/niwinz/django-redis
-django-admin-rangefilter==0.5.4 # https://github.com/silentsokolov/django-admin-rangefilter
-
-# Django REST Framework
-djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
-
-# Para filtros no DRF
-# https://django-filter.readthedocs.io/en/master/#
-django-filter==2.4.0
-
-# djangorestframework-jwt==1.11.0  # https://getblimp.github.io/django-rest-framework-jwt/
-
-django-cors-headers # https://github.com/adamchainz/django-cors-headers
-
-
-# Para validação e formatação de CNPJ e CPF
-# https://github.com/poliquin/brazilnum
-brazilnum==0.8.8
-
-sentry-sdk==0.14.2  # https://github.com/getsentry/sentry-python
-
-# Gerador de PDF
-WeasyPrint==52.2
-django-weasyprint==1.0.2
-
-# Para somar valores nos templates (incluindo floats)
-django-mathfilters==1.0.0
+celery==5.2.1
+flower==1.2.0
+django-celery-beat==2.1.0
+redis==3.4.1
+django-redis==4.11.0
 
 # Integração com Kibana
+# ------------------------------------------------------------------------------
 elastic-apm==6.15.1
 psutil==5.9.4
 
-# Formatação de números
-# https://github.com/python-babel/babel
-
+# Outras libs e utilitários
+# ------------------------------------------------------------------------------
 Babel==2.12.1
+Pillow==9.5.0
+argon2-cffi==19.2.0
+brazilnum==0.8.8
+openpyxl==3.0.3
+python-slugify==8.0.1
+pytz==2019.3
+rcssmin==1.1.1
+sentry-sdk==0.14.2
+whitenoise==5.0.1
+
+# Gerador de PDF
+# ------------------------------------------------------------------------------
+WeasyPrint==52.2
+django-weasyprint==1.0.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,6 +36,10 @@ rcssmin==1.1.1
 # Fork do django-des para suportar o Django 4
 git+https://github.com/prefeiturasp/django-des-fork.git#egg=django-des
 
+# Django REST Framework e plugins
+# ------------------------------------------------------------------------------
+djangorestframework-simplejwt==5.3.0
+
 
 # DEPENDENCIAS AINDA NÃO REVISTAS
 
@@ -64,7 +68,7 @@ djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
 # https://django-filter.readthedocs.io/en/master/#
 django-filter==2.4.0
 
-djangorestframework-jwt==1.11.0  # https://getblimp.github.io/django-rest-framework-jwt/
+# djangorestframework-jwt==1.11.0  # https://getblimp.github.io/django-rest-framework-jwt/
 
 django-cors-headers # https://github.com/adamchainz/django-cors-headers
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,40 +1,34 @@
 -r ./base.txt
 
-# Dependencias revisadas
+# Banco de dados
+# ------------------------------------------------------------------------------
 psycopg2-binary==2.9.5
-
-django-extensions==3.2.3
-
-
-# Dependencias não revisadas
-
-Werkzeug==1.0.0 # https://github.com/pallets/werkzeug
-ipdb==0.13.1  # https://github.com/gotcha/ipdb
-Sphinx==2.4.3  # https://github.com/sphinx-doc/sphinx
-
-# Testing
-# ------------------------------------------------------------------------------
-mypy==1.3.0  # https://github.com/python/mypy
-django-stubs==4.2.1  # https://github.com/typeddjango/django-stubs
-pytest==7.3.2  # https://github.com/pytest-dev/pytest
-pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
-pytest-sugar==0.9.7  # https://github.com/Frozenball/pytest-sugar
-
-model-bakery==1.1.0 # https://model-bakery.readthedocs.io/en/latest/index.html
-freezegun==0.3.12 # https://github.com/spulec/freezegun
-
-# Code quality
-# ------------------------------------------------------------------------------
-flake8==3.7.9  # https://github.com/PyCQA/flake8
-coverage==5.0.3  # https://github.com/nedbat/coveragepy
-black==19.10b0  # https://github.com/ambv/black
-pylint-django==2.0.14  # https://github.com/PyCQA/pylint-django
-pylint-celery==0.3  # https://github.com/PyCQA/pylint-celery
-pre-commit==2.1.1  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
+Sphinx==2.4.3
+Werkzeug==1.0.0
+django-coverage-plugin==1.8.0
+django-debug-toolbar==2.2
+django-extensions==3.2.3
+ipdb==0.13.1
 
-django-debug-toolbar==2.2  # https://github.com/jazzband/django-debug-toolbar
-django-coverage-plugin==1.8.0  # https://github.com/nedbat/django_coverage_plugin
+# Testes Unitários
+# ------------------------------------------------------------------------------
+django-stubs==4.2.1
+factory-boy==2.12.0
+freezegun==0.3.12
+model-bakery==1.1.0
+mypy==1.3.0
+pytest-django==4.5.2
+pytest-sugar==0.9.7
+pytest==7.3.2
+
+# Qualidade de Código
+# ------------------------------------------------------------------------------
+black==19.10b0
+coverage==5.0.3
+flake8==3.7.9
+pre-commit==2.1.1
+pylint-celery==0.3
+pylint-django==2.0.14

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,13 +2,11 @@
 
 -r ./base.txt
 
-# Dependencias revisadas
+# Banco de dados
+# ------------------------------------------------------------------------------
 psycopg2==2.9.5 --no-binary psycopg2
-
-# Dependencias não revisadas
-
-gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 
 # Django
 # ------------------------------------------------------------------------------
-django-anymail[mailgun]==7.0.0  # https://github.com/anymail/django-anymail
+django-anymail[mailgun]==7.0.0
+gunicorn==20.0.4

--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -58,21 +58,8 @@ def usuario(unidade):
 
 @pytest.fixture
 def jwt_authenticated_client(client, usuario):
-    from unittest.mock import patch
     api_client = APIClient()
-    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
-        data = {
-            "nome": "LUCIA HELENA",
-            "cpf": "62085077072",
-            "email": "luh@gmail.com",
-            "login": "7210418"
-        }
-        mock_post.return_value.ok = True
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = data
-        resp = api_client.post('/api/login', {'login': usuario.username, 'senha': usuario.password}, format='json')
-        resp_data = resp.json()
-        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    api_client.force_authenticate(user=usuario)
     return api_client
 
 
@@ -2961,22 +2948,8 @@ def usuario_permissao_sme(unidade, grupo_sme):
 
 @pytest.fixture
 def jwt_authenticated_client_sme(client, usuario_permissao_sme):
-    from unittest.mock import patch
-    from rest_framework.test import APIClient
     api_client = APIClient()
-    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
-        data = {
-            "nome": "Usuario SME",
-            "cpf": "12345678910",
-            "email": "usuario.sme@gmail.com",
-            "login": "1235678"
-        }
-        mock_post.return_value.ok = True
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = data
-        resp = api_client.post('/api/login', {'login': usuario_permissao_sme.username, 'senha': usuario_permissao_sme.password}, format='json')
-        resp_data = resp.json()
-        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    api_client.force_authenticate(user=usuario_permissao_sme)
     return api_client
 
 

--- a/sme_ptrf_apps/core/tests/conftest.py
+++ b/sme_ptrf_apps/core/tests/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
 from django.contrib.auth.models import Permission
+
+from rest_framework.test import APIClient
+
 from model_bakery import baker
 
 from sme_ptrf_apps.users.models import Grupo
@@ -341,24 +344,8 @@ def usuario_permissao_associacao_so_leitura(
 
 @pytest.fixture
 def jwt_authenticated_client_a(client, usuario_permissao_associacao):
-    from unittest.mock import patch
-
-    from rest_framework.test import APIClient
     api_client = APIClient()
-    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
-        data = {
-            "nome": "LUCIA HELENA",
-            "cpf": "62085077072",
-            "email": "luh@gmail.com",
-            "login": "7210418"
-        }
-        mock_post.return_value.ok = True
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = data
-        resp = api_client.post('/api/login', {'login': usuario_permissao_associacao.username,
-                                              'senha': usuario_permissao_associacao.password}, format='json')
-        resp_data = resp.json()
-        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    api_client.force_authenticate(user=usuario_permissao_associacao)
     return api_client
 
 

--- a/sme_ptrf_apps/jwt_middleware.py
+++ b/sme_ptrf_apps/jwt_middleware.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.middleware import get_user
 from django.utils.functional import SimpleLazyObject
+from django.contrib.auth.models import AnonymousUser
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 
@@ -21,6 +22,6 @@ class JWTAuthenticationMiddleware:
             if authenticated_tuple:
                 user, jwt = authenticated_tuple
         except InvalidToken:
-            return None
+            return AnonymousUser()
 
-        return user if user and user.is_authenticated else None
+        return user if user and user.is_authenticated else AnonymousUser()

--- a/sme_ptrf_apps/receitas/tests/conftest.py
+++ b/sme_ptrf_apps/receitas/tests/conftest.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from model_bakery import baker
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APIClient
 
 from sme_ptrf_apps.core.models import PrestacaoConta
 from sme_ptrf_apps.users.models import Grupo
@@ -482,23 +482,8 @@ def usuario_permissao(unidade, grupo_receita):
 
 @pytest.fixture
 def jwt_authenticated_client_p(client, usuario_permissao):
-    from unittest.mock import patch
-    from rest_framework.test import APIClient
     api_client = APIClient()
-    with patch('sme_ptrf_apps.users.api.views.login.AutenticacaoService.autentica') as mock_post:
-        data = {
-            "nome": "LUCIA HELENA",
-            "cpf": "62085077072",
-            "email": "luh@gmail.com",
-            "login": "7210418"
-        }
-        mock_post.return_value.ok = True
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = data
-        resp = api_client.post('/api/login', {'login': usuario_permissao.username, 'senha': usuario_permissao.password},
-                               format='json')
-        resp_data = resp.json()
-        api_client.credentials(HTTP_AUTHORIZATION='JWT {0}'.format(resp_data['token']))
+    api_client.force_authenticate(user=usuario_permissao)
     return api_client
 
 

--- a/sme_ptrf_apps/users/api/views/login.py
+++ b/sme_ptrf_apps/users/api/views/login.py
@@ -3,7 +3,8 @@ import logging
 from django.contrib.auth import get_user_model
 from rest_framework import permissions, status
 from rest_framework.response import Response
-from rest_framework_jwt.views import ObtainJSONWebToken
+from rest_framework_simplejwt.views import TokenObtainPairView
+
 from waffle import get_waffle_flag_model
 
 from sme_ptrf_apps.users.api.services import AutenticacaoService
@@ -14,7 +15,7 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
-class LoginView(ObtainJSONWebToken):
+class LoginView(TokenObtainPairView):
     """
     POST auth/login/
     """
@@ -73,6 +74,10 @@ class LoginView(ObtainJSONWebToken):
                     user_dict['unidades'] = unidades
                     user_dict['permissoes'] = self.get_user_permissions(user)
                     user_dict['feature_flags'] = feature_flags
+
+                    # Para manter compatibilidade com o front que espera o token no campo token
+                    user_dict['token'] = resp.data['access']
+
                     data = {**user_dict, **resp.data}
                     return Response(data)
             return Response(response.json(), response.status_code)


### PR DESCRIPTION
Esse PR:

- Instala e configura o pacote djangorestframework-simplejwt
- Remove dos requirements o pacote djangorestframework-jwt
- Altera o middleware que injeta o usuário na requisição para que passe a usar a nova lib
- Altera a view de login para que passe a usar a nova lib
- Faz reorganização dos arquivos de requirements

Atende AB#104709