### PR TITLE
test: Adiciona library pytest-factoryboy

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -17,6 +17,7 @@ ipdb==0.13.1
 # ------------------------------------------------------------------------------
 django-stubs==4.2.1
 factory-boy==2.12.0
+pytest-factoryboy==2.5.1
 freezegun==0.3.12
 model-bakery==1.1.0
 mypy==1.3.0


### PR DESCRIPTION
Esse PR:

- Adiciona o pytest-factoryboy que facilita a combinação da abordagem de factories para a configuração de testes com a injeção de dependência, que é o cerne das fixtures do pytest.