### PR TITLE
fix(106328): Valida data_transacao da depesa de acordo com o período da pc devolvida

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -881,6 +881,14 @@ def prestacao_conta_iniciada(periodo_2020_1, associacao):
         associacao=associacao,
     )
 
+@pytest.fixture
+def prestacao_conta_2020_1_devolvida(periodo_2020_1, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_2020_1,
+        associacao=associacao,
+        status=PrestacaoConta.STATUS_DEVOLVIDA
+    )
 
 @pytest.fixture
 def prestacao_conta_devolvida(periodo, associacao):

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -113,6 +113,10 @@ class PrestacaoConta(ModeloBase):
     )
 
     @property
+    def devolvida_para_acertos(self):
+        return self.status == PrestacaoConta.STATUS_DEVOLVIDA
+
+    @property
     def tecnico_responsavel(self):
         atribuicoes = Atribuicao.search(
             **{'unidade__uuid': self.associacao.unidade.uuid, 'periodo__uuid': self.periodo.uuid})

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_put_despesas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_put_despesas.py
@@ -33,3 +33,27 @@ def test_api_post_despesas(
     despesa = Despesa.objects.get(uuid=result["uuid"])
 
     assert despesa.cpf_cnpj_fornecedor == payload_despesa_valida['cpf_cnpj_fornecedor']
+
+def test_api_post_validacao_data_transacao_despesa(
+    jwt_authenticated_client_d,
+    tipo_aplicacao_recurso,
+    tipo_custeio,
+    tipo_documento,
+    tipo_transacao,
+    acao,
+    acao_associacao,
+    associacao,
+    tipo_conta,
+    conta_associacao,
+    despesa,
+    rateio_despesa_capital,
+    prestacao_conta_2020_1_devolvida,
+    payload_despesa_valida,
+    periodo_2021_1
+):
+    payload_despesa_valida['data_transacao'] = '2021-03-10'
+    response = jwt_authenticated_client_d.put(f'/api/despesas/{despesa.uuid}/', data=json.dumps(payload_despesa_valida),
+                          content_type='application/json')
+
+    assert response.json() == {'mensagem': ['Permitido apenas datas dentro do período referente à devolução.']}
+    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
Esse PR:

- Valida data_transacao da depesa de acordo com o período da pc devolvida
- Ajusta update de despesa para registrar logs corretamente
- Adiciona teste de validação de data_transacao

História: AB#106328