### PR TITLE
feat(105498): Adicionar no relatorio consolidado unidades retificadas

### DIFF
--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -995,6 +995,21 @@ def atrelar_pc_ao_consolidado_dre(dre, periodo, consolidado_dre):
         logger.info(f'Atrelando Prestação ao Consolidado DRE: Prestação {prestacao}. Consolidado Dre {consolidado_dre}')
         consolidado_dre.vincular_pc_ao_consolidado(prestacao)
 
+def verifica_se_eh_relatorio_publicacoes_parciais(dre, periodo):
+    qtde_unidades_na_dre = Unidade.objects.filter(
+        dre_id=dre,
+    ).exclude(associacoes__cnpj__exact='').count()
+
+    qtde_pcs_publicadas_no_periodo_pela_dre = PrestacaoConta.objects.filter(
+        periodo=periodo,
+        status__in=['APROVADA', 'APROVADA_RESSALVA', 'REPROVADA'],
+        associacao__unidade__dre=dre,
+        publicada=True
+    ).count()
+
+    if (int(qtde_unidades_na_dre) == int(qtde_pcs_publicadas_no_periodo_pela_dre)):
+        return True
+    return False
 
 def gerar_relatorio_consolidado_dre(
     dre_uuid,

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
@@ -64,7 +64,11 @@
           <div>
             <span class="font-10 pt-2 pb-2">Coluna 18 - É a soma das colunas 12 a 17.</span>
             <br/>
-            <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada na referida publicação.</span>
+            {% if dados.execucao_fisica.eh_relatorio_consolidado_publicacoes_parciais %}
+              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada nas publicações parciais.</span>
+            {% else %}
+              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada na referida publicação.</span>
+            {% endif %}
           </div>
         </div>
 


### PR DESCRIPTION
Esse PR:

- Adiciona no relatório consolidado de publicações parciais o número de unidades que tiveram uma pc pelo menos uma vez retificada.
- Modifica a nota explicativa do relatório.
- Cria serviço para verificar quando o relatório é consolidado de publicações parciais.

História: AB#105498