### PR TITLE
feat(106214): Remove contas sem data de inicio do retorno da API

### DIFF
--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -366,7 +366,7 @@ class AssociacoesViewSet(ModelViewSet):
                     contas_criadas_nesse_periodo_ou_anteriores.append(conta)
             contas = contas_criadas_nesse_periodo_ou_anteriores
         else:
-            contas = ContaAssociacao.ativas_com_solicitacao_em_aberto.filter(associacao=associacao).all()
+            contas = ContaAssociacao.ativas_com_solicitacao_em_aberto.filter(associacao=associacao, data_inicio__isnull=False).all()
 
         contas_data = ContaAssociacaoDadosSerializer(contas, many=True).data
 

--- a/sme_ptrf_apps/core/fixtures/factories/tipo_conta_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/tipo_conta_factory.py
@@ -8,6 +8,7 @@ class TipoContaFactory(DjangoModelFactory):
     class Meta:
         model = TipoConta
         
+    nome = Sequence(lambda n: fake.unique.word())
     banco_nome = Sequence(lambda n: f"Banco {fake.unique.name()}")
     agencia = Sequence(lambda n: f"{str(fake.unique.random_int(min=1000, max=9999))}-{fake.random_number(digits=1)}")
     numero_conta = Sequence(lambda n: f"{str(fake.unique.random_int(min=10, max=99))}.{str(fake.unique.random_int(min=100, max=999))}-{fake.random_number(digits=1)}")

--- a/sme_ptrf_apps/core/tests/test_api_contas/test_get_contas.py
+++ b/sme_ptrf_apps/core/tests/test_api_contas/test_get_contas.py
@@ -1,0 +1,19 @@
+import pytest
+import json
+from rest_framework import status
+
+pytestmark = pytest.mark.django_db
+
+def test_api_resgata_apenas_contas_com_data_inicial(jwt_authenticated_client_a, conta_associacao_factory):
+    
+    conta_com_data_inicial = conta_associacao_factory.create()
+    
+    conta_sem_data_inicial = conta_associacao_factory.create(associacao=conta_com_data_inicial.associacao, data_inicio=None)
+    
+    url = f'/api/associacoes/{conta_com_data_inicial.associacao.uuid}/contas/'
+    
+    response = jwt_authenticated_client_a.get(url, content_type='application/json')
+    result = json.loads(response.content)    
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(result) == 1


### PR DESCRIPTION
Esse PR:

- Remove contas sem data inicial do retorno da API.
- Corrige factory de tipos de conta adicionando nome único.
- Cria testes relacionados.

História: AB#106214