### PR TITLE
fix(107380): Ignora contas não iniciadas para valores reprogramados

### DIFF
--- a/sme_ptrf_apps/dre/services/valores_reprogramados_dre_service.py
+++ b/sme_ptrf_apps/dre/services/valores_reprogramados_dre_service.py
@@ -175,6 +175,9 @@ def monta_estrutura_valores_reprogramados(associacao):
     lista_contas = []
 
     for conta_associacao in associacao.contas.all():
+        if not conta_associacao.ativa_no_periodo(associacao.periodo_inicial):
+            continue
+
         acoes = []
 
         for acao_associacao in associacao.acoes.exclude(acao__e_recursos_proprios=True):


### PR DESCRIPTION
Esse PR:

- Altera o método que retorna a estrutura dos valores reprogramados para desconsiderar contas ainda não iniciadas. 

Resolve AB#107380