### PR TITLE
feat(103306): Atualiza Django para  4.2.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Django
 # ------------------------------------------------------------------------------
-django==4.1.12
+django==4.2.7
 django-admin-interface==0.26.1
 django-admin-rangefilter==0.5.4
 django-allauth==0.56.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,7 +7,7 @@ psycopg2-binary==2.9.5
 # Django
 # ------------------------------------------------------------------------------
 Sphinx==2.4.3
-Werkzeug==2.2.3
+Werkzeug==3.0.1
 django-coverage-plugin==1.8.0
 django-debug-toolbar==4.2.0
 django-extensions==3.2.3

--- a/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
+++ b/sme_ptrf_apps/core/api/views/demonstrativo_financeiro_viewset.py
@@ -269,32 +269,6 @@ class DemonstrativoFinanceiroViewSet(GenericViewSet):
 
         return Response(result)
 
-    # TODO Estava dando erro na atualização do DRF 3.14. Aparentemente não é usado. Confirmar e remover.
-    # @action(detail=False, methods=['get'], url_path='__demonstrativo-info',
-    #         permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
-    # def __demonstrativo_info(self, request):
-    #     acao_associacao_uuid = self.request.query_params.get('acao-associacao')
-    #     conta_associacao_uuid = self.request.query_params.get('conta-associacao')
-    #     periodo_uuid = self.request.query_params.get('periodo')
-    #
-    #     if not acao_associacao_uuid or not conta_associacao_uuid or not periodo_uuid:
-    #         erro = {
-    #             'erro': 'parametros_requeridos',
-    #             'mensagem': 'É necessário enviar o uuid do período, o uuid da ação da associação e o uuid da conta da associação.'
-    #         }
-    #         return Response(erro, status=status.HTTP_400_BAD_REQUEST)
-    #
-    #     conta_associacao = ContaAssociacao.by_uuid(conta_associacao_uuid)
-    #     prestacao_conta = PrestacaoConta.objects.filter(associacao=conta_associacao.associacao,
-    #                                                     periodo__uuid=periodo_uuid).first()
-    #
-    #     demonstrativo_financeiro = DemonstrativoFinanceiro.objects.filter(acao_associacao__uuid=acao_associacao_uuid,
-    #                                                                       conta_associacao__uuid=conta_associacao_uuid,
-    #                                                                       prestacao_conta=prestacao_conta).last()
-    #     msg = str(demonstrativo_financeiro) if demonstrativo_financeiro else 'Documento pendente de geração'
-    #
-    #     return Response(msg)
-
     @action(detail=False, methods=['get'], url_path='demonstrativo-info',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def demonstrativo_info(self, request):

--- a/sme_ptrf_apps/core/models/fechamento_periodo.py
+++ b/sme_ptrf_apps/core/models/fechamento_periodo.py
@@ -306,6 +306,7 @@ class FechamentoPeriodo(ModeloBase):
     @classmethod
     def implanta_saldo(cls, acao_associacao, conta_associacao, aplicacao, saldo):
         total_receitas_field = f'total_receitas_{aplicacao.lower()}'
+        saldo_reprogramado_field = f'saldo_reprogramado_{aplicacao.lower()}'
         fechamento_implantacao = cls.objects.update_or_create(
             periodo=conta_associacao.associacao.periodo_inicial,
             associacao=conta_associacao.associacao,
@@ -315,6 +316,7 @@ class FechamentoPeriodo(ModeloBase):
                 total_receitas_field: saldo,
                 'fechamento_anterior': None,
                 'status': STATUS_IMPLANTACAO,
+                saldo_reprogramado_field: 0,  # Será recalculado no pre_save, mas precisa ser informado aqui a partir do Django 4.2
             }
         )
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_implantacao_saldos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_implantacao_saldos.py
@@ -1,302 +1,355 @@
 import json
+from decimal import Decimal
 
 import pytest
 from rest_framework import status
 
-from ...models import Associacao
+from ...models import Associacao, FechamentoPeriodo
 
 pytestmark = pytest.mark.django_db
 
 
-def test_get_permite_implantacao_ok(jwt_authenticated_client_a, associacao, periodo_anterior):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/',
-                          content_type='application/json')
+def test_get_permite_implantacao_ok(
+    jwt_authenticated_client_a, associacao, periodo_anterior
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'permite_implantacao': True,
-        'erro': '',
-        'mensagem': 'Os saldos podem ser implantados normalmente.'
+        "permite_implantacao": True,
+        "erro": "",
+        "mensagem": "Os saldos podem ser implantados normalmente.",
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_get_permite_implantacao_sem_periodo_inicial_definido(jwt_authenticated_client_a, associacao_sem_periodo_inicial,
-                                                              periodo_anterior):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_sem_periodo_inicial.uuid}/permite-implantacao-saldos/',
-                          content_type='application/json')
+def test_get_permite_implantacao_sem_periodo_inicial_definido(
+    jwt_authenticated_client_a, associacao_sem_periodo_inicial, periodo_anterior
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao_sem_periodo_inicial.uuid}/permite-implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'permite_implantacao': False,
-        'erro': 'periodo_inicial_nao_definido',
-        'mensagem': 'Período inicial não foi definido para essa associação. Verifique com o administrador.'
+        "permite_implantacao": False,
+        "erro": "periodo_inicial_nao_definido",
+        "mensagem": "Período inicial não foi definido para essa associação. Verifique com o administrador.",
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_get_permite_implantacao_com_prestacao_contas(jwt_authenticated_client_a, associacao, periodo_anterior, prestacao_conta_iniciada,
-                                                      acao_associacao_role_cultural, conta_associacao):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/',
-                          content_type='application/json')
+def test_get_permite_implantacao_com_prestacao_contas(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    prestacao_conta_iniciada,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'permite_implantacao': False,
-        'erro': 'prestacao_de_contas_nao-encontrada',
-        'mensagem': 'Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial'
-                    ' e devolivida.'
+        "permite_implantacao": False,
+        "erro": "prestacao_de_contas_nao-encontrada",
+        "mensagem": "Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial"
+        " e devolivida.",
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_get_permite_implantacao_com_prestacao_contas_devolvida(jwt_authenticated_client_a, associacao,
-                                                                periodo_anterior, prestacao_conta_devolvida,
-                                                                acao_associacao_role_cultural, conta_associacao):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/',
-                                              content_type='application/json')
+def test_get_permite_implantacao_com_prestacao_contas_devolvida(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    prestacao_conta_devolvida,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'permite_implantacao': True,
-        'erro': '',
-        'mensagem': 'Os saldos podem ser implantados normalmente.'
+        "permite_implantacao": True,
+        "erro": "",
+        "mensagem": "Os saldos podem ser implantados normalmente.",
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_get_permite_implantacao_com_prestacao_contas_devolvida_periodo_posterior(jwt_authenticated_client_a,
-                                                                                  associacao,
-                                                                                  periodo_anterior,
-                                                                                  prestacao_conta_devolvida_posterior,
-                                                                                  acao_associacao_role_cultural,
-                                                                                  conta_associacao):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/',
-                                              content_type='application/json')
+def test_get_permite_implantacao_com_prestacao_contas_devolvida_periodo_posterior(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    prestacao_conta_devolvida_posterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/permite-implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'permite_implantacao': False,
-        'erro': 'prestacao_de_contas_nao-encontrada',
-        'mensagem': 'Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial'
-                    ' e devolivida.'
+        "permite_implantacao": False,
+        "erro": "prestacao_de_contas_nao-encontrada",
+        "mensagem": "Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial"
+        " e devolivida.",
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_retrieve_implanta_saldos_saldos_ainda_nao_implantados(jwt_authenticated_client_a, associacao, periodo_anterior):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_saldos_ainda_nao_implantados(
+    jwt_authenticated_client_a, associacao, periodo_anterior
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'associacao': f'{associacao.uuid}',
-        'periodo': {
-            'referencia': '2019.1',
-            'data_inicio_realizacao_despesas': '2019-01-01',
-            'data_fim_realizacao_despesas': '2019-08-31',
-            'referencia_por_extenso': '1° repasse de 2019',
-            'uuid': f'{periodo_anterior.uuid}'
+        "associacao": f"{associacao.uuid}",
+        "periodo": {
+            "referencia": "2019.1",
+            "data_inicio_realizacao_despesas": "2019-01-01",
+            "data_fim_realizacao_despesas": "2019-08-31",
+            "referencia_por_extenso": "1° repasse de 2019",
+            "uuid": f"{periodo_anterior.uuid}",
         },
-        'saldos': [],
+        "saldos": [],
     }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
 
-def test_retrieve_implanta_saldos_saldos_ja_implantados(jwt_authenticated_client_a, associacao, periodo_anterior,
-                                                        fechamento_periodo_anterior_role_implantado,
-                                                        acao_associacao_role_cultural,
-                                                        conta_associacao):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_saldos_ja_implantados(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    fechamento_periodo_anterior_role_implantado,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    assert 'saldos' in result
+    assert "saldos" in result
 
     saldos_esperados = [
-        {
-            'saldo':1000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        },
-        {
-            'saldo': 2000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        }
+        {"saldo": 1000.0, "conta_uuid": f"{conta_associacao.uuid}"},
+        {"saldo": 2000.0, "conta_uuid": f"{conta_associacao.uuid}"},
     ]
 
     result_saldos = []
-    for saldo in result['saldos']:
-        result_saldos.append({
-            'saldo': saldo['saldo'],
-            'conta_uuid': saldo['conta_associacao']['uuid']
-        })
+    for saldo in result["saldos"]:
+        result_saldos.append(
+            {"saldo": saldo["saldo"], "conta_uuid": saldo["conta_associacao"]["uuid"]}
+        )
 
     assert response.status_code == status.HTTP_200_OK
     assert result_saldos == saldos_esperados
 
 
-def test_retrieve_implanta_saldos_saldos_ja_implantados_com_pc_devolvida(jwt_authenticated_client_a, associacao,
-                                                                         periodo_anterior,
-                                                                         fechamento_periodo_anterior_role_implantado,
-                                                                         acao_associacao_role_cultural,
-                                                                         conta_associacao,
-                                                                         prestacao_conta_devolvida
-                                                                         ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_saldos_ja_implantados_com_pc_devolvida(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    fechamento_periodo_anterior_role_implantado,
+    acao_associacao_role_cultural,
+    conta_associacao,
+    prestacao_conta_devolvida,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    assert 'saldos' in result
+    assert "saldos" in result
 
     saldos_esperados = [
-        {
-            'saldo':1000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        },
-        {
-            'saldo': 2000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        }
+        {"saldo": 1000.0, "conta_uuid": f"{conta_associacao.uuid}"},
+        {"saldo": 2000.0, "conta_uuid": f"{conta_associacao.uuid}"},
     ]
 
     result_saldos = []
-    for saldo in result['saldos']:
-        result_saldos.append({
-            'saldo': saldo['saldo'],
-            'conta_uuid': saldo['conta_associacao']['uuid']
-        })
+    for saldo in result["saldos"]:
+        result_saldos.append(
+            {"saldo": saldo["saldo"], "conta_uuid": saldo["conta_associacao"]["uuid"]}
+        )
 
     assert response.status_code == status.HTTP_200_OK
     assert result_saldos == saldos_esperados
 
 
-def test_retrieve_implanta_saldos_saldos_ja_implantados_com_pc_devolvida_posterior(jwt_authenticated_client_a,
-                                                                                   associacao,
-                                                                                   periodo_anterior,
-                                                                                   fechamento_periodo_anterior_role_implantado,
-                                                                                   acao_associacao_role_cultural,
-                                                                                   conta_associacao,
-                                                                                   prestacao_conta_devolvida_posterior
-                                                                                   ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_saldos_ja_implantados_com_pc_devolvida_posterior(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    fechamento_periodo_anterior_role_implantado,
+    acao_associacao_role_cultural,
+    conta_associacao,
+    prestacao_conta_devolvida_posterior,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'erro': 'prestacao_de_contas_nao-encontrada',
-        'mensagem': 'Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial'
-                    ' e devolivida.'
+        "erro": "prestacao_de_contas_nao-encontrada",
+        "mensagem": "Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial"
+        " e devolivida.",
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert result == esperado
 
 
-def test_retrieve_implanta_saldos_sem_periodo_inicial_definido(jwt_authenticated_client_a, associacao_sem_periodo_inicial,
-                                                               periodo_anterior):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_sem_periodo_inicial.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_sem_periodo_inicial_definido(
+    jwt_authenticated_client_a, associacao_sem_periodo_inicial, periodo_anterior
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao_sem_periodo_inicial.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'erro': 'periodo_inicial_nao_definido',
-        'mensagem': 'Período inicial não foi definido para essa associação. Verifique com o administrador.'
+        "erro": "periodo_inicial_nao_definido",
+        "mensagem": "Período inicial não foi definido para essa associação. Verifique com o administrador.",
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert result == esperado
 
 
-def test_post_implanta_saldos_com_prestacao_contas(jwt_authenticated_client_a, associacao, periodo_anterior, prestacao_conta_iniciada,
-                                                   acao_associacao_role_cultural, conta_associacao):
+def test_post_implanta_saldos_com_prestacao_contas(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    prestacao_conta_iniciada,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
     payload = {
-        'saldos': [
+        "saldos": [
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 1000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 1000.0,
             },
         ],
     }
 
-    response = jwt_authenticated_client_a.post(f'/api/associacoes/{associacao.uuid}/implanta-saldos/', data=json.dumps(payload),
-                           content_type='application/json')
+    response = jwt_authenticated_client_a.post(
+        f"/api/associacoes/{associacao.uuid}/implanta-saldos/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'erro': 'prestacao_de_contas_nao-encontrada',
-        'mensagem': 'Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial'
-                    ' e devolivida.'
+        "erro": "prestacao_de_contas_nao-encontrada",
+        "mensagem": "Os saldos não podem ser implantados, não existe uma prestação de contas do periodo inicial"
+        " e devolivida.",
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert result == esperado
 
 
-def test_post_implanta_saldos_sem_prestacao_contas(jwt_authenticated_client_a, associacao, periodo_anterior, acao_associacao_role_cultural,
-                                                   conta_associacao):
+def test_post_implanta_saldos_sem_prestacao_contas(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
     payload = {
-        'saldos': [
+        "saldos": [
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 1000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 1000.0,
             },
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CUSTEIO',
-                'saldo': 2000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CUSTEIO",
+                "saldo": 2000.0,
             },
         ],
     }
 
-    response = jwt_authenticated_client_a.post(f'/api/associacoes/{associacao.uuid}/implanta-saldos/', data=json.dumps(payload),
-                           content_type='application/json')
+    response = jwt_authenticated_client_a.post(
+        f"/api/associacoes/{associacao.uuid}/implanta-saldos/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    esperado = {'associacao': f'{associacao.uuid}',
-                'periodo': {'data_fim_realizacao_despesas': '2019-08-31',
-                            'data_inicio_realizacao_despesas': '2019-01-01',
-                            'referencia': '2019.1',
-                            'referencia_por_extenso': '1° repasse de 2019',
-                            'uuid': f'{periodo_anterior.uuid}'},
-                'saldos': [
-                    {
-                        'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                        'aplicacao': 'CAPITAL',
-                        'conta_associacao': f'{conta_associacao.uuid}',
-                        'saldo': 1000.0
-                    },
-                    {
-                        'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                        'aplicacao': 'CUSTEIO',
-                        'conta_associacao': f'{conta_associacao.uuid}',
-                        'saldo': 2000.0
-                    }
-                ]
-                }
+    esperado = {
+        "associacao": f"{associacao.uuid}",
+        "periodo": {
+            "data_fim_realizacao_despesas": "2019-08-31",
+            "data_inicio_realizacao_despesas": "2019-01-01",
+            "referencia": "2019.1",
+            "referencia_por_extenso": "1° repasse de 2019",
+            "uuid": f"{periodo_anterior.uuid}",
+        },
+        "saldos": [
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "CAPITAL",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 1000.0,
+            },
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "CUSTEIO",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 2000.0,
+            },
+        ],
+    }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
     assert Associacao.by_uuid(associacao.uuid).fechamentos_associacao.exists()
     implantacao = Associacao.by_uuid(associacao.uuid).fechamentos_associacao.first()
-    assert implantacao.status == 'IMPLANTACAO'
+    assert implantacao.status == "IMPLANTACAO"
     assert implantacao.total_receitas_capital == 1000.0
     assert implantacao.total_receitas_custeio == 2000.0
     assert implantacao.conta_associacao == conta_associacao
@@ -305,33 +358,50 @@ def test_post_implanta_saldos_sem_prestacao_contas(jwt_authenticated_client_a, a
     assert implantacao.saldo_reprogramado_custeio == 2000.0
 
 
-def test_post_implanta_saldos_ja_existente(jwt_authenticated_client_a, associacao, periodo_anterior, acao_associacao_role_cultural,
-                                           conta_associacao, fechamento_periodo_anterior_role_implantado):
+def test_post_implanta_saldos_ja_existente(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+    fechamento_periodo_anterior_role_implantado,
+):
     payload = {
-        'saldos': [
+        "saldos": [
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 1000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 1000.0,
             },
         ],
     }
 
-    response = jwt_authenticated_client_a.post(f'/api/associacoes/{associacao.uuid}/implanta-saldos/', data=json.dumps(payload),
-                           content_type='application/json')
+    response = jwt_authenticated_client_a.post(
+        f"/api/associacoes/{associacao.uuid}/implanta-saldos/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    esperado = {'associacao': f'{associacao.uuid}',
-                'periodo': {'data_fim_realizacao_despesas': '2019-08-31',
-                            'data_inicio_realizacao_despesas': '2019-01-01',
-                            'referencia': '2019.1',
-                            'referencia_por_extenso': '1° repasse de 2019',
-                            'uuid': f'{periodo_anterior.uuid}'},
-                'saldos': [{'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                            'aplicacao': 'CAPITAL',
-                            'conta_associacao': f'{conta_associacao.uuid}',
-                            'saldo': 1000.0}]}
+    esperado = {
+        "associacao": f"{associacao.uuid}",
+        "periodo": {
+            "data_fim_realizacao_despesas": "2019-08-31",
+            "data_inicio_realizacao_despesas": "2019-01-01",
+            "referencia": "2019.1",
+            "referencia_por_extenso": "1° repasse de 2019",
+            "uuid": f"{periodo_anterior.uuid}",
+        },
+        "saldos": [
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "CAPITAL",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 1000.0,
+            }
+        ],
+    }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
@@ -340,32 +410,40 @@ def test_post_implanta_saldos_ja_existente(jwt_authenticated_client_a, associaca
     assert Associacao.by_uuid(associacao.uuid).fechamentos_associacao.count() == 1
 
 
-def test_post_implanta_saldos_duplicados(jwt_authenticated_client_a, associacao, periodo_anterior, acao_associacao_role_cultural,
-                                         conta_associacao):
+def test_post_implanta_saldos_duplicados(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
     payload = {
-        'saldos': [
+        "saldos": [
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 1000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 1000.0,
             },
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 100.0
-            }
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 100.0,
+            },
         ],
     }
 
-    response = jwt_authenticated_client_a.post(f'/api/associacoes/{associacao.uuid}/implanta-saldos/', data=json.dumps(payload),
-                           content_type='application/json')
+    response = jwt_authenticated_client_a.post(
+        f"/api/associacoes/{associacao.uuid}/implanta-saldos/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
     esperado = {
-        'erro': 'informacoes_repetidas',
-        'mensagem': 'Existem valores repetidos de Ação, Conta e Aplicação. Verifique.'
+        "erro": "informacoes_repetidas",
+        "mensagem": "Existem valores repetidos de Ação, Conta e Aplicação. Verifique.",
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -374,105 +452,112 @@ def test_post_implanta_saldos_duplicados(jwt_authenticated_client_a, associacao,
     assert Associacao.by_uuid(associacao.uuid).fechamentos_associacao.count() == 0
 
 
-def test_retrieve_implanta_saldos_saldos_ja_implantados_livre_aplicacao(jwt_authenticated_client_a, associacao, periodo_anterior,
-                                                                        fechamento_periodo_anterior_role_implantado_com_livre_aplicacao,
-                                                                        acao_associacao_role_cultural,
-                                                                        conta_associacao):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/implantacao-saldos/',
-                          content_type='application/json')
+def test_retrieve_implanta_saldos_saldos_ja_implantados_livre_aplicacao(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    fechamento_periodo_anterior_role_implantado_com_livre_aplicacao,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    response = jwt_authenticated_client_a.get(
+        f"/api/associacoes/{associacao.uuid}/implantacao-saldos/",
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    assert 'saldos' in result
+    assert "saldos" in result
 
     saldos_esperados = [
-        {
-            'saldo':1000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        },
-        {
-            'saldo': 2000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        },
-        {
-            'saldo': 3000.0,
-            'conta_uuid': f'{conta_associacao.uuid}'
-        }
+        {"saldo": 1000.0, "conta_uuid": f"{conta_associacao.uuid}"},
+        {"saldo": 2000.0, "conta_uuid": f"{conta_associacao.uuid}"},
+        {"saldo": 3000.0, "conta_uuid": f"{conta_associacao.uuid}"},
     ]
 
     result_saldos = []
-    for saldo in result['saldos']:
-        result_saldos.append({
-            'saldo': saldo['saldo'],
-            'conta_uuid': saldo['conta_associacao']['uuid']
-        })
+    for saldo in result["saldos"]:
+        result_saldos.append(
+            {"saldo": saldo["saldo"], "conta_uuid": saldo["conta_associacao"]["uuid"]}
+        )
 
     assert response.status_code == status.HTTP_200_OK
     assert result_saldos == saldos_esperados
 
-def test_post_implanta_saldos_sem_prestacao_contas_com_livre_utilizacao(jwt_authenticated_client_a, associacao, periodo_anterior,
-                                                                        acao_associacao_role_cultural,
-                                                                        conta_associacao):
+
+def test_post_implanta_saldos_sem_prestacao_contas_com_livre_utilizacao(
+    jwt_authenticated_client_a,
+    associacao,
+    periodo_anterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
     payload = {
-        'saldos': [
+        "saldos": [
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CAPITAL',
-                'saldo': 1000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CAPITAL",
+                "saldo": 1000.0,
             },
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'CUSTEIO',
-                'saldo': 2000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "CUSTEIO",
+                "saldo": 2000.0,
             },
             {
-                'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                'conta_associacao': f'{conta_associacao.uuid}',
-                'aplicacao': 'LIVRE',
-                'saldo': 3000.0
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "aplicacao": "LIVRE",
+                "saldo": 3000.0,
             },
         ],
     }
 
-    response = jwt_authenticated_client_a.post(f'/api/associacoes/{associacao.uuid}/implanta-saldos/', data=json.dumps(payload),
-                           content_type='application/json')
+    response = jwt_authenticated_client_a.post(
+        f"/api/associacoes/{associacao.uuid}/implanta-saldos/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
     result = json.loads(response.content)
 
-    esperado = {'associacao': f'{associacao.uuid}',
-                'periodo': {'data_fim_realizacao_despesas': '2019-08-31',
-                            'data_inicio_realizacao_despesas': '2019-01-01',
-                            'referencia': '2019.1',
-                            'referencia_por_extenso': '1° repasse de 2019',
-                            'uuid': f'{periodo_anterior.uuid}'},
-                'saldos': [
-                    {
-                        'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                        'aplicacao': 'CAPITAL',
-                        'conta_associacao': f'{conta_associacao.uuid}',
-                        'saldo': 1000.0
-                    },
-                    {
-                        'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                        'aplicacao': 'CUSTEIO',
-                        'conta_associacao': f'{conta_associacao.uuid}',
-                        'saldo': 2000.0
-                    },
-                    {
-                        'acao_associacao': f'{acao_associacao_role_cultural.uuid}',
-                        'aplicacao': 'LIVRE',
-                        'conta_associacao': f'{conta_associacao.uuid}',
-                        'saldo': 3000.0
-                    }
-                ]
-                }
+    esperado = {
+        "associacao": f"{associacao.uuid}",
+        "periodo": {
+            "data_fim_realizacao_despesas": "2019-08-31",
+            "data_inicio_realizacao_despesas": "2019-01-01",
+            "referencia": "2019.1",
+            "referencia_por_extenso": "1° repasse de 2019",
+            "uuid": f"{periodo_anterior.uuid}",
+        },
+        "saldos": [
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "CAPITAL",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 1000.0,
+            },
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "CUSTEIO",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 2000.0,
+            },
+            {
+                "acao_associacao": f"{acao_associacao_role_cultural.uuid}",
+                "aplicacao": "LIVRE",
+                "conta_associacao": f"{conta_associacao.uuid}",
+                "saldo": 3000.0,
+            },
+        ],
+    }
 
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
     assert Associacao.by_uuid(associacao.uuid).fechamentos_associacao.exists()
     implantacao = Associacao.by_uuid(associacao.uuid).fechamentos_associacao.first()
-    assert implantacao.status == 'IMPLANTACAO'
+    assert implantacao.status == "IMPLANTACAO"
     assert implantacao.total_receitas_capital == 1000.0
     assert implantacao.total_receitas_custeio == 2000.0
     assert implantacao.total_receitas_livre == 3000.0
@@ -481,3 +566,20 @@ def test_post_implanta_saldos_sem_prestacao_contas_com_livre_utilizacao(jwt_auth
     assert implantacao.saldo_reprogramado_capital == 1000.0
     assert implantacao.saldo_reprogramado_custeio == 2000.0
     assert implantacao.saldo_reprogramado_livre == 3000.0
+
+
+def test_metodo_implanta_saldo(
+    associacao,
+    periodo_anterior,
+    acao_associacao_role_cultural,
+    conta_associacao,
+):
+    FechamentoPeriodo.implanta_saldo(
+        acao_associacao_role_cultural, conta_associacao, "CAPITAL", Decimal(1000.0)
+    )
+    assert FechamentoPeriodo.objects.first().saldo_reprogramado_capital == 1000.0
+
+    FechamentoPeriodo.implanta_saldo(
+        acao_associacao_role_cultural, conta_associacao, "CUSTEIO", Decimal(2000.0)
+    )
+    assert FechamentoPeriodo.objects.first().saldo_reprogramado_custeio == 2000.0


### PR DESCRIPTION
Esse PR:

- Atualiza o Django para a versão 4.2.7
- Ajusta o código do método de implantação de saldo para se adequar a nova versão
- Atualiza o pacote Werkzeug para resolver vulnerabilidade
- Remove bloco de código comentado

Atende AB#103306