### PR TITLE
feat(108932): Nao permitir carga repasse realizado em contas encerradas

### DIFF
--- a/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
@@ -213,7 +213,11 @@ def processa_repasse(reader, tipo_conta, arquivo):
                 if start < conta_associacao.data_inicio:
                     msg_erro = f"O período informado de repasse é anterior ao período de criação da conta."
                     raise Exception(msg_erro)
-
+                
+                if hasattr(conta_associacao, 'solicitacao_encerramento') and conta_associacao.solicitacao_encerramento.aprovada:
+                    msg_erro = "A conta possui pedido de encerramento aprovado pela DRE."
+                    raise Exception(msg_erro)
+                
             if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
                 repasse = Repasse.objects.create(
                     associacao=associacao,


### PR DESCRIPTION
Esse PR:

- Adiciona a verificação de conta encerrada para arquivos de carga de repasses realizados.

História: AB#108932