### PR TITLE
feat(108932): Não permitir carga repasse realizados conta encerrada

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -31,6 +31,10 @@ from sme_ptrf_apps.core.fixtures.factories.prestacao_conta_factory import Presta
 from sme_ptrf_apps.users.fixtures.factories.usuario_factory import UsuarioFactory
 from sme_ptrf_apps.users.fixtures.factories.grupo_acesso_factory import GrupoAcessoFactory
 from sme_ptrf_apps.users.fixtures.factories.visao_factory import VisaoFactory
+from sme_ptrf_apps.core.fixtures.factories.acao_factory import AcaoFactory
+from sme_ptrf_apps.core.fixtures.factories.arquivo_factory import ArquivoFactory
+from sme_ptrf_apps.core.fixtures.factories.solicitacao_encerramento_conta_associacao_factory import SolicitacaoEncerramentoContaAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
 
 from sme_ptrf_apps.fixtures import *
 
@@ -45,6 +49,10 @@ register(PrestacaoContaFactory)
 register(UsuarioFactory)
 register(GrupoAcessoFactory)
 register(VisaoFactory)
+register(SolicitacaoEncerramentoContaAssociacaoFactory)
+register(ArquivoFactory)
+register(AcaoFactory)
+register(AcaoAssociacaoFactory)
 
 @pytest.fixture
 def fake_user(client, django_user_model, unidade):

--- a/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
@@ -1,0 +1,11 @@
+from factory import DjangoModelFactory
+from faker import Faker
+from sme_ptrf_apps.core.models.acao_associacao import AcaoAssociacao
+
+fake = Faker("pt_BR")
+
+class AcaoAssociacaoFactory(DjangoModelFactory):
+    class Meta:
+        model = AcaoAssociacao
+
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/core/fixtures/factories/acao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/acao_factory.py
@@ -1,0 +1,11 @@
+from factory import DjangoModelFactory
+from faker import Faker
+from sme_ptrf_apps.core.models.acao import Acao
+
+fake = Faker("pt_BR")
+
+class AcaoFactory(DjangoModelFactory):
+    class Meta:
+        model = Acao
+
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/core/fixtures/factories/arquivo_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/arquivo_factory.py
@@ -1,0 +1,11 @@
+from factory import DjangoModelFactory
+from faker import Faker
+from sme_ptrf_apps.core.models.arquivo import Arquivo
+
+fake = Faker("pt_BR")
+
+class ArquivoFactory(DjangoModelFactory):
+    class Meta:
+        model = Arquivo
+
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/core/fixtures/factories/periodo_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/periodo_factory.py
@@ -12,3 +12,5 @@ class PeriodoFactory(DjangoModelFactory):
     data_inicio_realizacao_despesas = Sequence(lambda n: fake.date_between_dates(date_start=datetime(2019, 1, 1), date_end=datetime.today()))
     data_fim_realizacao_despesas = LazyAttribute(lambda obj: obj.data_inicio_realizacao_despesas + timedelta(days=120))
     referencia = LazyAttribute(lambda obj: obj.data_inicio_realizacao_despesas.strftime("%Y.1"))
+    
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/core/fixtures/factories/solicitacao_encerramento_conta_associacao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/solicitacao_encerramento_conta_associacao_factory.py
@@ -1,0 +1,17 @@
+from factory import DjangoModelFactory, SubFactory, Sequence
+from faker import Faker
+from sme_ptrf_apps.core.fixtures.factories.conta_associacao_factory import ContaAssociacaoFactory
+from sme_ptrf_apps.core.models.solicitacao_encerramento_conta_associacao import SolicitacaoEncerramentoContaAssociacao
+from ..providers.solicitacao_encerramento_conta_associacao_provider import provider_status_solicitacao_encerramento_conta_associacao
+
+fake = Faker("pt_BR")
+fake.add_provider(provider_status_solicitacao_encerramento_conta_associacao)
+
+class SolicitacaoEncerramentoContaAssociacaoFactory(DjangoModelFactory):
+    class Meta:
+        model = SolicitacaoEncerramentoContaAssociacao
+
+    conta_associacao = SubFactory(ContaAssociacaoFactory)
+    status = fake.provider_status_solicitacao_encerramento_conta_associacao()
+    
+    # TODO adicionar campos restantes

--- a/sme_ptrf_apps/core/fixtures/providers/arquivo_provider.py
+++ b/sme_ptrf_apps/core/fixtures/providers/arquivo_provider.py
@@ -1,0 +1,7 @@
+from faker.providers import DynamicProvider
+from sme_ptrf_apps.core.models.arquivo import Arquivo
+
+provider_tipo_carga_arquivo = DynamicProvider(
+     provider_name="provider_tipo_carga_arquivo",
+     elements=[choice[0] for choice in Arquivo.CARGA_CHOICES]
+)

--- a/sme_ptrf_apps/core/fixtures/providers/solicitacao_encerramento_conta_associacao_provider.py
+++ b/sme_ptrf_apps/core/fixtures/providers/solicitacao_encerramento_conta_associacao_provider.py
@@ -1,0 +1,7 @@
+from faker.providers import DynamicProvider
+from sme_ptrf_apps.core.models.solicitacao_encerramento_conta_associacao import SolicitacaoEncerramentoContaAssociacao
+
+provider_status_solicitacao_encerramento_conta_associacao = DynamicProvider(
+     provider_name="provider_status_solicitacao_encerramento_conta_associacao",
+     elements=[choice[0] for choice in SolicitacaoEncerramentoContaAssociacao.STATUS_CHOICES]
+)

--- a/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_realizados.py
@@ -213,7 +213,11 @@ def processa_repasse(reader, tipo_conta, arquivo):
                 if start < conta_associacao.data_inicio:
                     msg_erro = f"O período informado de repasse é anterior ao período de criação da conta."
                     raise Exception(msg_erro)
-
+                
+                if hasattr(conta_associacao, 'solicitacao_encerramento') and conta_associacao.solicitacao_encerramento.aprovada:
+                    msg_erro = "A conta possui pedido de encerramento aprovado pela DRE."
+                    raise Exception(msg_erro)
+                
             if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
                 repasse = Repasse.objects.create(
                     associacao=associacao,


### PR DESCRIPTION
Esse PR:

- Adiciona a verificação de conta encerrada para arquivos de carga de repasses realizados.
- Adiciona teste e factories relacionadas.

História: AB#108932

