### PR TITLE
fix(108777): Corrige validacao primeira PC com valores corretos

### DIFF
--- a/sme_ptrf_apps/core/models/conta_associacao.py
+++ b/sme_ptrf_apps/core/models/conta_associacao.py
@@ -388,6 +388,9 @@ class ContaAssociacao(ModeloBase):
                 resultado[
                     "mensagem"
                 ] = "O pedido de solicitação de encerramento de conta bancária foi efetuado com sucesso. O encerramento definitivo da conta será realizado após a geração da PC e a conclusão da análise pela DRE."
+            elif not self.valida_se_algum_valor_reprogramado_foi_preenchido():
+                resultado["pode_encerrar_conta"] = True
+                resultado["mensagem"] = None
 
         return resultado
 


### PR DESCRIPTION
Esse PR:

- Adiciona a validação de quando os status de valores reprogramados forem corretos, a primeira PC não existe e não existe nenhum campo de valor reprogramado preenchido a conta da associação pode ser encerrada.

História: AB#108777