### PR TITLE
feat(109692): Adiciona verificacao conta quando saldo insuficiente

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -35,6 +35,9 @@ from sme_ptrf_apps.core.fixtures.factories.acao_factory import AcaoFactory
 from sme_ptrf_apps.core.fixtures.factories.arquivo_factory import ArquivoFactory
 from sme_ptrf_apps.core.fixtures.factories.solicitacao_encerramento_conta_associacao_factory import SolicitacaoEncerramentoContaAssociacaoFactory
 from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.fechamento_periodo_factory import FechamentoPeriodoFactory
+from sme_ptrf_apps.despesas.fixtures.factories.despesa_factory import DespesaFactory
+from sme_ptrf_apps.despesas.fixtures.factories.rateio_despesa_factory import RateioDespesaFactory
 
 from sme_ptrf_apps.fixtures import *
 
@@ -53,6 +56,9 @@ register(SolicitacaoEncerramentoContaAssociacaoFactory)
 register(ArquivoFactory)
 register(AcaoFactory)
 register(AcaoAssociacaoFactory)
+register(FechamentoPeriodoFactory)
+register(DespesaFactory)
+register(RateioDespesaFactory)
 
 @pytest.fixture
 def fake_user(client, django_user_model, unidade):

--- a/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
@@ -1,5 +1,7 @@
-from factory import DjangoModelFactory
+from factory import DjangoModelFactory, SubFactory
 from faker import Faker
+from sme_ptrf_apps.core.fixtures.factories.acao_factory import AcaoFactory
+from sme_ptrf_apps.core.fixtures.factories.associacao_factory import AssociacaoFactory
 from sme_ptrf_apps.core.models.acao_associacao import AcaoAssociacao
 
 fake = Faker("pt_BR")
@@ -7,5 +9,7 @@ fake = Faker("pt_BR")
 class AcaoAssociacaoFactory(DjangoModelFactory):
     class Meta:
         model = AcaoAssociacao
-
-    # TODO adicionar outros campos
+        
+    associacao = SubFactory(AssociacaoFactory)
+    acao = SubFactory(AcaoFactory)
+    status = "ATIVA"

--- a/sme_ptrf_apps/core/fixtures/factories/acao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/acao_factory.py
@@ -1,4 +1,4 @@
-from factory import DjangoModelFactory
+from factory import DjangoModelFactory,Sequence
 from faker import Faker
 from sme_ptrf_apps.core.models.acao import Acao
 
@@ -7,5 +7,10 @@ fake = Faker("pt_BR")
 class AcaoFactory(DjangoModelFactory):
     class Meta:
         model = Acao
-
-    # TODO adicionar outros campos
+        
+    nome = Sequence(lambda n: fake.unique.name())
+    posicao_nas_pesquisas = "ZZZZZZZZZZ"
+    e_recursos_proprios = False
+    aceita_capital = False
+    aceita_custeio = False
+    aceita_livre = False

--- a/sme_ptrf_apps/core/fixtures/factories/fechamento_periodo_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/fechamento_periodo_factory.py
@@ -1,0 +1,21 @@
+from factory import DjangoModelFactory, SubFactory
+from faker import Faker
+from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.associacao_factory import AssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.periodo_factory import PeriodoFactory
+from sme_ptrf_apps.core.fixtures.factories.prestacao_conta_factory import PrestacaoContaFactory
+from sme_ptrf_apps.core.models.fechamento_periodo import FechamentoPeriodo
+
+
+fake = Faker()
+
+class FechamentoPeriodoFactory(DjangoModelFactory):
+    class Meta:
+        model = FechamentoPeriodo
+   
+    prestacao_conta = SubFactory(PrestacaoContaFactory)
+    periodo = SubFactory(PeriodoFactory)
+    associacao = SubFactory(AssociacaoFactory)
+    acao_associacao = SubFactory(AcaoAssociacaoFactory)
+    
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_saldos_insuficientes_para_rateios.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_saldos_insuficientes_para_rateios.py
@@ -1,0 +1,149 @@
+from decimal import Decimal
+import pytest
+
+from datetime import date
+from sme_ptrf_apps.core.models.acao_associacao import AcaoAssociacao
+from sme_ptrf_apps.core.models.fechamento_periodo import FechamentoPeriodo
+
+from sme_ptrf_apps.despesas.models.rateio_despesa import RateioDespesa
+from ....services import saldos_insuficientes_para_rateios
+
+pytestmark = pytest.mark.django_db
+
+@pytest.fixture
+def dados_em_comum_testes_saldos_insuficientes_para_rateios(associacao_factory, conta_associacao_factory, despesa_factory, rateio_despesa_factory, periodo_factory, fechamento_periodo_factory, tipo_conta_factory, prestacao_conta_factory, acao_associacao_factory, acao_factory):
+    associacao = associacao_factory.create()
+
+    acao = acao_factory.create(nome="PTRF Básico", aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+    acao_associacao = acao_associacao_factory.create(associacao=associacao, acao=acao)
+
+    tipo_conta = tipo_conta_factory.create(nome="Caixa")
+    conta = conta_associacao_factory.create(tipo_conta=tipo_conta, associacao=associacao)
+
+    periodo_anterior = periodo_factory.create(
+        referencia="2021.3",
+        data_inicio_realizacao_despesas=date(2021, 10, 1),
+        data_fim_realizacao_despesas=date(2021, 12, 31),
+    )
+    periodo = periodo_factory.create(
+        periodo_anterior=periodo_anterior,
+        referencia="2022.1",
+        data_inicio_realizacao_despesas=date(2022, 1, 1),
+        data_fim_realizacao_despesas=date(2022, 4, 30),
+    )
+    
+    despesa = despesa_factory.create(associacao=associacao, data_transacao=date(2021,10,2), data_documento=date(2021,10,2))
+    
+    pc = prestacao_conta_factory.create(periodo=periodo_anterior, associacao=associacao)
+    
+    return associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc
+
+def test_valor_conta_insuficiente(dados_em_comum_testes_saldos_insuficientes_para_rateios, rateio_despesa_factory, fechamento_periodo_factory):
+    associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc = dados_em_comum_testes_saldos_insuficientes_para_rateios
+    
+    rateios = list()
+    rateio = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(9000), valor_original=Decimal(9000), aplicacao_recurso="CUSTEIO",acao_associacao=acao_associacao, status="COMPLETO")
+    
+    rateios.append({'id': rateio.id, 'despesa': rateio.despesa, 'conta_associacao': rateio.conta_associacao.uuid, 'acao_associacao': rateio.acao_associacao.uuid, 'aplicacao_recurso': "CUSTEIO", 'valor_rateio': rateio.valor_rateio})
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=acao_associacao, fechamento_anterior=None, total_receitas_capital=0, total_despesas_capital=0, total_receitas_custeio=500, total_despesas_custeio=9000, status="FECHADO")
+    
+    response = saldos_insuficientes_para_rateios(rateios=rateios, periodo=periodo, exclude_despesa=despesa.uuid)
+    
+    assert response['tipo_saldo'] == "CONTA"
+    assert response['saldos_insuficientes'][0]['conta'] == "Caixa"
+    assert response['saldos_insuficientes'][0]['saldo_disponivel'] == Decimal(500)
+    assert response['saldos_insuficientes'][0]['total_rateios'] == Decimal(9000)
+    
+def test_valor_acao_insuficiente(dados_em_comum_testes_saldos_insuficientes_para_rateios, rateio_despesa_factory, fechamento_periodo_factory, acao_associacao_factory, acao_factory):
+    associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc = dados_em_comum_testes_saldos_insuficientes_para_rateios
+
+    rateios = list()
+    rateio = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(10000), valor_original=Decimal(10000), aplicacao_recurso="CUSTEIO",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    
+    rateios.append({'id': rateio.id, 'despesa': rateio.despesa, 'conta_associacao': rateio.conta_associacao.uuid, 'acao_associacao': rateio.acao_associacao.uuid, 'aplicacao_recurso': "CUSTEIO", 'valor_rateio': rateio.valor_rateio})
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=acao_associacao, fechamento_anterior=None, total_receitas_capital=0, total_despesas_capital=0, total_receitas_custeio=500, total_despesas_custeio=10000, status="FECHADO")
+    
+    outra_acao = acao_factory.create(nome="Role Cultural", aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+    outra_acao_associacao = acao_associacao_factory.create(associacao=associacao, acao=outra_acao)
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=outra_acao_associacao, fechamento_anterior=None, total_receitas_capital=200000, total_despesas_capital=0, total_receitas_custeio=200000, total_despesas_custeio=0, status="FECHADO")
+    
+    response = saldos_insuficientes_para_rateios(rateios=rateios, periodo=periodo, exclude_despesa=despesa.uuid)
+    
+    assert response['tipo_saldo'] == "ACAO"
+    assert response['saldos_insuficientes'][0]['conta'] == "Caixa"
+    assert response['saldos_insuficientes'][0]['aplicacao'] == "CUSTEIO"
+    assert response['saldos_insuficientes'][0]['saldo_disponivel'] == Decimal(500)
+    assert response['saldos_insuficientes'][0]['total_rateios'] == Decimal(10000)
+    
+    
+def test_valor_aplicacao_insuficiente(dados_em_comum_testes_saldos_insuficientes_para_rateios, rateio_despesa_factory, fechamento_periodo_factory):
+    associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc = dados_em_comum_testes_saldos_insuficientes_para_rateios
+
+    rateios = list()
+    rateio = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(10000), valor_original=Decimal(10000), aplicacao_recurso="CAPITAL",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    
+    rateios.append({'id': rateio.id, 'despesa': rateio.despesa, 'conta_associacao': rateio.conta_associacao.uuid, 'acao_associacao': rateio.acao_associacao.uuid, 'aplicacao_recurso': "CAPITAL", 'valor_rateio': rateio.valor_rateio})
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=acao_associacao, fechamento_anterior=None, total_receitas_capital=0, total_despesas_capital=10000, total_receitas_custeio=50000, total_despesas_custeio=0, status="FECHADO")
+    
+    response = saldos_insuficientes_para_rateios(rateios=rateios, periodo=periodo, exclude_despesa=despesa.uuid)
+    
+    assert response['tipo_saldo'] == "ACAO"
+    assert response['saldos_insuficientes'][0]['conta'] == "Caixa"
+    assert response['saldos_insuficientes'][0]['aplicacao'] == "CAPITAL"
+    assert response['saldos_insuficientes'][0]['saldo_disponivel'] == Decimal(0)
+    assert response['saldos_insuficientes'][0]['total_rateios'] == Decimal(10000)
+
+def test_uso_valor_livre_aplicacao(dados_em_comum_testes_saldos_insuficientes_para_rateios, rateio_despesa_factory, fechamento_periodo_factory, acao_associacao_factory, acao_factory):
+    associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc = dados_em_comum_testes_saldos_insuficientes_para_rateios
+
+    rateios = list()
+    rateio_custeio = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(10000), valor_original=Decimal(10000), aplicacao_recurso="CUSTEIO",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    rateio_capital = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(6000), valor_original=Decimal(6000), aplicacao_recurso="CAPITAL",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    
+    rateios.append({'id': rateio_custeio.id, 'despesa': rateio_custeio.despesa, 'conta_associacao': rateio_custeio.conta_associacao.uuid, 'acao_associacao': rateio_custeio.acao_associacao.uuid, 'aplicacao_recurso': rateio_custeio.aplicacao_recurso, 'valor_rateio': rateio_custeio.valor_rateio})
+    
+    rateios.append({'id': rateio_capital.id, 'despesa': rateio_capital.despesa, 'conta_associacao': rateio_capital.conta_associacao.uuid, 'acao_associacao': rateio_capital.acao_associacao.uuid, 'aplicacao_recurso': rateio_capital.aplicacao_recurso, 'valor_rateio': rateio_capital.valor_rateio})
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=acao_associacao, fechamento_anterior=None, total_receitas_capital=5000, total_despesas_capital=6000, total_receitas_custeio=5000, total_despesas_custeio=10000, total_receitas_livre=6000, status="FECHADO")
+    
+    outra_acao = acao_factory.create(nome="Role Cultural", aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+    outra_acao_associacao = acao_associacao_factory.create(associacao=associacao, acao=outra_acao)
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=outra_acao_associacao, fechamento_anterior=None, total_receitas_capital=200000, total_despesas_capital=0, total_receitas_custeio=200000, total_despesas_custeio=0, status="FECHADO")
+    
+    response = saldos_insuficientes_para_rateios(rateios=rateios, periodo=periodo, exclude_despesa=despesa.uuid)
+    
+    assert response['tipo_saldo'] == "ACAO"
+    assert response['saldos_insuficientes'] == []
+    
+def test_uso_valor_livre_aplicacao_em_um_rateio_mas_insuficiente_para_o_outro(dados_em_comum_testes_saldos_insuficientes_para_rateios, rateio_despesa_factory, fechamento_periodo_factory, acao_associacao_factory, acao_factory):
+    associacao, acao_associacao, conta, periodo, periodo_anterior, despesa, pc = dados_em_comum_testes_saldos_insuficientes_para_rateios
+
+    rateios = list()
+    rateio_custeio = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(10000), valor_original=Decimal(10000), aplicacao_recurso="CUSTEIO",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    rateio_capital = rateio_despesa_factory.create(despesa=despesa, associacao=associacao, conta_associacao=conta, valor_rateio=Decimal(6000), valor_original=Decimal(6000), aplicacao_recurso="CAPITAL",acao_associacao=acao_associacao, status="COMPLETO", conferido="True")
+    
+    rateios.append({'id': rateio_custeio.id, 'despesa': rateio_custeio.despesa, 'conta_associacao': rateio_custeio.conta_associacao.uuid, 'acao_associacao': rateio_custeio.acao_associacao.uuid, 'aplicacao_recurso': rateio_custeio.aplicacao_recurso, 'valor_rateio': rateio_custeio.valor_rateio})
+    
+    rateios.append({'id': rateio_capital.id, 'despesa': rateio_capital.despesa, 'conta_associacao': rateio_capital.conta_associacao.uuid, 'acao_associacao': rateio_capital.acao_associacao.uuid, 'aplicacao_recurso': rateio_capital.aplicacao_recurso, 'valor_rateio': rateio_capital.valor_rateio})
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=acao_associacao, fechamento_anterior=None, total_receitas_capital=5000, total_despesas_capital=6000, total_receitas_custeio=5000, total_despesas_custeio=10000, total_receitas_livre=5000, status="FECHADO")
+    
+    outra_acao = acao_factory.create(nome="Role Cultural", aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+    outra_acao_associacao = acao_associacao_factory.create(associacao=associacao, acao=outra_acao)
+    
+    fechamento_periodo_factory.create(prestacao_conta=pc, periodo=periodo_anterior, associacao=associacao, conta_associacao=conta, acao_associacao=outra_acao_associacao, fechamento_anterior=None, total_receitas_capital=200000, total_despesas_capital=0, total_receitas_custeio=200000, total_despesas_custeio=0, status="FECHADO")
+    
+    response = saldos_insuficientes_para_rateios(rateios=rateios, periodo=periodo, exclude_despesa=despesa.uuid)
+    
+    assert response['tipo_saldo'] == "ACAO"
+    assert response['saldos_insuficientes'][0]['conta'] == "Caixa"
+    assert response['saldos_insuficientes'][0]['aplicacao'] == "CUSTEIO"
+    assert response['saldos_insuficientes'][0]['saldo_disponivel'] == Decimal(9000)
+    assert response['saldos_insuficientes'][0]['total_rateios'] == Decimal(10000)
+
+

--- a/sme_ptrf_apps/despesas/fixtures/factories/despesa_factory.py
+++ b/sme_ptrf_apps/despesas/fixtures/factories/despesa_factory.py
@@ -1,0 +1,25 @@
+from factory import DjangoModelFactory, SubFactory, Sequence
+from faker import Faker
+
+from sme_ptrf_apps.core.fixtures.factories.associacao_factory import AssociacaoFactory
+from sme_ptrf_apps.despesas.models.despesa import Despesa
+
+
+fake = Faker("pt_BR")
+
+class DespesaFactory(DjangoModelFactory):
+    class Meta:
+        model = Despesa
+
+    associacao = SubFactory(AssociacaoFactory)
+    numero_documento = Sequence(lambda n: f"DOC-{n}")
+    data_documento = fake.date_this_year()
+    cpf_cnpj_fornecedor = Sequence(lambda n: fake.unique.cnpj())
+    nome_fornecedor = fake.company()
+    documento_transacao = Sequence(lambda n: f"TRAN-{n}")
+    data_transacao = fake.date_this_year()
+    eh_despesa_sem_comprovacao_fiscal = fake.pybool()
+    eh_despesa_reconhecida_pela_associacao = fake.pybool()
+    numero_boletim_de_ocorrencia = Sequence(lambda n: f"BO-{n}")
+
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/despesas/fixtures/factories/rateio_despesa_factory.py
+++ b/sme_ptrf_apps/despesas/fixtures/factories/rateio_despesa_factory.py
@@ -1,0 +1,24 @@
+from factory import DjangoModelFactory, SubFactory
+from faker import Faker
+from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.associacao_factory import AssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.conta_associacao_factory import ContaAssociacaoFactory
+
+from sme_ptrf_apps.despesas.fixtures.factories.despesa_factory import DespesaFactory
+from sme_ptrf_apps.despesas.models.rateio_despesa import RateioDespesa
+from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CHOICES
+
+
+fake = Faker()
+
+class RateioDespesaFactory(DjangoModelFactory):
+    class Meta:
+        model = RateioDespesa
+
+    despesa = SubFactory(DespesaFactory)
+    associacao = SubFactory(AssociacaoFactory)
+    conta_associacao = SubFactory(ContaAssociacaoFactory)
+    acao_associacao = SubFactory(AcaoAssociacaoFactory)
+    aplicacao_recurso = fake.random_element(elements=[choice[0] for choice in APLICACAO_CHOICES])
+    
+    # TODO adicionar outros campos

--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_post.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_post.py
@@ -67,6 +67,7 @@ def test_api_verifica_saldo_antes_post_sem_saldo(
             {
                 'acao': acao_associacao.acao.nome,
                 'aplicacao': 'CUSTEIO',
+                'conta': 'Cheque',
                 'saldo_disponivel': 0,
                 'total_rateios': 1000.00
             }

--- a/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_put.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_rateios_despesas/test_verifica_saldo_antes_put.py
@@ -76,6 +76,7 @@ def test_api_verifica_saldo_antes_put_sem_saldo(
             {
                 'acao': acao_associacao.acao.nome,
                 'aplicacao': 'CUSTEIO',
+                'conta': 'Cheque',
                 'saldo_disponivel': 20100.00,
                 'total_rateios': 90000.00
             }
@@ -194,6 +195,7 @@ def test_api_verifica_saldo_antes_put_saldo_insuficiente_acao_com_saldo_exato_em
             {
                 'acao': 'PTRF',
                 'aplicacao': 'CUSTEIO',
+                'conta': 'Cheque',
                 'saldo_disponivel': 100.0,
                 'total_rateios': 102.0
             }


### PR DESCRIPTION
Esse PR:

- Adiciona a verificação por ação e aplicação dentro de cada conta no momento de cadastro de uma despesa.
- Modifica serviço saldos_insuficientes_para_rateios para contemplar contas.
- Adiciona factories e testes relacionados.

História: AB#109692