### PR TITLE
feat(108442): Adiciona servico tratar processo ser receber PC

### DIFF
--- a/sme_ptrf_apps/core/models/proccessos_associacao.py
+++ b/sme_ptrf_apps/core/models/proccessos_associacao.py
@@ -26,7 +26,7 @@ class ProcessoAssociacao(ModeloBase):
     def by_associacao_periodo(cls, associacao, periodo):
         ano = periodo.referencia[0:4]
         processos = cls.objects.filter(associacao=associacao, ano=ano)
-        return processos.first().numero_processo if processos.exists() else ""
+        return processos.last().numero_processo if processos.exists() else ""
 
     @classmethod
     def ultimo_processo_do_ano_por_associacao(cls, associacao, ano):

--- a/sme_ptrf_apps/core/services/processos_services.py
+++ b/sme_ptrf_apps/core/services/processos_services.py
@@ -9,3 +9,14 @@ def get_processo_sei_da_prestacao(prestacao_contas):
 def get_processo_sei_da_associacao_no_periodo(associacao, periodo):
     return ProcessoAssociacao.by_associacao_periodo(associacao=associacao,
                                                     periodo=periodo)
+    
+def trata_processo_sei_ao_receber_pc(prestacao_conta, processo_sei, acao_processo_sei):
+    ano = prestacao_conta.periodo.referencia[0:4]
+    if acao_processo_sei == 'editar':
+        processo_associacao = ProcessoAssociacao.ultimo_processo_do_ano_por_associacao(associacao=prestacao_conta.associacao, ano=ano)
+        processo_associacao.numero_processo = processo_sei
+        processo_associacao.save()
+    elif acao_processo_sei == 'incluir':
+        ProcessoAssociacao.objects.create(associacao=prestacao_conta.associacao, ano=ano, numero_processo=processo_sei)
+
+    

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta.py
@@ -25,6 +25,8 @@ def prestacao_conta_nao_recebida(periodo, associacao):
 def test_api_recebe_prestacao_conta(jwt_authenticated_client_a, prestacao_conta_nao_recebida):
     payload = {
         'data_recebimento': '2020-10-01',
+        'processo_sei': '1234.5678/9101112-1',
+        'acao_processo_sei': None
     }
 
     url = f'/api/prestacoes-contas/{prestacao_conta_nao_recebida.uuid}/receber/'
@@ -75,6 +77,8 @@ def test_api_recebe_prestacao_conta_nao_pode_aceitar_status_diferente_de_nao_rec
                                                                                       prestacao_conta_em_analise):
     payload = {
         'data_recebimento': '2020-10-01',
+        'processo_sei': '1234.5678/9101112-1',
+        'acao_processo_sei': None
     }
 
     url = f'/api/prestacoes-contas/{prestacao_conta_em_analise.uuid}/receber/'
@@ -97,3 +101,108 @@ def test_api_recebe_prestacao_conta_nao_pode_aceitar_status_diferente_de_nao_rec
 
     prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_em_analise.uuid)
     assert prestacao_atualizada.status == PrestacaoConta.STATUS_EM_ANALISE, 'Status não deveria ter sido alterado.'
+    
+def test_api_recebe_prestacao_conta_exige_processo_sei(jwt_authenticated_client_a, prestacao_conta_nao_recebida):
+    payload = {
+        'data_recebimento': '2020-10-01',
+        'acao_processo_sei': None
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_nao_recebida.uuid}/receber/'
+
+    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    
+    result = json.loads(response.content)
+    
+    resultado_esperado = {
+        'uuid': f'{prestacao_conta_nao_recebida.uuid}', 
+        'erro': 'falta_de_informacoes_processo_sei', 
+        'operacao': 'receber', 
+        'mensagem': 'Faltou informar o processo SEI de recebimento da Prestação de Contas.'
+    }
+
+    assert result == resultado_esperado, "Deveria ter retornado erro falta_de_informacoes_processo_sei."
+    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_nao_recebida.uuid)
+    assert prestacao_atualizada.status == PrestacaoConta.STATUS_NAO_RECEBIDA, 'Status não deveria ter sido alterado.'
+    
+def test_api_recebe_prestacao_conta_e_edita_processo_sei(jwt_authenticated_client_a, prestacao_conta_nao_recebida):
+    from sme_ptrf_apps.core.fixtures.factories.processo_associacao_factory import ProcessoAssociacaoFactory
+    from sme_ptrf_apps.core.models.proccessos_associacao import ProcessoAssociacao
+    
+    ano = prestacao_conta_nao_recebida.periodo.referencia[0:4]
+    associacao = prestacao_conta_nao_recebida.associacao
+    numero_processo = '1111.1111/1111111-1'
+    processo_associacao = ProcessoAssociacaoFactory.create(associacao=associacao, ano=ano, numero_processo=numero_processo)
+    
+    payload = {
+        'data_recebimento': '2020-10-01',
+        'processo_sei': '2222.2222/2222111-1',
+        'acao_processo_sei': 'editar'
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_nao_recebida.uuid}/receber/'
+
+    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+    
+    processo_editado = ProcessoAssociacao.objects.get(uuid=processo_associacao.uuid)
+    
+    assert processo_editado.numero_processo == '2222.2222/2222111-1'
+    
+def test_api_recebe_prestacao_conta_e_inclui_novo_processo_sei(jwt_authenticated_client_a, prestacao_conta_nao_recebida):
+    from sme_ptrf_apps.core.fixtures.factories.processo_associacao_factory import ProcessoAssociacaoFactory
+    from sme_ptrf_apps.core.models.proccessos_associacao import ProcessoAssociacao
+    
+    ano = prestacao_conta_nao_recebida.periodo.referencia[0:4]
+    associacao = prestacao_conta_nao_recebida.associacao
+    numero_processo = '1111.1111/1111111-1'
+    processo_associacao = ProcessoAssociacaoFactory.create(associacao=associacao, ano=ano, numero_processo=numero_processo)
+    
+    processos_antes_de_receber_pc = ProcessoAssociacao.objects.all()
+    assert processos_antes_de_receber_pc.count() == 1
+    
+    payload = {
+        'data_recebimento': '2020-10-01',
+        'processo_sei': '2222.2222/2222111-1',
+        'acao_processo_sei': 'incluir'
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_nao_recebida.uuid}/receber/'
+
+    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+    
+    processos_depois_de_receber_pc = ProcessoAssociacao.objects.all()
+    assert processos_depois_de_receber_pc.count() == 2
+    
+def test_api_recebe_prestacao_conta_e_mantem_processo_sei(jwt_authenticated_client_a, prestacao_conta_nao_recebida):
+    from sme_ptrf_apps.core.fixtures.factories.processo_associacao_factory import ProcessoAssociacaoFactory
+    from sme_ptrf_apps.core.models.proccessos_associacao import ProcessoAssociacao
+    
+    ano = prestacao_conta_nao_recebida.periodo.referencia[0:4]
+    associacao = prestacao_conta_nao_recebida.associacao
+    numero_processo = '1111.1111/1111111-1'
+    processo_associacao = ProcessoAssociacaoFactory.create(associacao=associacao, ano=ano, numero_processo=numero_processo)
+    
+    processos_antes_de_receber_pc = ProcessoAssociacao.objects.all()
+    assert processos_antes_de_receber_pc.count() == 1
+    
+    payload = {
+        'data_recebimento': '2020-10-01',
+        'processo_sei': '2222.2222/2222111-1',
+        'acao_processo_sei': None
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_nao_recebida.uuid}/receber/'
+
+    response = jwt_authenticated_client_a.patch(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+    
+    processo_nao_editado = ProcessoAssociacao.objects.get(uuid=processo_associacao.uuid)
+    
+    assert processo_nao_editado.numero_processo == '1111.1111/1111111-1'


### PR DESCRIPTION
Esse PR:

- Adiciona o serviço para tratar o processo SEI ao receber PCS.
- Altera view de recebimento de PC.
- Altera ordenação resgate de processos SEI.

História: AB#108442