### PR TITLE
feat(111777) Geração de PDFs dos documentos de PC apenas quando necessário

### DIFF
--- a/sme_ptrf_apps/core/services/falha_geracao_pc_service.py
+++ b/sme_ptrf_apps/core/services/falha_geracao_pc_service.py
@@ -79,10 +79,12 @@ class FalhaGeracaoPcService:
     def marcar_como_resolvido(self):
         registro_de_falha_ao_gerar_pc = self.retorna_registro_falha_geracao_pc()
 
-        if registro_de_falha_ao_gerar_pc:
+        if registro_de_falha_ao_gerar_pc and not registro_de_falha_ao_gerar_pc.resolvido:
             logger.info(f"Marcando como resolvido registro de falha {registro_de_falha_ao_gerar_pc}")
             registro_de_falha_ao_gerar_pc.resolvido = True
             registro_de_falha_ao_gerar_pc.save()
+        else:
+            logger.info(f"Não há registro de falha pendente.")
 
 
 class InfoRegistroFalhaGeracaoPc(FalhaGeracaoPcService):

--- a/sme_ptrf_apps/core/services/prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/services/prestacao_conta_service.py
@@ -261,24 +261,29 @@ class PrestacaoContaService:
         logger.info(f'Terminando processo da PC {self._prestacao}...')
 
         calculo_concluido = self._prestacao.status in [PrestacaoConta.STATUS_CALCULADA, PrestacaoConta.STATUS_DEVOLVIDA_CALCULADA]
+        logger.info(f'PC {self._prestacao} está calculada? {calculo_concluido}')
 
         # Verificar se todos os demonstrativos financeiros da prestacao de contas foram concluídos
-        demonstrativos_concluidos = False
+        demonstrativos_concluidos = False  # Deve ter ao menos um demonstrativo financeiro
         for demonstrativo in self._prestacao.demonstrativos_da_prestacao.all():
             if demonstrativo.status == DemonstrativoFinanceiro.STATUS_CONCLUIDO:
                 demonstrativos_concluidos = True
             else:
+                logger.info(f'Demonstrativo financeiro {demonstrativo} não está concluído.')
                 demonstrativos_concluidos = False
                 break
 
+        logger.info(f'Todos os demonstrativos financeiros da PC {self._prestacao} estão concluídos? {demonstrativos_concluidos}')
+
         # Verificar se todos os relatórios de bens da prestacao de contas foram concluídos
-        relatorios_concluidos = False
+        relatorios_concluidos = True  # Não é obrigatório ter relatórios de bens, mas se tiver, todos devem estar concluídos
         for relatorio in self._prestacao.relacoes_de_bens_da_prestacao.all():
-            if relatorio.status == RelacaoBens.STATUS_CONCLUIDO:
-                relatorios_concluidos = True
-            else:
+            if relatorio.status != RelacaoBens.STATUS_CONCLUIDO:
+                logger.info(f'Relatório de bens {relatorio} não está concluído.')
                 relatorios_concluidos = False
                 break
+
+        logger.info(f'Todos os relatórios de bens da PC {self._prestacao} estão concluídos? {relatorios_concluidos}')
 
         if calculo_concluido and demonstrativos_concluidos and relatorios_concluidos:
             logger.info(f'Terminando o processo da PC {self._prestacao}...')

--- a/sme_ptrf_apps/core/services/prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/services/prestacao_conta_service.py
@@ -44,7 +44,7 @@ class PrestacaoContaService:
 
         self._prestacao = PrestacaoConta.by_periodo(associacao=self._associacao, periodo=self._periodo)
 
-        # self._e_retorno_devolucao = self._prestacao.status in (PrestacaoConta.STATUS_DEVOLVIDA, PrestacaoConta.STATUS_DEVOLVIDA_CALCULADA) if self._prestacao else False
+        # Apenas PCs devolvidas tem o campo data_recebimento preenchido
         self._e_retorno_devolucao = self._prestacao.data_recebimento is not None if self._prestacao else False
 
         self._acoes = self._associacao.acoes.filter(status=AcaoAssociacao.STATUS_ATIVA)

--- a/sme_ptrf_apps/core/tasks/calcular_prestacao_de_contas.py
+++ b/sme_ptrf_apps/core/tasks/calcular_prestacao_de_contas.py
@@ -22,10 +22,6 @@ def calcular_prestacao_de_contas_async(
     periodo_uuid,
     associacao_uuid,
     username="",
-    e_retorno_devolucao=False,
-    devolucao_tem_solicitacoes_mudanca=False,
-    devolucao_tem_solicitacoes_mudanca_realizadas=True,
-    devolucao_tem_acertos_em_extrato=False,
     justificativa_acertos_pendentes='',
 ):
     from sme_ptrf_apps.core.services.prestacao_contas_services import (
@@ -40,16 +36,17 @@ def calcular_prestacao_de_contas_async(
 
         task.grava_log_concatenado(f'Iniciando a task calcular_prestacao_de_contas_async - VERSÃO 2')
 
-        task.grava_log_concatenado(f'É retorno de devolução: {e_retorno_devolucao}')
-        task.grava_log_concatenado(f'Tem solicitações de mudança: {devolucao_tem_solicitacoes_mudanca}')
-        task.grava_log_concatenado(f'Tem solicitações de mudança realizadas: {devolucao_tem_solicitacoes_mudanca_realizadas}')
-        task.grava_log_concatenado(f'Tem acertos em extrato: {devolucao_tem_acertos_em_extrato}')
-
         pc_service = PrestacaoContaService(
             periodo_uuid=periodo_uuid,
             associacao_uuid=associacao_uuid,
             username=username,
         )
+
+        task.grava_log_concatenado(f'Prestação de contas: {pc_service.prestacao}')
+        task.grava_log_concatenado(f'É retorno de devolução: {pc_service.e_retorno_devolucao}')
+        task.grava_log_concatenado(f'Tem solicitações de mudança: {pc_service.pc_e_devolucao_com_solicitacoes_mudanca}')
+        task.grava_log_concatenado(f'Tem solicitações de mudança realizadas: {pc_service.pc_e_devolucao_com_solicitacoes_mudanca_realizadas}')
+        task.grava_log_concatenado(f'Tem acertos em extrato: {pc_service.pc_e_devolucao_com_solicitacao_acerto_em_extrato}')
 
         periodo = pc_service.periodo
         prestacao = pc_service.prestacao
@@ -71,23 +68,12 @@ def calcular_prestacao_de_contas_async(
 
         pc_service.atualiza_justificativa_conciliacao_original()
 
-        if e_retorno_devolucao and devolucao_tem_solicitacoes_mudanca:
-            """
-            Na verdade, não deveria haver fechamentos para a PC nesse caso, já que eles são apagados no ato da
-            devolução quanto as solicitações de ajuste demandam alteração de lançamentos.
-            Serão apagados aqui por segurança.
-            """
+        if pc_service.requer_apagar_fechamentos:
             task.grava_log_concatenado(f'Apagando fechamentos existentes para a pc {prestacao.uuid}. Eles serão recalculados.')
             prestacao.apaga_fechamentos()
             task.grava_log_concatenado(f'Fechamentos apagados para a prestação de contas {prestacao}.')
 
-        if e_retorno_devolucao and (devolucao_tem_solicitacoes_mudanca_realizadas or devolucao_tem_acertos_em_extrato):
-            """
-            No caso de devoluções de PC os documentos são regerados apenas se:
-                - Houver solicitações de ajustes REALIZADAS e que demandem alteração de lançamentos,
-                - Houver solicitações de ajustes nas informações de extrato.
-            Nesses casos, os originais precisam ser apagados para que os novos sejam gerados.
-            """
+        if pc_service.requer_apagar_documentos:
             task.grava_log_concatenado(
                 f'Solicitações de ajustes requerem regerar os documentos da pc {prestacao.uuid}. Eles serão apagados para nova geração posterior.')
 
@@ -99,26 +85,14 @@ def calcular_prestacao_de_contas_async(
 
             task.grava_log_concatenado(f'Documentos da pc {prestacao.uuid} apagados.')
 
-        if (not e_retorno_devolucao) or devolucao_tem_solicitacoes_mudanca:
-            """
-            Fechamentos devem ser criados nas seguintes situações:
-                - Na primeira geração de uma PC (quando não é uma devolução)
-                - Devoluções com solicitações de ajustes que demandem alteração de lançamentos, realizadas ou não
-            """
+        if pc_service.requer_criar_fechamentos:
             task.grava_log_concatenado(f'Criando os fechamentos para pc {prestacao.uuid}.')
             _criar_fechamentos(acoes, contas, periodo, prestacao)
             task.grava_log_concatenado(f'Fechamentos criados para a prestação de contas {prestacao}.')
         else:
             task.grava_log_concatenado(f'Solicitações de ajustes NÃO requerem recalcular os fechamentos.')
 
-        if (not e_retorno_devolucao) or (devolucao_tem_solicitacoes_mudanca_realizadas or devolucao_tem_acertos_em_extrato):
-            """
-            Os dados para os documentos da PC precisam ser calculados e persistidos nas seguintes situações:
-                - Na primeira geração de uma PC (quando não é uma devolução)
-                - Houver solicitações de ajustes REALIZADAS e que demandem alteração de lançamentos,
-                - Houver solicitações de ajustes nas informações de extrato.
-            Além disso, qualquer prévia de documento deve ser apagada, nas mesmas situações.
-            """
+        if pc_service.requer_gerar_documentos:
             task.grava_log_concatenado(f'Apagando prévias de documentos da pc {prestacao.uuid}.')
             _apagar_previas_documentos(contas=contas, periodo=periodo, prestacao=prestacao)
             task.grava_log_concatenado(f'Prévias apagadas.')
@@ -127,15 +101,11 @@ def calcular_prestacao_de_contas_async(
             pc_service.persiste_dados_docs()
             task.grava_log_concatenado(f'Dados dos documentos da {prestacao} persistidos para posterior geração dos PDFs.')
 
-        if e_retorno_devolucao and not devolucao_tem_acertos_em_extrato and not devolucao_tem_solicitacoes_mudanca_realizadas:
-            """
-            Se a devolução não tiver solicitações de ajustes REALIZADAS que demandem alteração de lançamentos e
-            nem solicitações de ajustes nas informações de extrato, não é necessário gerar novos documentos.
-            """
+        else:
             task.grava_log_concatenado(f'Solicitações de ajustes NÃO requerem gerar novamente os documentos da pc {prestacao.uuid}.')
 
         prestacao = prestacao.concluir_v2(
-            e_retorno_devolucao=e_retorno_devolucao,
+            e_retorno_devolucao=pc_service.e_retorno_devolucao,
             justificativa_acertos_pendentes=justificativa_acertos_pendentes
         )
 


### PR DESCRIPTION
Esse PR:

- Altera o novo processo de PC para só gerar os PDFs de demonstrativos financeiros e relações de bens se for necessário.
- Ajusta a task de término de PC para não considerar falha a inexistência de relações de bens.
- Faz algumas refatorações para melhorar legibilidade do código.  

Atende AB#111777