### PR TITLE
feat(112851): Filtro por código EOL no acompanhamento de PC (DRE e SME)

### DIFF
--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -95,8 +95,11 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
 
         nome = self.request.query_params.get('nome')
         if nome is not None:
-            qs = qs.filter(Q(associacao__nome__unaccent__icontains=nome) | Q(
-                associacao__unidade__nome__unaccent__icontains=nome))
+            qs = qs.filter(
+                Q(associacao__unidade__codigo_eol=nome) |
+                Q(associacao__nome__unaccent__icontains=nome) |
+                Q(associacao__unidade__nome__unaccent__icontains=nome)
+            )
 
         dre_uuid = self.request.query_params.get('associacao__unidade__dre__uuid')
         periodo_uuid = self.request.query_params.get('periodo__uuid')

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -365,8 +365,11 @@ def lista_prestacoes_de_conta_nao_recebidas(
         'unidade__tipo_unidade', 'unidade__nome')
 
     if filtro_nome is not None:
-        associacoes_da_dre = associacoes_da_dre.filter(Q(nome__unaccent__icontains=filtro_nome) | Q(
-            unidade__nome__unaccent__icontains=filtro_nome))
+        associacoes_da_dre = associacoes_da_dre.filter(
+            Q(unidade__codigo_eol=filtro_nome) |
+            Q(nome__unaccent__icontains=filtro_nome) |
+            Q(unidade__nome__unaccent__icontains=filtro_nome)
+        )
 
     if filtro_tipo_unidade is not None:
         associacoes_da_dre = associacoes_da_dre.filter(unidade__tipo_unidade=filtro_tipo_unidade)
@@ -426,8 +429,11 @@ def lista_prestacoes_de_conta_todos_os_status(
     associacoes_da_dre = Associacao.get_associacoes_ativas_no_periodo(periodo=periodo, dre=dre).order_by('unidade__tipo_unidade', 'unidade__nome')
 
     if filtro_nome is not None:
-        associacoes_da_dre = associacoes_da_dre.filter(Q(nome__unaccent__icontains=filtro_nome) | Q(
-            unidade__nome__unaccent__icontains=filtro_nome))
+        associacoes_da_dre = associacoes_da_dre.filter(
+            Q(unidade__codigo_eol=filtro_nome) |
+            Q(nome__unaccent__icontains=filtro_nome) |
+            Q(unidade__nome__unaccent__icontains=filtro_nome)
+        )
 
     if filtro_tipo_unidade is not None:
         associacoes_da_dre = associacoes_da_dre.filter(unidade__tipo_unidade=filtro_tipo_unidade)


### PR DESCRIPTION
Esse PR:
- Adiciona a possibilidade de filtro por código EOL no acompanhamento de PCs das visões DRE e SME.

Atende AB#112851 e AB#112852