### PR TITLE
feat(116372): Valida existência de PC em carga de repasse

### DIFF
--- a/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
@@ -132,6 +132,10 @@ def get_id_linha(str_id_linha):
         raise ValueError(f"Não foi possível converter '{str_id}' em um valor inteiro.")
 
 
+def associacao_periodo_tem_pc(associacao, periodo):
+    return associacao.prestacoes_de_conta_da_associacao.filter(periodo=periodo).exists()
+
+
 def processa_repasse(reader, tipo_conta, arquivo):
     __ID_LINHA = 0
     __CODIGO_EOL = 1
@@ -198,10 +202,14 @@ def processa_repasse(reader, tipo_conta, arquivo):
                     if start_converted_date < conta_associacao.data_inicio:
                         msg_erro = f"O período informado de repasse é anterior ao período de criação da conta."
                         raise Exception(msg_erro)
-                    
+
                     if hasattr(conta_associacao, 'solicitacao_encerramento') and conta_associacao.solicitacao_encerramento.aprovada:
                         msg_erro = "A conta possui pedido de encerramento aprovado pela DRE."
                         raise Exception(msg_erro)
+
+                if associacao_periodo_tem_pc(associacao, periodo):
+                    msg_erro = f"A associação {associacao.unidade.codigo_eol} já possui PC gerada no período {periodo.referencia}."
+                    raise Exception(msg_erro)
 
                 if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
                     Repasse.objects.create(


### PR DESCRIPTION
Esse PR alterar a carga de repasses previsto:
- Valida a existência de PC para a associação no período e não cria o repasse previsto se existir a PC.

Atende AB#116372