### PR TITLE
feat(116380): Valida existência de PC em carga de repasse

### DIFF
--- a/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_realizados.py
+++ b/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_realizados.py
@@ -127,7 +127,7 @@ def test_carga_com_erro_formatacao(arquivo_carga, tipo_conta_cheque):
 def test_carga_com_erro(arquivo_carga_virgula, tipo_conta_cheque):
     carrega_repasses_realizados(arquivo_carga_virgula)
     msg = """\nErro na linha 1: Associação com código eol: 93238 não encontrado. Linha ID:10
-Foram criados 0 repasses. Erro na importação de 1 repasses."""
+Foram criados 0 repasses. Erro na importação de 1 repasse(s)."""
     assert arquivo_carga_virgula.log == msg
     assert arquivo_carga_virgula.status == ERRO
 
@@ -141,7 +141,7 @@ def test_carga_processado_com_erro(arquivo_carga_virgula_processado, periodo, as
                                    tipo_conta_cheque, acao_role_cultural, acao_role_cultural_teste):
     carrega_repasses_realizados(arquivo_carga_virgula_processado)
     msg = """\nErro na linha 1: Ação Rolê Cultural não permite capital.\nErro na linha 2: Associação com código eol: 93238 não encontrado. Linha ID:20
-Foram criados 0 repasses. Erro na importação de 2 repasses."""
+Foram criados 0 repasses. Erro na importação de 2 repasse(s)."""
     assert arquivo_carga_virgula_processado.log == msg
     assert arquivo_carga_virgula_processado.status == ERRO
 
@@ -156,7 +156,7 @@ def test_carga_deve_criar_conta(
 ):
     assert not ContaAssociacao.objects.filter(tipo_conta=tipo_conta_cartao, associacao=associacao).exists()
     carrega_repasses_realizados(arquivo_carga_deve_criar_conta)
-    msg = """\nForam criados 1 repasses. Erro na importação de 0 repasses."""
+    msg = """\nForam criados 1 repasses. Erro na importação de 0 repasse(s)."""
     assert arquivo_carga_deve_criar_conta.log == msg
     assert arquivo_carga_deve_criar_conta.status == SUCESSO
     conta_associacao_cartao = ContaAssociacao.objects.get(tipo_conta=tipo_conta_cartao, associacao=associacao)
@@ -175,14 +175,14 @@ def test_carga_deve_gerar_erro_periodo_anterior_a_criacao_da_conta(
     carrega_repasses_realizados(arquivo_carga_deve_criar_conta)
 
     msg= """\nErro na linha 1: O período informado de repasse é anterior ao período de criação da conta.
-Foram criados 0 repasses. Erro na importação de 1 repasses."""
+Foram criados 0 repasses. Erro na importação de 1 repasse(s)."""
 
     assert arquivo_carga_deve_criar_conta.log == msg
     assert arquivo_carga_deve_criar_conta.status == ERRO
 
 def test_carga_em_conta_encerrada_deve_gerar_erro(periodos_de_2019_ate_2023, acao_factory, acao_associacao_factory, associacao_factory, arquivo_factory, unidade_factory, tipo_conta_factory, conta_associacao_factory, solicitacao_encerramento_conta_associacao_factory):
     from sme_ptrf_apps.core.models.solicitacao_encerramento_conta_associacao import SolicitacaoEncerramentoContaAssociacao
-    
+
     unidade = unidade_factory(codigo_eol='666666')
     associacao = associacao_factory(unidade=unidade)
     acao = acao_factory(nome='Acao teste', aceita_capital=True, aceita_custeio=True)
@@ -193,12 +193,67 @@ def test_carga_em_conta_encerrada_deve_gerar_erro(periodos_de_2019_ate_2023, aca
 
     conteudo_arquivo = SimpleUploadedFile(f'carga_repasse_cheque.csv',
         bytes(f"""Linha_ID,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao,Data receita,Periodo\n10,666666,99000.98,99000.98,,Acao teste,02/04/2019,2019.2""", encoding="utf-8"))
-    
+
     arquivo = arquivo_factory.create(identificador='carga_repasse_cheque', conteudo=conteudo_arquivo, tipo_carga=CARGA_REPASSE_REALIZADO, tipo_delimitador=DELIMITADOR_VIRGULA)
-    
+
     carrega_repasses_realizados(arquivo)
-    
-    msg= """\nErro na linha 1: A conta possui pedido de encerramento aprovado pela DRE.\nForam criados 0 repasses. Erro na importação de 1 repasses."""
-    
+
+    msg= """\nErro na linha 1: A conta possui pedido de encerramento aprovado pela DRE.\nForam criados 0 repasses. Erro na importação de 1 repasse(s)."""
+
     assert arquivo.log == msg
     assert arquivo.status == ERRO
+
+
+@pytest.fixture
+def arquivo_associacao_periodo_com_pc():
+    return SimpleUploadedFile(
+        f'carga_repasse_cheque_2.csv',
+        bytes(
+            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao,Data receita,Periodo\n10,123456,99000.98,99000.98,,PTRF Básico,01/01/2024,2024.1""",
+            encoding="utf-8"))
+
+
+@pytest.fixture
+def arquivo_carga_associacao_periodo_com_pc(arquivo_associacao_periodo_com_pc):
+    return baker.make(
+        'Arquivo',
+        identificador='2024_01_01_a_2024_06_30_cheque_2',
+        conteudo=arquivo_associacao_periodo_com_pc,
+        tipo_carga=CARGA_REPASSE_REALIZADO,
+        tipo_delimitador=DELIMITADOR_VIRGULA
+    )
+
+
+@pytest.fixture
+def periodo_pc():
+    return baker.make(
+        'Periodo',
+        referencia='2024.1',
+        data_inicio_realizacao_despesas=datetime.date(2024, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2024, 6, 30),
+    )
+
+
+@pytest.fixture
+def pc_teste(periodo_pc, associacao):
+    return baker.make(
+        'PrestacaoConta',
+        periodo=periodo_pc,
+        associacao=associacao,
+        data_recebimento=datetime.date(2024, 1, 1),
+        status='DEVOLVIDA'
+    )
+
+
+def test_carga_processado_com_erro_associacao_periodo_com_pc(
+    arquivo_carga_associacao_periodo_com_pc,
+    associacao,
+    pc_teste,
+    tipo_receita_repasse,
+    tipo_conta_cheque,
+    acao_ptrf_basico
+):
+    carrega_repasses_realizados(arquivo_carga_associacao_periodo_com_pc)
+    msg = """\nErro na linha 1: A associação 123456 já possui PC gerada no período 2024.1.\nForam criados 0 repasses. Erro na importação de 1 repasse(s)."""
+    assert arquivo_carga_associacao_periodo_com_pc.log == msg
+    assert arquivo_carga_associacao_periodo_com_pc.status == ERRO


### PR DESCRIPTION
Esse PR alterar a carga de repasses realizados:
- Valida a existência de PC para a associação no período e não cria o repasse realizado caso exista uma PC


Atende AB#116380