### PR TITLE
feat(117548): Conferencia de lancamentos

### DIFF
--- a/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
+++ b/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
@@ -57,10 +57,12 @@ class TiposAcertoLancamentoViewSet(mixins.ListModelMixin,
             permission_classes=[IsAuthenticated & PermissaoApiDre])
     def tabelas(self, request):
         aplicavel_despesas_periodos_anteriores = request.query_params.get('aplicavel_despesas_periodos_anteriores')
+        is_repasse = request.query_params.get('is_repasse')
 
         result = {
             "categorias": TipoAcertoLancamento.categorias(),
-            "agrupado_por_categorias": TipoAcertoLancamento.agrupado_por_categoria(aplicavel_despesas_periodos_anteriores)
+            "agrupado_por_categorias": TipoAcertoLancamento.agrupado_por_categoria(
+                aplicavel_despesas_periodos_anteriores, is_repasse)
         }
 
         return Response(result, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
@@ -47,16 +47,28 @@ class TipoAcertoLancamento(ModeloIdNome):
     ativo = models.BooleanField('Ativo', default=True)
 
     @classmethod
-    def agrupado_por_categoria(cls, aplicavel_despesas_periodos_anteriores=False):
+    def agrupado_por_categoria(cls, aplicavel_despesas_periodos_anteriores=False, is_repasse=False):
         from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
+
+        categorias_a_ignorar = None
+
+        if is_repasse:
+            categorias_a_ignorar = [
+                TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO
+            ]
+
         if aplicavel_despesas_periodos_anteriores:
-            FILTERED_CATEGORIA_CHOICES = (
-                (cls.CATEGORIA_CONCILIACAO_LANCAMENTO, cls.CATEGORIA_NOMES[cls.CATEGORIA_CONCILIACAO_LANCAMENTO]),
-                (cls.CATEGORIA_DESCONCILIACAO_LANCAMENTO, cls.CATEGORIA_NOMES[cls.CATEGORIA_DESCONCILIACAO_LANCAMENTO]),
-            )
-            return TipoAcertoLancamentoService.agrupado_por_categoria(FILTERED_CATEGORIA_CHOICES)
-        else:
-            return TipoAcertoLancamentoService.agrupado_por_categoria(cls.CATEGORIA_CHOICES)
+            # Apenas as categorias de conciliacao e desconciliacao devem ser retornadas
+
+            categorias_a_ignorar = [
+                TipoAcertoLancamento.CATEGORIA_DEVOLUCAO,
+                TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
+                TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
+                TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS,
+                TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+            ]
+
+        return TipoAcertoLancamentoService.agrupado_por_categoria(cls.CATEGORIA_CHOICES, categorias_a_ignorar)
 
     @classmethod
     def categorias(cls):

--- a/sme_ptrf_apps/core/services/prestacao_contas_services.py
+++ b/sme_ptrf_apps/core/services/prestacao_contas_services.py
@@ -898,7 +898,8 @@ def lancamentos_da_prestacao(
                 'despesas_impostos': DespesaImpostoSerializer(despesas_impostos, many=True,
                                                               required=False).data if despesas_impostos else None,
                 'informacoes': despesa.tags_de_informacao,
-                'informacoes_ordenamento': despesa.tags_de_informacao_concatenadas
+                'informacoes_ordenamento': despesa.tags_de_informacao_concatenadas,
+                'is_repasse': False
             }
 
             if com_ajustes:
@@ -949,7 +950,8 @@ def lancamentos_da_prestacao(
                                    'houve_considerados_corretos_automaticamente': analise_lancamento.houve_considerados_corretos_automaticamente,
                                    } if analise_lancamento else None,
             'informacoes': receita.tags_de_informacao,
-            'informacoes_ordenamento': receita.tags_de_informacao_concatenadas
+            'informacoes_ordenamento': receita.tags_de_informacao_concatenadas,
+            'is_repasse': receita.tipo_receita.e_repasse if receita.tipo_receita else False
         }
 
         if com_ajustes:

--- a/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
@@ -4,8 +4,9 @@ from ...utils.choices_to_json import choices_to_json
 
 class TipoAcertoLancamentoAgrupadoPorCategoria:
 
-    def __init__(self, choices):
+    def __init__(self, choices, categorias_a_ignorar):
         self.choices = choices
+        self.categorias_a_ignorar = categorias_a_ignorar if categorias_a_ignorar is not None else []
         self.__set_agrupamento()
 
     def __set_agrupamento(self):
@@ -14,6 +15,9 @@ class TipoAcertoLancamentoAgrupadoPorCategoria:
         for choice in self.choices:
             categoria_id = choice[0]
             categoria_nome = choice[1]
+
+            if categoria_id in self.categorias_a_ignorar:
+                continue
 
             tipos_acertos_lancamentos = TipoAcertoLancamento.objects.filter(
                 categoria=categoria_id).filter(ativo=True).values("id", "nome", "categoria", "ativo", "uuid")
@@ -88,8 +92,9 @@ class TipoAcertoLancamentoCategorias:
 
 class TipoAcertoLancamentoService:
     @classmethod
-    def agrupado_por_categoria(cls, choices):
-        return TipoAcertoLancamentoAgrupadoPorCategoria(choices=choices).agrupamento
+    def agrupado_por_categoria(cls, choices, categorias_a_ignorar=None):
+        return TipoAcertoLancamentoAgrupadoPorCategoria(
+            choices=choices, categorias_a_ignorar=categorias_a_ignorar).agrupamento
 
     @classmethod
     def categorias(cls, choices):

--- a/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_analises_prestacoes_contas/test_list_lancamentos.py
@@ -264,6 +264,7 @@ def monta_result_esperado(lancamentos_esperados, periodo, conta, inativa=False):
                 } if lancamento["analise_lancamento"] else None,
                 'informacoes': retorna_tags_de_informacao(lancamento=lancamento),
                 'informacoes_ordenamento': retorna_tags_de_informacao_concatenadas(lancamento=lancamento),
+                'is_repasse': False,
             }
         )
 

--- a/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/test_service_endpoint_tabelas_lancamentos.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_tipos_acertos_lancamentos_service/test_service_endpoint_tabelas_lancamentos.py
@@ -100,3 +100,50 @@ def test_service_tabelas_agrupado_por_categorias(
     assert resultado_esperado == resultado
 
 
+def test_service_tabelas_agrupado_por_categorias_deve_ignorar_categoria(
+    tipo_acerto_lancamento_agrupa_categoria_01,
+    tipo_acerto_lancamento_agrupa_categoria_02,
+    tipo_acerto_lancamento_agrupa_categoria_03,
+    tipo_acerto_lancamento_agrupa_categoria_04,  # Não deve entrar na listagem
+):
+
+    resultado_esperado = [
+        {
+            "id": "DEVOLUCAO",
+            "nome": "Devolução ao tesouro",
+            "texto": "Esse tipo de acerto demanda informação da data de pagamento da devolução.",
+            "cor": 1,
+            "tipos_acerto_lancamento": [
+                {
+                    "id": tipo_acerto_lancamento_agrupa_categoria_01.id,
+                    "nome": "Teste",
+                    "categoria": "DEVOLUCAO",
+                    "ativo": tipo_acerto_lancamento_agrupa_categoria_01.ativo,
+                    "uuid": tipo_acerto_lancamento_agrupa_categoria_01.uuid
+                },
+                {
+                    "id": tipo_acerto_lancamento_agrupa_categoria_02.id,
+                    "nome": "Teste 2",
+                    "categoria": "DEVOLUCAO",
+                    "ativo": tipo_acerto_lancamento_agrupa_categoria_02.ativo,
+                    "uuid": tipo_acerto_lancamento_agrupa_categoria_02.uuid
+                },
+                {
+                    "id": tipo_acerto_lancamento_agrupa_categoria_03.id,
+                    "nome": "Teste 3",
+                    "categoria": "DEVOLUCAO",
+                    "ativo": tipo_acerto_lancamento_agrupa_categoria_03.ativo,
+                    "uuid": tipo_acerto_lancamento_agrupa_categoria_03.uuid
+                }
+            ]
+        },
+    ]
+
+    categorias_a_ignorar = {
+        TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO
+    }
+
+    resultado = TipoAcertoLancamentoService.agrupado_por_categoria(
+        TipoAcertoLancamento.CATEGORIA_CHOICES, categorias_a_ignorar)
+
+    assert resultado_esperado == resultado


### PR DESCRIPTION
feat(117548): Conferencia de lancamentos

Esse PR:

- Altera serviço de agrupar por categoria para ignorar categorias dependendo do parametro
- Adiciona campo "is_repasse" ao serializer de analise_lancamento
- Altera testes relacionados

História: AB#117548