### PR TITLE
feat(116372): Carga de repasses previstos valida pc

### DIFF
--- a/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
@@ -4,7 +4,8 @@ import enum
 import logging
 import os
 
-from sme_ptrf_apps.core.models import Acao, AcaoAssociacao, Associacao, ContaAssociacao, Periodo, TipoConta
+from sme_ptrf_apps.core.models import Acao, AcaoAssociacao, Associacao, ContaAssociacao, Periodo, TipoConta, \
+    PrestacaoConta
 from sme_ptrf_apps.core.models.arquivo import (
     DELIMITADOR_PONTO_VIRGULA,
     DELIMITADOR_VIRGULA,
@@ -147,6 +148,9 @@ def processa_repasse(reader, tipo_conta, arquivo):
     nome_arquivo = arquivo.identificador
 
     periodo = get_periodo(nome_arquivo)
+
+    if PrestacaoConta.objects.filter(periodo=periodo).exists():
+        raise CargaRepassePrevistoException(f"Já existe prestações de conta para o período {periodo.referencia}.")
 
     logs = []
     importados = 0

--- a/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_previstos.py
+++ b/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_previstos.py
@@ -272,6 +272,6 @@ def test_carga_processado_com_erro_associacao_periodo_com_pc(
     acao_ptrf_basico
 ):
     carrega_repasses_previstos(arquivo_carga_associacao_periodo_com_pc)
-    msg = """Erro na linha 1: A associação 123456 já possui PC gerada no período 2019.1.\nForam criados 0 repasses. Erro na importação de 1 repasse(s)."""
+    msg = "Erro ao processar repasses previstos: Já existe prestações de conta para o período 2019.1."
     assert arquivo_carga_associacao_periodo_com_pc.log == msg
     assert arquivo_carga_associacao_periodo_com_pc.status == ERRO


### PR DESCRIPTION
Esse PR:
- Alterar a carga de repasses previstos para recusar a carga caso já exista alguma PC no período do repasse.


Atende AB#116372