### PR TITLE
feat(118811): Nao permitir mesmo numero processo sei no mesmo ano

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/processo_associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/processo_associacao_serializer.py
@@ -47,6 +47,21 @@ class ProcessoAssociacaoCreateSerializer(serializers.ModelSerializer):
 
             associacao = data.get('associacao')
             periodos = data.get('periodos', [])
+            numero_processo = data.get('numero_processo')
+            
+            # Verifica se já existe na associação no mesmo ano o mesmo numero
+            if numero_processo and associacao and ano_processo:
+                processos_existentes = ProcessoAssociacao.objects.filter(
+                    associacao=associacao, numero_processo=numero_processo, ano=ano_processo
+                )
+
+                if self.instance:
+                    processos_existentes = processos_existentes.exclude(pk=self.instance.pk)
+
+                if processos_existentes.exists():
+                    raise serializers.ValidationError({
+                        "numero_processo": f"Este número de processo SEI já existe para o ano informado."
+                    })
 
             # Verifica se os períodos estão sendo reutilizados na mesma associação
             for periodo in periodos:

--- a/sme_ptrf_apps/core/fixtures/factories/unidade_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/unidade_factory.py
@@ -15,7 +15,7 @@ class DreFactory(DjangoModelFactory):
     nome = Sequence(lambda n: f"DIRETORIA REGIONAL DE EDUCACAO {fake.unique.name().upper()}")
     tipo_unidade = "DRE"
     codigo_eol = Sequence(lambda n: str(fake.unique.random_int(min=100000, max=999999)))
-    sigla = Sequence(lambda n: fake.unique.lexify(text="??", letters="ABCDEFGHIJK"))
+    sigla = Sequence(lambda n: fake.unique.lexify(text="??", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
     dre_cnpj = Sequence(lambda n: fake.unique.cnpj())
     dre_diretor_regional_rf = Sequence(lambda n: str(fake.unique.random_int(min=1000000, max=9999999)))
     dre_diretor_regional_nome = Sequence(lambda n:fake.unique.name().upper())

--- a/sme_ptrf_apps/core/tests/tests_api_processos_associacoes/test_processo_associacao_update.py
+++ b/sme_ptrf_apps/core/tests/tests_api_processos_associacoes/test_processo_associacao_update.py
@@ -1,10 +1,12 @@
 import json
+import uuid
 
 import pytest
 from rest_framework import status
 from waffle.testutils import override_flag
 
 from sme_ptrf_apps.core.models import ProcessoAssociacao
+from sme_ptrf_apps.core.models.periodo import Periodo
 
 pytestmark = pytest.mark.django_db
 
@@ -62,4 +64,63 @@ def test_update_processo_associacao_sem_periodos_com_flag_ligada(jwt_authenticat
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         result = json.loads(response.content)
         assert result == {'periodos': ["É necessário informar ao menos um período quando a feature 'periodos-processo-sei' está ativa."]}
+        
+def test_update_processo_associacao_com_mesmo_numero_processo_para_mesmo_ano_na_mesma_associacao(
+    jwt_authenticated_client_a,
+    periodos_de_2019_ate_2023,
+    associacao_factory,
+    processo_associacao_factory
+):
+    periodo1 = Periodo.objects.get(referencia=2019.1)
+    periodo2 = Periodo.objects.get(referencia=2019.2)
+    associacao = associacao_factory.create()
+    processo1 = processo_associacao_factory.create(associacao=associacao, ano='2019', numero_processo="123456")
+    processo2 = processo_associacao_factory.create(associacao=associacao, ano='2019', numero_processo="111111")
+    
+    payload = {
+        'ano': '2019',
+        'numero_processo': "123456",
+        'periodos': [str(periodo2.uuid)],
+        'associacao': str(associacao.uuid)
+    }
+    
+    with override_flag('periodos-processo-sei', active=True):
+        response = jwt_authenticated_client_a.put(
+            f'/api/processos-associacao/{processo2.uuid}/',
+            data=json.dumps(payload),
+            content_type='application/json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        result = json.loads(response.content)
+        assert result == {'numero_processo': ['Este número de processo SEI já existe para o ano informado.']}
+
+def test_update_processo_associacao_com_mesmo_numero_processo_para_outro_ano_na_mesma_associacao(
+    jwt_authenticated_client_a,
+    periodos_de_2019_ate_2023,
+    associacao_factory,
+    processo_associacao_factory
+):
+    periodo1 = Periodo.objects.get(referencia=2019.1)
+    periodo2 = Periodo.objects.get(referencia=2020.1)
+    associacao = associacao_factory.create()
+    processo1 = processo_associacao_factory.create(associacao=associacao, ano='2019', numero_processo="123456")
+    processo2 = processo_associacao_factory.create(associacao=associacao, ano='2020', numero_processo="111111")
+    
+    payload = {
+        'ano': '2020',
+        'numero_processo': "123456",
+        'periodos': [str(periodo2.uuid)],
+        'associacao': str(associacao.uuid)
+    }
+    
+    with override_flag('periodos-processo-sei', active=True):
+        response = jwt_authenticated_client_a.put(
+            f'/api/processos-associacao/{processo2.uuid}/',
+            data=json.dumps(payload),
+            content_type='application/json')
+        
+        assert response.status_code == status.HTTP_200_OK
+        result = json.loads(response.content)
+        assert result['numero_processo'] == '123456'
+        assert result['uuid'] == str(processo2.uuid).replace('urn:', '').replace('uuid:', '')
 


### PR DESCRIPTION
Esse PR:

- Adicione validação para evitar o cadastro de processos SEI com o mesmo número no mesmo ano.

História: [AB#118811](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/118811)