### PR TITLE
feat(119271): Migração atas ignorar acentos e case

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -461,15 +461,27 @@ class AtaAdmin(admin.ModelAdmin):
 
     get_referencia_periodo.short_description = 'Período'
 
+    def get_presidente(self, obj):
+        return obj.presidente_da_reuniao.nome if obj and obj.presidente_da_reuniao else ''
+
+    get_presidente.short_description = 'Presidente'
+
+    def get_secretario(self, obj):
+        return obj.secretario_da_reuniao.nome if obj and obj.secretario_da_reuniao else ''
+
+    get_secretario.short_description = 'Secretário'
+
+
     raw_id_fields = ('prestacao_conta', 'associacao', 'composicao', 'presidente_da_reuniao', 'secretario_da_reuniao')
 
     list_display = (
         'get_eol_unidade',
         'get_referencia_periodo',
         'tipo_ata',
+        'get_presidente',
+        'get_secretario',
         'parecer_conselho',
         'previa',
-        'arquivo_pdf',
     )
 
     list_filter = (

--- a/sme_ptrf_apps/core/tasks/migra_campos_presidente_secretario_atas.py
+++ b/sme_ptrf_apps/core/tasks/migra_campos_presidente_secretario_atas.py
@@ -33,9 +33,13 @@ def atualizar_presidente_e_secretario():
 
         ata_atualizada = True
 
+        # Remove a flag de revisão caso exista
+        if ata.comentarios and '**rever**' in ata.comentarios:
+            ata.comentarios = ata.comentarios.replace('**rever**', '').strip()
+
         if ata.presidente_reuniao:
             # Atualizar presidente
-            presidente = Participante.objects.filter(nome=ata.presidente_reuniao, ata=ata).first()
+            presidente = Participante.objects.filter(nome__unaccent__icontains=ata.presidente_reuniao, ata=ata).first()
             if presidente:
                 ata.presidente_da_reuniao = presidente
             else:
@@ -44,7 +48,7 @@ def atualizar_presidente_e_secretario():
 
         if ata.secretario_reuniao:
             # Atualizar secretário
-            secretario = Participante.objects.filter(nome=ata.secretario_reuniao, ata=ata).first()
+            secretario = Participante.objects.filter(nome__unaccent__icontains=ata.secretario_reuniao, ata=ata).first()
             if secretario:
                 ata.secretario_da_reuniao = secretario
             else:


### PR DESCRIPTION
Esse PR:

- Altera a migração de presidentes e secretários das
atas para na busca ignorar a diferença entre maiúsculas
e minúsculas e também acentuação.

- Inclui no admin de atas as colunas  presidente e secretário

[AB#119271](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/119271)