### PR TITLE
feat(119271): Altera migração presidente secretário atas

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1490,6 +1490,7 @@ class PresenteAtaAdmin(admin.ModelAdmin):
         'ata__periodo',
         'ata__associacao__unidade__tipo_unidade',
         'ata__associacao__unidade__dre',
+        'ata__tipo_ata',
         'cargo',
         'membro',
         ('criado_em', DateRangeFilter),

--- a/sme_ptrf_apps/core/tasks/migra_campos_presidente_secretario_atas.py
+++ b/sme_ptrf_apps/core/tasks/migra_campos_presidente_secretario_atas.py
@@ -1,7 +1,9 @@
 import logging
 
 from celery import shared_task
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+
+from django.db.models import Q, Value
+from django.db.models.functions import Replace
 
 from sme_ptrf_apps.core.models import (
     Ata,
@@ -14,7 +16,7 @@ logger = logging.getLogger(__name__)
 @shared_task(
     retry_backoff=2,
     retry_kwargs={'max_retries': 8},
-    time_limet=333333,
+    time_limit=333333,
     soft_time_limit=333333
 )
 def migrar_campos_presidente_secretario_atas_async():
@@ -23,50 +25,61 @@ def migrar_campos_presidente_secretario_atas_async():
     logger.info(f"Finalizado serviço de atualização em massa de regularidade")
 
 
+def remover_tag_ajustar_das_atas():
+    # Atualiza o campo comentarios, removendo a substring '**ajustar**'
+    Ata.objects.filter(comentarios__icontains='**ajustar**').update(
+        comentarios=Replace('comentarios', Value('**ajustar**'), Value(''))
+    )
+
+
 def atualizar_presidente_e_secretario():
-    atas_sem_presidente_secretario = Ata.objects.filter(presidente_da_reuniao__isnull=True,
-                                                        secretario_da_reuniao__isnull=True)
+
+    remover_tag_ajustar_das_atas()
+
+    atas_sem_presidente_secretario = Ata.objects.filter(
+        Q(presidente_da_reuniao__isnull=True) | Q(secretario_da_reuniao__isnull=True)
+    )
 
     atas_nao_atualizadas = []
     for ata in atas_sem_presidente_secretario:
         logger.info(f"Ata ID {ata.id}...")
 
-        ata_atualizada = True
+        presidente_atualizado = True
+        secretario_atualizado = True
+        salvar_ata = False
 
-        # Remove a flag de revisão caso exista
-        if ata.comentarios and '**rever**' in ata.comentarios:
-            ata.comentarios = ata.comentarios.replace('**rever**', '').strip()
-
-        if ata.presidente_reuniao:
+        if ata.presidente_reuniao and not ata.presidente_da_reuniao:
             # Atualizar presidente
             presidente = Participante.objects.filter(nome__unaccent__icontains=ata.presidente_reuniao, ata=ata).first()
             if presidente:
                 ata.presidente_da_reuniao = presidente
+                salvar_ata = True
             else:
-                ata_atualizada = False
+                presidente_atualizado = False
                 logger.warning(f"Presidente não encontrado para a ata ID {ata.id} com nome {ata.presidente_reuniao}.")
 
-        if ata.secretario_reuniao:
+        if ata.secretario_reuniao and not ata.secretario_da_reuniao:
             # Atualizar secretário
             secretario = Participante.objects.filter(nome__unaccent__icontains=ata.secretario_reuniao, ata=ata).first()
             if secretario:
                 ata.secretario_da_reuniao = secretario
+                salvar_ata = True
             else:
                 logger.warning(f"Secretário não encontrado para a ata ID {ata.id} com nome {ata.secretario_reuniao}.")
-                ata_atualizada = False
+                secretario_atualizado = False
 
-        if not ata_atualizada:
+        if not presidente_atualizado or not secretario_atualizado:
             if ata.comentarios is None:
                 ata.comentarios = '**rever**'
             else:
                 ata.comentarios = f'{ata.comentarios} **rever**'
 
-            ata.save()
+            salvar_ata = True
 
             atas_nao_atualizadas.append(ata)
 
         # Salva a ata se algum dos campos foi atualizado
-        if ata.presidente_da_reuniao or ata.secretario_da_reuniao:
+        if salvar_ata:
             ata.save()
 
     if atas_nao_atualizadas:


### PR DESCRIPTION
Esse PR:

- Altera a migração  de presidente secretário de ata para que a migração seja  feita mesmo que falte apenas um dos cargos.
- A flag "**rever**" passa a ser reavaliada antes do início do processo para todas as atas que tem a flag.
- Altera o admin de participantes de atas incluindo um filtro por tipo de ata.

[AB#119271](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/119271)