### PR TITLE
fix(120372): Corrige persistencia imposto sem data no demo financeiro

### DIFF
--- a/sme_ptrf_apps/core/services/persistencia_dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/persistencia_dados_demo_financeiro_service.py
@@ -345,7 +345,9 @@ class PersistenciaDadosDemoFinanceiro:
             if 'despesas_impostos' in despesa:
                 info_retencao_imposto = ''
                 for imposto in despesa['despesas_impostos']:
-                    data_transacao_imposto = self.string_to_date(imposto["data_transacao"]).date()
+                    data_transacao_imposto = ''
+                    if imposto["data_transacao"]:
+                        data_transacao_imposto = self.string_to_date(imposto["data_transacao"]).date()
                     valor_imposto = imposto["valor"]
 
                     info_retencao_imposto = info_retencao_imposto + f"{valor_imposto};{data_transacao_imposto}\r\n"


### PR DESCRIPTION
Esse PR:

- Corrige a persistência de dados do demonstrativo financeiro, criando uma condição que evita tentar transformar uma data inexistente de uma despesa do tipo imposto.

História: [AB#120372](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/120372)