### PR TITLE
fix(120329): Corrige validacao unidades faltantes com tipo receita cadastrado

### DIFF
--- a/sme_ptrf_apps/receitas/admin.py
+++ b/sme_ptrf_apps/receitas/admin.py
@@ -18,8 +18,9 @@ class TipoReceitaForm(ModelForm):
             if len(unidades_com_receita_do_tipo) > 0 and not (unidades.filter(codigo_eol__in=unidades_com_receita_do_tipo).exists() and (len(unidades_selecionadas) == len(unidades_com_receita_do_tipo))):
                 unidades_faltantes = Unidade.objects.filter(codigo_eol__in=unidades_com_receita_do_tipo).exclude(
                     codigo_eol__in=unidades_selecionadas).values_list('codigo_eol', flat=True)
-                raise ValidationError(
-                    f"Não é possível restringir tipo de receita, pois existem unidades que já possuem receita criada com esse tipo e não estão selecionadas. Unidades faltantes: {list(unidades_faltantes)}")
+                if len(unidades_faltantes) > 0:
+                    raise ValidationError(
+                        f"Não é possível restringir tipo de receita, pois existem unidades que já possuem receita criada com esse tipo e não estão selecionadas. Unidades faltantes: {list(unidades_faltantes)}")
         return unidades
 
 


### PR DESCRIPTION
Esse PR:

- Corrige a verificação da quantidade de unidades cadastradas que já possuem uma receita do tipo de receita cadastrado e estão sendo removidas da lista de unidades do tipo de receita pelo admin.

História: [AB#120329](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/120329)