### PR TITLE
fix(122906): Despesa periodo anterior editável

### DIFF
--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -134,9 +134,15 @@ class Despesa(ModeloBase):
             data_transacao = self.data_transacao
 
             data_inicio_realizacao_despesas = self.associacao.periodo_inicial.data_inicio_realizacao_despesas if self.associacao and self.associacao.periodo_inicial and self.associacao.periodo_inicial.data_inicio_realizacao_despesas else None
+            data_fim_realizacao_despesas = self.associacao.periodo_inicial.data_fim_realizacao_despesas if self.associacao and self.associacao.periodo_inicial and self.associacao.periodo_inicial.data_fim_realizacao_despesas else None
 
-            if data_inicio_realizacao_despesas:
-                if data_transacao < data_inicio_realizacao_despesas:
+            if data_fim_realizacao_despesas:
+                if data_transacao <= data_fim_realizacao_despesas:
+                    self.despesa_anterior_ao_uso_do_sistema = True
+                else:
+                    self.despesa_anterior_ao_uso_do_sistema = False
+            elif data_inicio_realizacao_despesas:
+                if data_transacao <= data_inicio_realizacao_despesas:
                     self.despesa_anterior_ao_uso_do_sistema = True
                 else:
                     self.despesa_anterior_ao_uso_do_sistema = False

--- a/sme_ptrf_apps/despesas/services/despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/despesa_service.py
@@ -32,6 +32,8 @@ def migra_despesas_periodos_anteriores():
     """
     Percorre todas as despesas com data de transação anterior ao período inicial de sua associação e atualiza os campos
     despesa_anterior_ao_uso_do_sistema e despesa_anterior_ao_uso_do_sistema_pc_concluida.
+
+    O período inicial de uma associação é o período do seu saldo de implantação
     """
     logger.info('Obtendo lista de todas as associações ativas..')
     associacoes = Associacao.ativas.all()
@@ -43,7 +45,7 @@ def migra_despesas_periodos_anteriores():
 
         logger.info(f'Migrando despesas anteriores a {associacao.periodo_inicial.referencia} da associação {associacao}..')
 
-        despesas_anteriores = associacao.despesas.filter(data_transacao__lt=associacao.periodo_inicial.data_inicio_realizacao_despesas)
+        despesas_anteriores = associacao.despesas.filter(data_transacao__lte=associacao.periodo_inicial.data_fim_realizacao_despesas)
 
         for despesa in despesas_anteriores:
             logger.info(f'Migrando despesa {despesa}..')


### PR DESCRIPTION
Esse PR implementa a migração dos novos campos que marcam despesas de períodos anteriores.

Obs: Esse PR corrige o código de um PR anterior que tinha um erro de lógica.

AB#122906