### PR TITLE
Inclusão de acento nos testes unitários

### DIFF
--- a/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_dados_unidades/test_exportacoes_unidades.py
+++ b/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_dados_unidades/test_exportacoes_unidades.py
@@ -113,7 +113,7 @@ def test_exporta_unidades_csv(mock_writer):
     nome_arquivo = "exportacao_unidades"
     cabecalho = [[
         'Código EOL', 'Tipo', 'Nome', 'CEP', 'Tipo Logradouro', 'Logradouro',
-        'Bairro', 'Numero', 'Complemento', 'Telefone', 'E-mail',
+        'Bairro', 'Número', 'Complemento', 'Telefone', 'E-mail',
         'Código EOL DRE', 'Nome DRE', 'Sigla DRE', 'Nome Diretor Unidade',
         'Data e hora de criação do registro',
         'Data e hora da última atualização do registro', ],
@@ -131,7 +131,7 @@ def test_exporta_unidades_csv(mock_writer):
 
     cabecalho_esperado = [
         'Código EOL', 'Tipo', 'Nome', 'CEP', 'Tipo Logradouro', 'Logradouro',
-        'Bairro', 'Numero', 'Complemento', 'Telefone', 'E-mail',
+        'Bairro', 'Número', 'Complemento', 'Telefone', 'E-mail',
         'Código EOL DRE', 'Nome DRE', 'Sigla DRE', 'Nome Diretor Unidade',
         'Data e hora de criação do registro',
         'Data e hora da última atualização do registro']


### PR DESCRIPTION
Inclusão de acentuação no cabeçalho dos testes unitários em relação ao valor esperado do CSV gerado