### PR TITLE
test(124771): inclusão de receitas previstas paa nos testes de acoes associações

### DIFF
--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
@@ -20,6 +20,7 @@ def test_retrieve_acao_associacao(
     esperado = {
         'uuid': f'{acao_associacao.uuid}',
         'id': acao_associacao.id,
+        'receitas_previstas_paa': [],
         'associacao': {
             'uuid': f'{acao_associacao.associacao.uuid}',
             'nome': acao_associacao.associacao.nome,

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -25,6 +25,7 @@ def test_api_list_acoes_associacoes_todas(
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -79,6 +80,7 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -132,6 +134,7 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -185,6 +188,7 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -240,6 +244,7 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -296,6 +301,7 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
             {
                 'uuid': f'{acao_associacao.uuid}',
                 'id': acao_associacao.id,
+                'receitas_previstas_paa': [],
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
                     'nome': acao_associacao.associacao.nome,
@@ -346,6 +352,7 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
         {
             'uuid': f'{acao_associacao_charli_bingo_000086_x.uuid}',
             'id': acao_associacao_charli_bingo_000086_x.id,
+            'receitas_previstas_paa': [],
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
                 'nome': acao_associacao_charli_bingo_000086_x.associacao.nome,
@@ -381,6 +388,7 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
         {
             'uuid': f'{acao_associacao_charli_bravo_000086_x.uuid}',
             'id': acao_associacao_charli_bravo_000086_x.id,
+            'receitas_previstas_paa': [],
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',
                 'nome': acao_associacao_charli_bravo_000086_x.associacao.nome,
@@ -430,6 +438,7 @@ def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticat
         {
             'uuid': f'{acao_associacao_charli_bingo_000086_x.uuid}',
             'id': acao_associacao_charli_bingo_000086_x.id,
+            'receitas_previstas_paa': [],
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
                 'nome': acao_associacao_charli_bingo_000086_x.associacao.nome,
@@ -479,6 +488,7 @@ def test_api_list_associacoes_por_associacoes_somente_nao_encerradas(jwt_authent
         {
             'uuid': f'{acao_associacao_charli_bravo_000086_x.uuid}',
             'id': acao_associacao_charli_bravo_000086_x.id,
+            'receitas_previstas_paa': [],
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',
                 'nome': acao_associacao_charli_bravo_000086_x.associacao.nome,


### PR DESCRIPTION
Esse PR:

Atualiza os testes unitários de Ações Associações devido à atualização de serializer para retorno de receitas previstas PAA

História AB#124771