### PR TITLE
feat(126749): Adição de testes unitários para os novos cenários de exclusão de categoria pdde

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -3098,20 +3098,3 @@ def task_celery_criada_2(periodo_2020_1, associacao):
         associacao=associacao,
         periodo=periodo_2020_1
     )
-
-
-@pytest.fixture
-def categoria_pdde():
-    return baker.make(
-        'CategoriaPdde',
-        nome='Categoria PDDE Teste',
-    )
-
-
-@pytest.fixture
-def acao_pdde(categoria_pdde):
-    return baker.make(
-        'AcaoPdde',
-        nome='Ação PDDE Teste',
-        categoria=categoria_pdde,
-    )

--- a/sme_ptrf_apps/core/api/views/categorias_pdde_viewset.py
+++ b/sme_ptrf_apps/core/api/views/categorias_pdde_viewset.py
@@ -46,8 +46,7 @@ class CategoriaPddeViewSet(WaffleFlagMixin, ModelViewSet):
             validação de constraints da Model (ao Criar)"""
 
         nome = self.validar_campos(request)
-        try:
-            CategoriaPdde.objects.get(nome=nome)
+        if CategoriaPdde.objects.filter(nome__iexact=nome).first():
             raise serializers.ValidationError(
                 {
                     "erro": "Duplicated",
@@ -55,10 +54,6 @@ class CategoriaPddeViewSet(WaffleFlagMixin, ModelViewSet):
                                "Categoria PDDE cadastrada com este nome.")
                 }
             )
-        except CategoriaPdde.DoesNotExist:
-            # Não existe nenhuma Categoria PDDE cadastrada com o nome informado,
-            # ao cadastrar uma Categoria PDDE
-            pass
         return super().create(request)
 
     def update(self, request, *args, **kwargs):
@@ -67,8 +62,7 @@ class CategoriaPddeViewSet(WaffleFlagMixin, ModelViewSet):
 
         obj = self.get_object()
         nome = request.data.get('nome')
-        try:
-            CategoriaPdde.objects.exclude(pk=obj.pk).get(nome=nome)
+        if CategoriaPdde.objects.exclude(pk=obj.pk).filter(nome__iexact=nome).first():
             raise serializers.ValidationError(
                 {
                     "erro": "Duplicated",
@@ -76,10 +70,7 @@ class CategoriaPddeViewSet(WaffleFlagMixin, ModelViewSet):
                                "Categoria PDDE cadastrada com este nome.")
                 }
             )
-        except CategoriaPdde.DoesNotExist:
-            # Não existe nenhuma Categoria PDDE cadastrada com o nome informado,
-            # ao atualizar uma Categoria PDDE
-            pass
+
         return super().update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):

--- a/sme_ptrf_apps/core/tests/tests_acoes_pdde/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_acoes_pdde/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from model_bakery import baker
+
 from ...models import AcaoPdde
 from ...admin import AcaoPddeAdmin
 from django.contrib.admin.sites import site
@@ -7,3 +9,20 @@ from django.contrib.admin.sites import site
 @pytest.fixture
 def acao_pdde_admin():
     return AcaoPddeAdmin(model=AcaoPdde, admin_site=site)
+
+
+@pytest.fixture
+def categoria_pdde():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste',
+    )
+
+
+@pytest.fixture
+def acao_pdde(categoria_pdde):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste',
+        categoria=categoria_pdde,
+    )

--- a/sme_ptrf_apps/core/tests/tests_acoes_pdde/test_acoes_pdde_model.py
+++ b/sme_ptrf_apps/core/tests/tests_acoes_pdde/test_acoes_pdde_model.py
@@ -22,3 +22,10 @@ def test_unique_together(acao_pdde):
 
     with pytest.raises(Exception):
         AcaoPddeFactory(nome="Ação PDDE Teste", categoria=acao_pdde.categoria)
+
+
+@pytest.mark.django_db
+def test_acao_pdde_categoria_objeto():
+    acao = AcaoPddeFactory(nome="Ação PDDE Novo")
+
+    assert acao.categoria == acao.categoria_objeto()

--- a/sme_ptrf_apps/core/tests/tests_categoria_pdde/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_categoria_pdde/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from model_bakery import baker
+
 from ...models import CategoriaPdde
 from ...admin import CategoriaPddeAdmin
 from django.contrib.admin.sites import site
@@ -7,3 +9,51 @@ from django.contrib.admin.sites import site
 @pytest.fixture
 def categoria_pdde_admin():
     return CategoriaPddeAdmin(model=CategoriaPdde, admin_site=site)
+
+
+@pytest.fixture
+def categoria_pdde():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste',
+    )
+
+
+@pytest.fixture
+def categoria_pdde_2():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste 2',
+    )
+
+@pytest.fixture
+def categoria_pdde_3():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste 3',
+    )
+
+@pytest.fixture
+def acao_pdde(categoria_pdde):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste',
+        categoria=categoria_pdde,
+    )
+
+@pytest.fixture
+def acao_pdde_2(categoria_pdde_2):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste 2',
+        categoria=categoria_pdde_2,
+    )
+
+
+@pytest.fixture
+def acao_pdde_3(categoria_pdde_2):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste 3',
+        categoria=categoria_pdde_2,
+    )


### PR DESCRIPTION
Esse PR:

- Adição de testes unitários para os novos cenários de exclusão de categoria pdde
- Aumento da cobertura de testes de ações pdde

História: AB#126749