### PR TITLE
feat(126749): Adição de testes unitários para os novos cenários de exclusão de categoria pdde

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -3102,23 +3102,6 @@ def task_celery_criada_2(periodo_2020_1, associacao):
 
 
 @pytest.fixture
-def categoria_pdde():
-    return baker.make(
-        'CategoriaPdde',
-        nome='Categoria PDDE Teste',
-    )
-
-
-@pytest.fixture
-def acao_pdde(categoria_pdde):
-    return baker.make(
-        'AcaoPdde',
-        nome='Ação PDDE Teste',
-        categoria=categoria_pdde,
-    )
-
-
-@pytest.fixture
 def receita_prevista_paa(acao_associacao):
     """
     Fixture para criar instancia de teste de 'ReceitaPrevistaPaa' associada à Ação e

--- a/sme_ptrf_apps/core/tests/tests_acoes_pdde/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_acoes_pdde/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from model_bakery import baker
+
 from ...models import AcaoPdde
 from ...admin import AcaoPddeAdmin
 from django.contrib.admin.sites import site
@@ -7,3 +9,20 @@ from django.contrib.admin.sites import site
 @pytest.fixture
 def acao_pdde_admin():
     return AcaoPddeAdmin(model=AcaoPdde, admin_site=site)
+
+
+@pytest.fixture
+def categoria_pdde():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste',
+    )
+
+
+@pytest.fixture
+def acao_pdde(categoria_pdde):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste',
+        categoria=categoria_pdde,
+    )

--- a/sme_ptrf_apps/core/tests/tests_acoes_pdde/test_acoes_pdde_model.py
+++ b/sme_ptrf_apps/core/tests/tests_acoes_pdde/test_acoes_pdde_model.py
@@ -22,3 +22,10 @@ def test_unique_together(acao_pdde):
 
     with pytest.raises(Exception):
         AcaoPddeFactory(nome="Ação PDDE Teste", categoria=acao_pdde.categoria)
+
+
+@pytest.mark.django_db
+def test_acao_pdde_categoria_objeto():
+    acao = AcaoPddeFactory(nome="Ação PDDE Novo")
+
+    assert acao.categoria == acao.categoria_objeto()

--- a/sme_ptrf_apps/core/tests/tests_categoria_pdde/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_categoria_pdde/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from model_bakery import baker
+
 from ...models import CategoriaPdde
 from ...admin import CategoriaPddeAdmin
 from django.contrib.admin.sites import site
@@ -7,3 +9,51 @@ from django.contrib.admin.sites import site
 @pytest.fixture
 def categoria_pdde_admin():
     return CategoriaPddeAdmin(model=CategoriaPdde, admin_site=site)
+
+
+@pytest.fixture
+def categoria_pdde():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste',
+    )
+
+
+@pytest.fixture
+def categoria_pdde_2():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste 2',
+    )
+
+@pytest.fixture
+def categoria_pdde_3():
+    return baker.make(
+        'CategoriaPdde',
+        nome='Categoria PDDE Teste 3',
+    )
+
+@pytest.fixture
+def acao_pdde(categoria_pdde):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste',
+        categoria=categoria_pdde,
+    )
+
+@pytest.fixture
+def acao_pdde_2(categoria_pdde_2):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste 2',
+        categoria=categoria_pdde_2,
+    )
+
+
+@pytest.fixture
+def acao_pdde_3(categoria_pdde_2):
+    return baker.make(
+        'AcaoPdde',
+        nome='Ação PDDE Teste 3',
+        categoria=categoria_pdde_2,
+    )


### PR DESCRIPTION
Esse PR:

- Adição de testes unitários para os novos cenários de exclusão de categoria pdde;
- Aumento na cobertura de testes
- Correção de conflito de merge

História: AB#126749