### PR TITLE
feat(127758): Ajustes no LogEntryAdmin

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1,6 +1,9 @@
 import logging
 from django.contrib import admin, messages
 from django.forms import ModelForm, ValidationError
+from django.utils.timezone import localtime, make_aware, get_current_timezone
+from auditlog.models import LogEntry
+from auditlog.admin import LogEntryAdmin
 from rangefilter.filters import DateRangeFilter
 from sme_ptrf_apps.core.services.processa_cargas import processa_cargas
 from sme_ptrf_apps.core.services import associacao_pode_implantar_saldo
@@ -1884,3 +1887,18 @@ class RecursoProprioPaaAdmin(admin.ModelAdmin):
     list_display = ('fonte_recurso', 'associacao', 'data_prevista', 'descricao', 'valor',)
     search_fields = ('fonte_recurso__nome', 'associacao__nome',)
     list_filter = ('associacao',)
+
+
+# Ajustes para o LogEntryAdmin não subir excessao de timezone/localtime
+try:
+    admin.site.unregister(LogEntry)
+except admin.sites.NotRegistered:
+    pass
+
+@admin.register(LogEntry)
+class LogEntryAdminCustom(LogEntryAdmin):
+    @admin.display(description="Created")
+    def created(self, obj):
+        fuso_horario_local = get_current_timezone()
+        data_hora_aware = make_aware(obj.timestamp, fuso_horario_local)
+        return localtime(data_hora_aware)


### PR DESCRIPTION
Esse PR:

- Ajuste na classe LogEntryAdmin para evitar erro de localtime/timezone ao exibir a listagem no admin devido à atualização da lib

História: AB#127758