### PR TITLE
feat(126467): Testes parar atualização dos saldos

### DIFF
--- a/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/acao_associacao_factory.py
@@ -6,10 +6,11 @@ from sme_ptrf_apps.core.models.acao_associacao import AcaoAssociacao
 
 fake = Faker("pt_BR")
 
+
 class AcaoAssociacaoFactory(DjangoModelFactory):
     class Meta:
         model = AcaoAssociacao
-        
+
     associacao = SubFactory(AssociacaoFactory)
     acao = SubFactory(AcaoFactory)
     status = "ATIVA"

--- a/sme_ptrf_apps/core/services/acoes_associacoes_service.py
+++ b/sme_ptrf_apps/core/services/acoes_associacoes_service.py
@@ -1,8 +1,6 @@
-from django.db import transaction
 from django.core.exceptions import ValidationError
 from sme_ptrf_apps.core.models import Associacao, AcaoAssociacao
 from sme_ptrf_apps.core.models.periodo import Periodo
-from sme_ptrf_apps.paa.models import ReceitaPrevistaPaa
 from sme_ptrf_apps.core.services.resumo_rescursos_service import ResumoRecursosService
 
 
@@ -38,60 +36,3 @@ def obter_saldos_periodo_atual(acao_associacao):
     }
 
     return saldos
-
-
-class SaldosPorAcaoPaaService:
-    def __init__(self, paa, associacao):
-        self.paa = paa
-        self.associacao = associacao
-
-    @transaction.atomic
-    def descongelar_saldos(self):
-        self.paa.set_descongelar_saldo()
-
-        receitas_previstas = []
-        acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=self.associacao.uuid)
-
-        for acao in acoes_associacao:
-            receita_prevista, _ = ReceitaPrevistaPaa.objects.update_or_create(
-                paa=self.paa,
-                acao_associacao=acao,
-                defaults={
-                    "saldo_congelado_custeio": None,
-                    "saldo_congelado_capital": None,
-                    "saldo_congelado_livre": None,
-                }
-            )
-
-            receitas_previstas.append(receita_prevista)
-
-        return receitas_previstas
-
-    @transaction.atomic
-    def congelar_saldos(self):
-        self.paa.set_congelar_saldo()
-        self.periodo = Periodo.da_data(self.paa.saldo_congelado_em)
-
-        receitas_previstas = []
-        acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=self.associacao.uuid)
-
-        for acao in acoes_associacao:
-            resumo = ResumoRecursosService.resumo_recursos(
-                periodo=self.periodo,
-                acao_associacao=acao,
-                data_fim=self.paa.saldo_congelado_em
-            )
-
-            receita_prevista, _ = ReceitaPrevistaPaa.objects.update_or_create(
-                paa=self.paa,
-                acao_associacao=acao,
-                defaults={
-                    "saldo_congelado_custeio": resumo.saldo_posterior.total_custeio,
-                    "saldo_congelado_capital": resumo.saldo_posterior.total_capital,
-                    "saldo_congelado_livre": resumo.saldo_posterior.total_livre,
-                }
-            )
-
-            receitas_previstas.append(receita_prevista)
-
-        return receitas_previstas

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
@@ -25,7 +25,7 @@ def test_retrieve_acao_associacao(
             'saldo_atual_capital': 0.0,
             'saldo_atual_custeio': 0.0,
             'saldo_atual_livre': 0.0,
-            'saldo_atual_total': 0.0
+
         },
         'associacao': {
             'uuid': f'{acao_associacao.associacao.uuid}',
@@ -62,6 +62,7 @@ def test_retrieve_acao_associacao(
     assert response.status_code == status.HTTP_200_OK
     assert result == esperado
 
+
 def test_retrieve_acao_associacao_saldo_atual(
     jwt_authenticated_client_a,
     acao_associacao_charli_bravo_000086_x
@@ -71,7 +72,6 @@ def test_retrieve_acao_associacao_saldo_atual(
         content_type='application/json')
 
     assert response.status_code == status.HTTP_200_OK
-    assert 'saldo_atual_total' in response.data
     assert 'saldo_atual_capital' in response.data
     assert 'saldo_atual_custeio' in response.data
     assert 'saldo_atual_livre' in response.data

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -30,7 +30,7 @@ def test_api_list_acoes_associacoes_todas(
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
+
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -91,7 +91,7 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
+
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -151,7 +151,7 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
+
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -211,7 +211,6 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -273,7 +272,6 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -336,7 +334,6 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
                     'saldo_atual_capital': 0.0,
                     'saldo_atual_custeio': 0.0,
                     'saldo_atual_livre': 0.0,
-                    'saldo_atual_total': 0.0
                 },
                 'associacao': {
                     'uuid': f'{acao_associacao.associacao.uuid}',
@@ -374,11 +371,12 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
     assert response.status_code == status.HTTP_200_OK
     assert result['results'] == resultado_esperado
 
+
 def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_authenticated_client_a,
                                                                           acao_associacao_charli_bravo_000086_x,
                                                                           acao_associacao_charli_bingo_000086_x,
                                                                           acao_x
-                                                                        ):
+                                                                          ):
 
     response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=ENCERRADAS,NAO_ENCERRADAS',
                                               content_type='application/json')
@@ -393,7 +391,6 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
                 'saldo_atual_capital': 0.0,
                 'saldo_atual_custeio': 0.0,
                 'saldo_atual_livre': 0.0,
-                'saldo_atual_total': 0.0
             },
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
@@ -435,7 +432,6 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
                 'saldo_atual_capital': 0.0,
                 'saldo_atual_custeio': 0.0,
                 'saldo_atual_livre': 0.0,
-                'saldo_atual_total': 0.0
             },
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',
@@ -473,10 +469,11 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
     assert response.status_code == status.HTTP_200_OK
     assert result['results'] == resultado_esperado
 
+
 def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticated_client_a,
                                                                  acao_associacao_charli_bingo_000086_x,
                                                                  acao_x
-                                                                ):
+                                                                 ):
 
     response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=ENCERRADAS',
                                               content_type='application/json')
@@ -491,7 +488,6 @@ def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticat
                 'saldo_atual_capital': 0.0,
                 'saldo_atual_custeio': 0.0,
                 'saldo_atual_livre': 0.0,
-                'saldo_atual_total': 0.0
             },
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bingo_000086_x.associacao.uuid}',
@@ -529,10 +525,11 @@ def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticat
     assert response.status_code == status.HTTP_200_OK
     assert result['results'] == resultado_esperado
 
+
 def test_api_list_associacoes_por_associacoes_somente_nao_encerradas(jwt_authenticated_client_a,
                                                                      acao_associacao_charli_bravo_000086_x,
                                                                      acao_x
-                                                                    ):
+                                                                     ):
 
     response = jwt_authenticated_client_a.get(f'/api/acoes-associacoes/?filtro_informacoes=NAO_ENCERRADAS',
                                               content_type='application/json')
@@ -547,7 +544,6 @@ def test_api_list_associacoes_por_associacoes_somente_nao_encerradas(jwt_authent
                 'saldo_atual_capital': 0.0,
                 'saldo_atual_custeio': 0.0,
                 'saldo_atual_livre': 0.0,
-                'saldo_atual_total': 0.0
             },
             'associacao': {
                 'uuid': f'{acao_associacao_charli_bravo_000086_x.associacao.uuid}',

--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -21,7 +21,7 @@ from sme_ptrf_apps.paa.api.serializers.paa_serializer import PaaSerializer
 from sme_ptrf_apps.paa.api.serializers.receita_prevista_paa_serializer import ReceitaPrevistaPaaSerializer
 from sme_ptrf_apps.paa.models import Paa
 from sme_ptrf_apps.core.models import Associacao
-from sme_ptrf_apps.core.services.acoes_associacoes_service import SaldosPorAcaoPaaService
+from sme_ptrf_apps.paa.services.receitas_previstas_paa_service import SaldosPorAcaoPaaService
 
 logger = logging.getLogger(__name__)
 

--- a/sme_ptrf_apps/paa/fixtures/factories/receitas_previstas_factory.py
+++ b/sme_ptrf_apps/paa/fixtures/factories/receitas_previstas_factory.py
@@ -2,7 +2,8 @@ from factory import DjangoModelFactory, SubFactory, Sequence
 from faker import Faker
 from sme_ptrf_apps.paa.models import ReceitaPrevistaPaa
 from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
-
+from sme_ptrf_apps.paa.fixtures.factories.paa import (
+    PaaFactory)
 fake = Faker("pt_BR")
 
 
@@ -10,6 +11,7 @@ class ReceitaPrevistaPaaFactory(DjangoModelFactory):
     class Meta:
         model = ReceitaPrevistaPaa
 
+    paa = SubFactory(PaaFactory)
     acao_associacao = SubFactory(AcaoAssociacaoFactory)
     previsao_valor_custeio = Sequence(lambda n: fake.random_number(digits=3))
     previsao_valor_capital = Sequence(lambda n: fake.random_number(digits=3))

--- a/sme_ptrf_apps/paa/services/receitas_previstas_paa_service.py
+++ b/sme_ptrf_apps/paa/services/receitas_previstas_paa_service.py
@@ -1,0 +1,62 @@
+from django.db import transaction
+from sme_ptrf_apps.core.models import Associacao
+from sme_ptrf_apps.core.models.periodo import Periodo
+from sme_ptrf_apps.paa.models import ReceitaPrevistaPaa
+from sme_ptrf_apps.core.services.resumo_rescursos_service import ResumoRecursosService
+
+
+class SaldosPorAcaoPaaService:
+    def __init__(self, paa, associacao):
+        self.paa = paa
+        self.associacao = associacao
+
+    @transaction.atomic
+    def descongelar_saldos(self):
+        self.paa.set_descongelar_saldo()
+
+        receitas_previstas = []
+        acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=self.associacao.uuid)
+
+        for acao in acoes_associacao:
+            receita_prevista, _ = ReceitaPrevistaPaa.objects.update_or_create(
+                paa=self.paa,
+                acao_associacao=acao,
+                defaults={
+                    "saldo_congelado_custeio": None,
+                    "saldo_congelado_capital": None,
+                    "saldo_congelado_livre": None,
+                }
+            )
+
+            receitas_previstas.append(receita_prevista)
+
+        return receitas_previstas
+
+    @transaction.atomic
+    def congelar_saldos(self):
+        self.paa.set_congelar_saldo()
+        self.periodo = Periodo.da_data(self.paa.saldo_congelado_em)
+
+        receitas_previstas = []
+        acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=self.associacao.uuid)
+
+        for acao in acoes_associacao:
+            resumo = ResumoRecursosService.resumo_recursos(
+                periodo=self.periodo,
+                acao_associacao=acao,
+                data_fim=self.paa.saldo_congelado_em
+            )
+
+            receita_prevista, _ = ReceitaPrevistaPaa.objects.update_or_create(
+                paa=self.paa,
+                acao_associacao=acao,
+                defaults={
+                    "saldo_congelado_custeio": resumo.saldo_posterior.total_custeio,
+                    "saldo_congelado_capital": resumo.saldo_posterior.total_capital,
+                    "saldo_congelado_livre": resumo.saldo_posterior.total_livre,
+                }
+            )
+
+            receitas_previstas.append(receita_prevista)
+
+        return receitas_previstas

--- a/sme_ptrf_apps/paa/tests/conftest.py
+++ b/sme_ptrf_apps/paa/tests/conftest.py
@@ -22,6 +22,22 @@ def periodo_paa_admin():
 
 
 @pytest.fixture
+def periodo_2025_1(periodo_factory):
+    return periodo_factory.create(
+        referencia='2025.1',
+        data_inicio_realizacao_despesas=date(2025, 1, 1),
+        data_fim_realizacao_despesas=date(2025, 4, 30),
+    )
+
+
+@pytest.fixture
+def periodo_paa_2025_1(periodo_paa_factory, periodo_2025_1):
+    return periodo_paa_factory.create(referencia="Periodo 04/2025 a 10/2025",
+                                      data_inicial=date(2025, 1, 1),
+                                      data_final=date(2025, 4, 30))
+
+
+@pytest.fixture
 def periodo_paa_1(periodo_paa_factory):
     return periodo_paa_factory.create(referencia="Periodo 04/2025 a 10/2025",
                                       data_inicial=date(2025, 4, 1),

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_serializer.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_serializer.py
@@ -1,0 +1,15 @@
+import pytest
+
+from sme_ptrf_apps.paa.api.serializers import PaaSerializer
+
+pytestmark = pytest.mark.django_db
+
+
+def test_paa_retriever_serializer(paa):
+    serializer = PaaSerializer(paa)
+    assert serializer.data is not None
+    assert 'uuid' in serializer.data
+    assert 'periodo_paa' in serializer.data
+    assert 'associacao' in serializer.data
+    assert 'periodo_paa_objeto' in serializer.data
+    assert 'saldo_congelado_em' in serializer.data

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_viewset.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_viewset.py
@@ -1,0 +1,44 @@
+import pytest
+from datetime import datetime
+from freezegun import freeze_time
+from rest_framework import status
+from sme_ptrf_apps.paa.models import Paa
+
+pytestmark = pytest.mark.django_db
+
+
+@freeze_time('2025-01-01')
+def test_desativar_atualizacao_saldo(jwt_authenticated_client_sme, periodo_paa_2025_1, flag_paa, paa_factory, acao_associacao_factory):
+    paa = paa_factory.create(
+        periodo_paa=periodo_paa_2025_1,
+    )
+
+    acao_associacao_factory.create(associacao=paa.associacao)
+    acao_associacao_factory.create(associacao=paa.associacao)
+
+    response = jwt_authenticated_client_sme.post(f"/api/paa/{paa.uuid}/desativar-atualizacao-saldo/")
+
+    result = response.json()
+    paa = Paa.objects.get(id=paa.id)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(result) == 2
+    assert paa.saldo_congelado_em == datetime(2025, 1, 1, 0, 0)
+
+
+def test_ativar_atualizacao_saldo(jwt_authenticated_client_sme, periodo_paa_2025_1, flag_paa, paa_factory, acao_associacao_factory):
+    paa = paa_factory.create(
+        periodo_paa=periodo_paa_2025_1,
+    )
+
+    acao_associacao_factory.create(associacao=paa.associacao)
+    acao_associacao_factory.create(associacao=paa.associacao)
+
+    response = jwt_authenticated_client_sme.post(f"/api/paa/{paa.uuid}/ativar-atualizacao-saldo/")
+
+    result = response.json()
+    paa = Paa.objects.get(id=paa.id)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(result) == 2
+    assert paa.saldo_congelado_em is None

--- a/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_model.py
+++ b/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_model.py
@@ -4,8 +4,9 @@ from sme_ptrf_apps.paa.fixtures.factories import ReceitaPrevistaPaaFactory
 
 
 @pytest.mark.django_db
-def test_create_receita_prevista_paa(acao_associacao):
+def test_create_receita_prevista_paa(paa, acao_associacao):
     receita = ReceitaPrevistaPaaFactory(
+        paa=paa,
         acao_associacao=acao_associacao,
         previsao_valor_custeio=1000.0,
         previsao_valor_capital=1010.0,

--- a/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_serializer.py
+++ b/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_serializer.py
@@ -13,3 +13,6 @@ def test_receita_prevista_serializer_list_serializer(receita_prevista_paa):
     assert 'previsao_valor_custeio' in serializer.data
     assert 'previsao_valor_capital' in serializer.data
     assert 'previsao_valor_livre' in serializer.data
+    assert 'saldo_congelado_custeio' in serializer.data
+    assert 'saldo_congelado_capital' in serializer.data
+    assert 'saldo_congelado_livre' in serializer.data

--- a/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_viewset.py
+++ b/sme_ptrf_apps/paa/tests/receitas_previstas_paa/test_receitas_previstas_paa_viewset.py
@@ -11,10 +11,11 @@ def flag_paa():
 
 
 @pytest.mark.django_db
-def test_lista_receita_prevista_paa(jwt_authenticated_client_sme, acao_associacao, flag_paa):
+def test_lista_receita_prevista_paa(jwt_authenticated_client_sme, acao_associacao, paa, flag_paa):
 
     for index in range(50):
         ReceitaPrevistaPaaFactory.create(
+            paa=paa,
             acao_associacao=acao_associacao,
             previsao_valor_custeio=100 + index,
             previsao_valor_capital=101 + index,

--- a/sme_ptrf_apps/paa/tests/receitas_previstas_pdde/test_receitas_previstas_pdde_model.py
+++ b/sme_ptrf_apps/paa/tests/receitas_previstas_pdde/test_receitas_previstas_pdde_model.py
@@ -4,8 +4,9 @@ from sme_ptrf_apps.paa.fixtures.factories import ReceitaPrevistaPaaFactory
 
 
 @pytest.mark.django_db
-def test_create_receita_prevista_paa(acao_associacao):
+def test_create_receita_prevista_paa(paa, acao_associacao):
     receita = ReceitaPrevistaPaaFactory(
+        paa=paa,
         acao_associacao=acao_associacao,
         previsao_valor_custeio=1000.0,
         previsao_valor_capital=1010.0,

--- a/sme_ptrf_apps/paa/tests/services/test_receitas_previstas_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_receitas_previstas_paa_service.py
@@ -1,0 +1,60 @@
+import pytest
+from freezegun import freeze_time
+from datetime import datetime
+from sme_ptrf_apps.paa.services.receitas_previstas_paa_service import SaldosPorAcaoPaaService
+
+
+@pytest.mark.django_db
+@freeze_time("2025-01-01")
+def test_congelar_saldos(paa_factory, acao_associacao_factory, periodo_paa_2025_1):
+    paa = paa_factory.create(periodo_paa=periodo_paa_2025_1)
+
+    acao_associacao_factory.create(associacao=paa.associacao)
+    acao_associacao_factory.create(associacao=paa.associacao)
+
+    service = SaldosPorAcaoPaaService(paa=paa, associacao=paa.associacao)
+    receitas_previstas = service.congelar_saldos()
+
+    assert paa.saldo_congelado_em == datetime(2025, 1, 1)
+    assert len(receitas_previstas) == 2
+
+    for receita in receitas_previstas:
+        assert receita.paa == paa
+        assert receita.saldo_congelado_custeio is not None
+        assert receita.saldo_congelado_capital is not None
+        assert receita.saldo_congelado_livre is not None
+
+
+@pytest.mark.django_db
+def test_descongelar_saldos(paa_factory, acao_associacao_factory, receita_prevista_paa_factory, periodo_paa_2025_1):
+    paa = paa_factory.create(
+        periodo_paa=periodo_paa_2025_1,
+        saldo_congelado_em="2025-01-01"
+    )
+
+    acao1 = acao_associacao_factory.create(associacao=paa.associacao)
+    acao2 = acao_associacao_factory.create(associacao=paa.associacao)
+
+    receita_prevista_paa_factory.create(
+        paa=paa,
+        acao_associacao=acao1,
+        saldo_congelado_custeio=100,
+        saldo_congelado_capital=50,
+        saldo_congelado_livre=20
+    )
+    receita_prevista_paa_factory.create(
+        paa=paa,
+        acao_associacao=acao2,
+        saldo_congelado_custeio=200,
+        saldo_congelado_capital=100,
+        saldo_congelado_livre=40
+    )
+
+    service = SaldosPorAcaoPaaService(paa=paa, associacao=paa.associacao)
+    receitas_previstas = service.descongelar_saldos()
+
+    assert paa.saldo_congelado_em is None
+    for receita in receitas_previstas:
+        assert receita.saldo_congelado_custeio is None
+        assert receita.saldo_congelado_capital is None
+        assert receita.saldo_congelado_livre is None


### PR DESCRIPTION
Esse PR:

- Implementa testes para actions ativa/desativar atualização do saldo
- Implementa testes para service congelar/descongelar atualização do saldos
- Atualiza testes do paa e ação associação

AB#126467