### PR TITLE
feat(127464): Listagem e ordenação de Prioridade PAA

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/especificacao_material_servico_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/especificacao_material_servico_serializer.py
@@ -4,6 +4,12 @@ from ..serializers.tipo_custeio_serializer import TipoCusteioSerializer
 from ...models import EspecificacaoMaterialServico
 
 
+class EspecificacaoMaterialServicoSimplesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EspecificacaoMaterialServico
+        fields = ('uuid', 'nome')
+
+
 class EspecificacaoMaterialServicoSerializer(serializers.ModelSerializer):
     tipo_custeio_objeto = TipoCusteioSerializer(read_only=True, source='tipo_custeio')
 

--- a/sme_ptrf_apps/despesas/api/serializers/tipo_custeio_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/tipo_custeio_serializer.py
@@ -3,6 +3,12 @@ from rest_framework import serializers
 from ...models import TipoCusteio
 
 
+class TipoCusteioSimplesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TipoCusteio
+        fields = ('uuid', 'nome')
+
+
 class TipoCusteioSerializer(serializers.ModelSerializer):
     class Meta:
         model = TipoCusteio

--- a/sme_ptrf_apps/despesas/models/especificacao_material_servico.py
+++ b/sme_ptrf_apps/despesas/models/especificacao_material_servico.py
@@ -24,6 +24,9 @@ class EspecificacaoMaterialServico(ModeloBase):
     def __str__(self):
         return f"{self.descricao}"
 
+    def nome(self):
+        return self.descricao
+
     class Meta:
         verbose_name = "Especificação de material ou serviço"
         verbose_name_plural = "Especificações de materiais ou serviços"

--- a/sme_ptrf_apps/paa/admin.py
+++ b/sme_ptrf_apps/paa/admin.py
@@ -11,6 +11,7 @@ from sme_ptrf_apps.paa.models import (
     ReceitaPrevistaPdde,
     Paa,
     PrioridadePaa)
+from sme_ptrf_apps.paa.querysets import queryset_prioridades_paa
 
 
 @admin.register(PeriodoPaa)
@@ -118,16 +119,15 @@ class ReceitaPrevistaPddeAdmin(admin.ModelAdmin):
 @admin.register(PrioridadePaa)
 class PrioridadePaaAdmin(admin.ModelAdmin):
     list_display = (
-        'paa',
+        'nome',
         'prioridade',
         'recurso',
-        'acao_associacao',
-        'programa_pdde',
-        'acao_pdde',
         'tipo_aplicacao',
+        'programa_pdde',
         'tipo_despesa_custeio',
         'especificacao_material',
-        'valor_total'
+        'valor_total',
+        'paa',
     )
     list_filter = ('recurso', 'prioridade', 'tipo_aplicacao', 'programa_pdde', 'acao_pdde',)
     raw_id_fields = ('paa', 'acao_pdde', 'acao_associacao', 'programa_pdde', 'tipo_despesa_custeio',
@@ -135,3 +135,7 @@ class PrioridadePaaAdmin(admin.ModelAdmin):
     readonly_fields = ('uuid', 'id', 'criado_em', 'alterado_em')
     search_fields = ('acao_associacao__acao__nome', 'acao_associacao__associacao__nome', 'programa_pdde__nome',
                      'acao_pdde__nome', 'tipo_despesa_custeio__nome', 'especificacao_material__descricao')
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return queryset_prioridades_paa(qs)

--- a/sme_ptrf_apps/paa/api/serializers/__init__.py
+++ b/sme_ptrf_apps/paa/api/serializers/__init__.py
@@ -1,13 +1,14 @@
 # flake8: noqa
 from .periodo_paa_serializer import PeriodoPaaSerializer
 from .paa_serializer import PaaSerializer
-from .acao_pdde_serializer import AcaoPddeSerializer
+from .acao_pdde_serializer import AcaoPddeSerializer, AcaoPddeSimplesSerializer
 from .fonte_recurso_paa_serializer import FonteRecursoPaaSerializer
 from .receita_prevista_paa_serializer import ReceitaPrevistaPaaSerializer
 from .receita_prevista_pdde_serializer import ReceitaPrevistaPddeSerializer
 from .recurso_proprio_paa_serializer import RecursoProprioPaaCreateSerializer, RecursoProprioPaaListSerializer
 from .programa_pdde_serializer import (
     ProgramaPddeSerializer,
+    ProgramaPddeSimplesSerializer,
     ProgramaPddeComTotaisSerializer,
     TotalGeralSerializer,
     ProgramasPddeSomatorioTotalSerializer

--- a/sme_ptrf_apps/paa/api/serializers/acao_pdde_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/acao_pdde_serializer.py
@@ -4,6 +4,13 @@ from sme_ptrf_apps.paa.models import AcaoPdde, ProgramaPdde
 from sme_ptrf_apps.paa.api.serializers.programa_pdde_serializer import ProgramaPddeSerializer
 
 
+class AcaoPddeSimplesSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AcaoPdde
+        fields = ('uuid', 'nome')
+
+
 class AcaoPddeSerializer(serializers.ModelSerializer):
     programa = serializers.SlugRelatedField(queryset=ProgramaPdde.objects.all(), slug_field='uuid')
     programa_objeto = ProgramaPddeSerializer(read_only=True, many=False)

--- a/sme_ptrf_apps/paa/api/serializers/programa_pdde_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/programa_pdde_serializer.py
@@ -3,6 +3,13 @@ from rest_framework import serializers
 from sme_ptrf_apps.paa.models import ProgramaPdde
 
 
+class ProgramaPddeSimplesSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = ProgramaPdde
+        fields = ('uuid', 'nome')
+
+
 class ProgramaPddeSerializer(serializers.ModelSerializer):
     pode_ser_excluida = serializers.SerializerMethodField()
 

--- a/sme_ptrf_apps/paa/api/views/prioridade_paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/prioridade_paa_viewset.py
@@ -15,6 +15,7 @@ from sme_ptrf_apps.paa.api.serializers import (
     PrioridadePaaListSerializer
 )
 from sme_ptrf_apps.users.permissoes import PermissaoApiUe
+from sme_ptrf_apps.paa.querysets import queryset_prioridades_paa
 
 
 class PrioridadePaaViewSet(WaffleFlagMixin, ModelViewSet):
@@ -26,7 +27,23 @@ class PrioridadePaaViewSet(WaffleFlagMixin, ModelViewSet):
     http_method_names = ["get", "post", "patch", "delete"]
     pagination_class = CustomPagination
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filterset_fields = ('acao_associacao__uuid',)
+    filterset_fields = (
+        'acao_associacao__uuid',
+        'paa__uuid',
+        'recurso',
+        'prioridade',  # 0 (False) ou 1 (True)
+        'programa_pdde__uuid',
+        'acao_pdde__uuid',
+        'tipo_aplicacao',
+        'tipo_despesa_custeio__uuid',
+        'especificacao_material__uuid',
+    )
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = queryset_prioridades_paa(qs)
+
+        return qs
 
     def get_serializer_class(self):
         if self.action == 'list':

--- a/sme_ptrf_apps/paa/models/prioridade_paa.py
+++ b/sme_ptrf_apps/paa/models/prioridade_paa.py
@@ -57,5 +57,17 @@ class PrioridadePaa(ModeloBase):
         verbose_name = "Prioridade do PAA"
         verbose_name_plural = "Prioridades do PAA"
 
+    def nome(self):
+        """
+            Exibição unificada em um campo, no admin, de acordo com a condição abaixo
+        """
+        if self.acao_associacao:
+            return self.acao_associacao.acao.nome
+        elif self.acao_pdde:
+            return self.acao_pdde.nome
+        else:
+            return 'Recursos Próprios'
+    nome.short_description = 'Ação'
+
 
 auditlog.register(PrioridadePaa)

--- a/sme_ptrf_apps/paa/querysets.py
+++ b/sme_ptrf_apps/paa/querysets.py
@@ -1,0 +1,43 @@
+from django.db.models import Case, When, Value, IntegerField, F, CharField
+from sme_ptrf_apps.paa.enums import RecursoOpcoesEnum
+
+
+def queryset_prioridades_paa(qs):
+    # Definição da ordenação customizada definida em história AB#127464
+    PRIORIDADEPAA_ORDENACAO_PRIORIDADE_RECURSO = Case(
+        # Prioridade Sim
+        When(prioridade=True, recurso=RecursoOpcoesEnum.PTRF.name, then=Value(1)),
+        When(prioridade=True, recurso=RecursoOpcoesEnum.PDDE.name, then=Value(2)),
+        When(prioridade=True, recurso=RecursoOpcoesEnum.RECURSO_PROPRIO.name, then=Value(3)),
+
+        # Prioridade Não
+        When(prioridade=False, recurso=RecursoOpcoesEnum.PTRF.name, then=Value(4)),
+        When(prioridade=False, recurso=RecursoOpcoesEnum.PDDE.name, then=Value(5)),
+        When(prioridade=False, recurso=RecursoOpcoesEnum.RECURSO_PROPRIO.name, then=Value(6)),
+        default=Value(99),
+        output_field=IntegerField()
+    )
+
+    # Alfabética
+    PRIORIDADEPAA_ORDENACAO_NOME = Case(
+        When(recurso=RecursoOpcoesEnum.PTRF.name, then=F('acao_associacao__acao__nome')),
+        When(recurso=RecursoOpcoesEnum.PDDE.name, then=F('acao_pdde__nome')),
+        When(recurso=RecursoOpcoesEnum.RECURSO_PROPRIO, then=F('especificacao_material__descricao')),
+        default=Value(''),
+        output_field=CharField()
+    )
+
+    qs = qs.select_related(
+        'paa',
+        'acao_associacao',
+        'acao_associacao__acao',
+        'acao_associacao__associacao',
+        'programa_pdde',
+        'acao_pdde__programa',
+        'especificacao_material',
+        'especificacao_material__tipo_custeio',
+        'tipo_despesa_custeio',
+    )
+
+    return qs.annotate(ordem_customizada=PRIORIDADEPAA_ORDENACAO_PRIORIDADE_RECURSO) \
+        .order_by('ordem_customizada', PRIORIDADEPAA_ORDENACAO_NOME)


### PR DESCRIPTION
Esse PR:

- Adiciona filtros de queryset e ordenação customizada. 
- Ordenação reutilizada no django admin.
- Inclusão de Serializers simplificados para compor o Serializer de listagem de Prioridades

História [AB#127464](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/127464)