### PR TITLE
tec(130911): Inclusão de Parâmetros de Documentação de API no Swagger

### DIFF
--- a/sme_ptrf_apps/core/api/views/atas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/atas_viewset.py
@@ -6,6 +6,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework import status
+
+from drf_spectacular.utils import (
+    extend_schema, OpenApiParameter, OpenApiTypes, OpenApiResponse, OpenApiExample)
+
 from sme_ptrf_apps.core.models.prestacao_conta import PrestacaoConta
 from sme_ptrf_apps.core.services.ata_service import validar_campos_ata
 from django.core.exceptions import ValidationError
@@ -37,6 +41,44 @@ class AtasViewSet(mixins.RetrieveModelMixin,
         else:
             return AtaSerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='associacao_uuid', description='UUID da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='periodo_uuid', description='UUID do Período', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conta-associacao', description='UUID da Conta da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+        ],
+        responses={200: OpenApiResponse(
+            response={
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        "nome_fornecedor": {"type": "string"},
+                        "cpf_cnpj_fornecedor": {"type": "string"},
+                        "tipo_documento": {"type": "string"},
+                        "numero_documento": {"type": "string"},
+                        "data_documento": {"type": "string"},
+                        "tipo_transacao": {"type": "string"},
+                        "data_transacao": {"type": "string"},
+                        "valor_total": {"type": "integer"},
+                        "motivos_pagamento_antecipado": {
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    "motivo": {"type": "string"},
+                                }
+                            }
+                        },
+                        "outros_motivos_pagamento_antecipado": {"type": "string"},
+                    },
+                }
+            }
+        )},
+    )
     @action(detail=False, methods=['get'], url_path='ata-despesas-com-pagamento-antecipado',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def ata_despesas_com_pagamento_antecipado(self, request):
@@ -66,6 +108,22 @@ class AtasViewSet(mixins.RetrieveModelMixin,
 
         return Response(despesas_com_pagamento_antecipado, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='prestacao-de-conta-uuid', description='UUID da prestação de contas', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='ata-uuid', description='UUID da ata', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+        ],
+        responses={200: 'Arquivo na fila para processamento.'},
+        examples=[
+            OpenApiExample(
+                'Resposta',
+                value={'mensagem': 'Arquivo na fila para processamento.'}
+            )
+        ],
+        description='Envia demonstrativo financeiro para processamento.'
+    )
     @action(detail=False, methods=['get'], url_path='gerar-arquivo-ata',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def gerar_arquivo_ata(self, request):
@@ -80,11 +138,12 @@ class AtasViewSet(mixins.RetrieveModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            prestacao_de_contas = PrestacaoConta.by_uuid(prestacao_de_contas_uuid)
+            PrestacaoConta.by_uuid(prestacao_de_contas_uuid)
         except ValidationError:
             erro = {
                 'erro': 'Objeto não encontrado.',
-                'mensagem': f"O objeto prestação de contas para o uuid {prestacao_de_contas_uuid} não foi encontrado na base."
+                'mensagem': (
+                    f"O objeto prestação de contas para o uuid {prestacao_de_contas_uuid} não foi encontrado na base.")
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
@@ -117,6 +176,16 @@ class AtasViewSet(mixins.RetrieveModelMixin,
             status=status.HTTP_200_OK
         )
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='ata-uuid', description='UUID da ata', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+        ],
+        responses={
+            (200, 'application/pdf'): OpenApiTypes.BINARY,
+        },
+        description="Retorna um arquivo PDF - Ata."
+    )
     @action(detail=False, methods=['get'], url_path='download-arquivo-ata',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def download_arquivo_ata(self, request):
@@ -157,6 +226,44 @@ class AtasViewSet(mixins.RetrieveModelMixin,
 
         return response
 
+    @extend_schema(
+        parameters=[],
+        responses={200: OpenApiResponse(
+            response={
+                'type': 'object',
+                'properties': {
+                    "tipo_ata": {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {'id': {'type': 'string'}, 'nome': {'type': 'string'}}
+                        },
+                    },
+                    "tipos_reuniao": {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {'id': {'type': 'string'}, 'nome': {'type': 'string'}}
+                        },
+                    },
+                    "convocacoes": {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {'id': {'type': 'string'}, 'nome': {'type': 'string'}}
+                        },
+                    },
+                    "pareceres": {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {'id': {'type': 'string'}, 'nome': {'type': 'string'}}
+                        },
+                    },
+                },
+            }
+        )},
+    )
     @action(detail=False, url_path='tabelas',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def tabelas(self, request):

--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -6,6 +6,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from drf_spectacular.utils import (
+    extend_schema, OpenApiParameter, OpenApiTypes, OpenApiResponse)
+
 from django.http import HttpResponse
 
 from sme_ptrf_apps.users.permissoes import (
@@ -43,6 +46,36 @@ class ConciliacoesViewSet(GenericViewSet):
     permission_classes = [IsAuthenticated & PermissaoApiUe]
     queryset = ObservacaoConciliacao.objects.all()
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='conta_associacao', description='UUID da Conta da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='periodo', description='UUID do Período', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+        ],
+        responses={200: OpenApiResponse(
+            response={
+                'type': 'object',
+                'properties': {
+                    'saldo_anterior': {'type': 'number'},
+                    'saldo_anterior_conciliado': {'type': 'number'},
+                    'saldo_anterior_nao_conciliado': {'type': 'number'},
+                    'receitas_total': {'type': 'number'},
+                    'receitas_conciliadas': {'type': 'number'},
+                    'receitas_nao_conciliadas': {'type': 'number'},
+                    'despesas_total': {'type': 'number'},
+                    'despesas_conciliadas': {'type': 'number'},
+                    'despesas_nao_conciliadas': {'type': 'number'},
+                    'despesas_outros_periodos': {'type': 'number'},
+                    'despesas_outros_periodos_conciliadas': {'type': 'number'},
+                    'despesas_outros_periodos_nao_conciliadas': {'type': 'number'},
+                    'saldo_posterior_total': {'type': 'number'},
+                    'saldo_posterior_conciliado': {'type': 'number'},
+                    'saldo_posterior_nao_conciliado': {'type': 'number'},
+                },
+            }
+        )},
+    )
     @action(detail=False, methods=['get'], url_path='tabela-valores-pendentes',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def tabela_valores_pendentes(self, request):
@@ -79,6 +112,19 @@ class ConciliacoesViewSet(GenericViewSet):
 
         return Response(result, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='conta_associacao', description='UUID da Conta da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='acao_associacao', description='UUID da Ação Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='periodo', description='UUID do Período', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conferido', description='Conferido?', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY, enum=['True', 'False']),
+        ],
+        responses={200: ReceitaListaSerializer(many=True)},
+    )
     @action(detail=False, methods=['get'],
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def receitas(self, request):
@@ -162,6 +208,19 @@ class ConciliacoesViewSet(GenericViewSet):
 
         return Response(ReceitaListaSerializer(receitas, many=True).data, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='periodo', description='UUID do Período', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conta_associacao', description='UUID da Conta da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='acao_associacao', description='UUID da Ação Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conferido', description='Conferido?', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY, enum=['True', 'False']),
+        ],
+        responses={200: RateioDespesaListaSerializer(many=True)},
+    )
     @action(detail=False, methods=['get'],
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def despesas(self, request):
@@ -308,10 +367,39 @@ class ConciliacoesViewSet(GenericViewSet):
 
         return Response({'mensagem': 'Informações gravadas'}, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='associacao', description='UUID da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='periodo', description='UUID do Período', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conta_associacao', description='UUID da Conta da Associação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name='conferido', description='Conferido?', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY, enum=['True', 'False']),
+        ],
+        responses={200: OpenApiResponse(
+            response={
+                'type': 'object',
+                'properties': {
+                    'data_encerramento': {'type': 'string', 'format': 'date'},
+                    'saldo_encerramewnto': {'type': 'number'},
+                    'possui_solicitacao_encerramento': {'type': 'boolean'},
+                    'data_extrato': {'type': 'string', 'format': 'date'},
+                    'saldo_extrato': {'type': 'number'},
+                    'observacao_uuid': {'type': 'string'},
+                    'observacao': {'type': 'string'},
+                    'comprovante_extrato': {'type': 'string'},
+                    'data_atualizacao_comprovante_extrato': {'type': 'string', 'format': 'date'},
+                    'permite_editar_campos_extrato': {'type': 'boolean'},
+                },
+            }
+        )},
+    )
     @action(detail=False, methods=['get'], url_path='observacoes',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def observacoes(self, request):
-        
+
         # Define a Associacao
         associacao_uuid = self.request.query_params.get('associacao')
 
@@ -331,7 +419,7 @@ class ConciliacoesViewSet(GenericViewSet):
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
-        
+
         # Define o período de conciliação
         periodo_uuid = self.request.query_params.get('periodo')
 
@@ -380,7 +468,7 @@ class ConciliacoesViewSet(GenericViewSet):
             comprovante_extrato_nome = observacao.comprovante_extrato.name
 
         result = {}
-        
+
         if observacao:
             result = {
                 'observacao_uuid': observacao.uuid,
@@ -403,19 +491,26 @@ class ConciliacoesViewSet(GenericViewSet):
                 'observacao_uuid': observacao.uuid if observacao else None,
                 'observacao': observacao.texto if observacao else None,
                 'comprovante_extrato': comprovante_extrato_nome if observacao else None,
-                'data_atualizacao_comprovante_extrato': observacao.data_atualizacao_comprovante_extrato if observacao else None,
+                'data_atualizacao_comprovante_extrato': observacao.data_atualizacao_comprovante_extrato if observacao else None,  # noqa
             }
-            
+
         permite_editar = permite_editar_campos_extrato(
             associacao,
             periodo,
             conta_associacao
         )
-        
+
         result['permite_editar_campos_extrato'] = permite_editar
-            
+
         return Response(result, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='observacao_uuid', description='UUID da Observação', required=True,
+                             type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+        ],
+        responses={200: OpenApiTypes.BINARY},
+    )
     @action(detail=False, methods=['get'], url_path='download-extrato-bancario',
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao]
             )
@@ -804,4 +899,3 @@ class ConciliacoesViewSet(GenericViewSet):
         }
 
         return Response(result, status=status.HTTP_200_OK)
-

--- a/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/membro_associacao_viewset.py
@@ -9,7 +9,8 @@ from rest_framework.filters import SearchFilter
 
 from sme_ptrf_apps.core.api.serializers import MembroAssociacaoCreateSerializer, MembroAssociacaoListSerializer
 from sme_ptrf_apps.core.models import MembroAssociacao
-from sme_ptrf_apps.core.services import TerceirizadasException, TerceirizadasService, SmeIntegracaoApiService, SmeIntegracaoApiException
+from sme_ptrf_apps.core.services import (
+    TerceirizadasException, TerceirizadasService, SmeIntegracaoApiService, SmeIntegracaoApiException)
 from sme_ptrf_apps.users.permissoes import PermissaoApiUe, PermissaoAPITodosComLeituraOuGravacao
 
 

--- a/sme_ptrf_apps/core/api/views/processos_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/processos_associacao_viewset.py
@@ -6,8 +6,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 from rest_framework import status
-from sme_ptrf_apps.core.api.serializers import ProcessoAssociacaoCreateSerializer, ProcessoAssociacaoRetrieveSerializer, \
-    PeriodoLookUpSerializer
+from sme_ptrf_apps.core.api.serializers import (
+    ProcessoAssociacaoCreateSerializer,
+    ProcessoAssociacaoRetrieveSerializer,
+    PeriodoLookUpSerializer)
 from sme_ptrf_apps.core.models import ProcessoAssociacao, Periodo
 from sme_ptrf_apps.users.permissoes import PermissaoApiDre
 
@@ -34,7 +36,8 @@ class ProcessosAssociacaoViewSet(mixins.RetrieveModelMixin,
         if instance.e_o_ultimo_processo_do_ano_com_pcs_vinculada:
             msg = {
                 'erro': 'possui_prestacao_de_conta_vinculada',
-                'mensagem': 'Não é possível excluir o número desse processo SEI, pois este já está vinculado a uma prestação de contas. Caso necessário, é possível editá-lo.'
+                'mensagem': ('Não é possível excluir o número desse processo SEI, pois este já está vinculado a'
+                             ' uma prestação de contas. Caso necessário, é possível editá-lo.')
             }
             return Response(msg, status=status.HTTP_400_BAD_REQUEST)
 
@@ -74,7 +77,8 @@ class ProcessosAssociacaoViewSet(mixins.RetrieveModelMixin,
             processos_associacao_query = processos_associacao_query.exclude(uuid=processo_uuid)
 
         # Exclui os períodos já vinculados a outros processos da associação.
-        periodos_ja_vinculados = [uuid for uuid in processos_associacao_query.values_list('periodos__uuid', flat=True).distinct() if uuid is not None]
+        periodos_ja_vinculados = [uuid for uuid in processos_associacao_query.values_list(
+            'periodos__uuid', flat=True).distinct() if uuid is not None]
         periodos_disponiveis = periodos_query.exclude(uuid__in=periodos_ja_vinculados)
 
         serializer = PeriodoLookUpSerializer(periodos_disponiveis, many=True)

--- a/sme_ptrf_apps/users/api/views/senha_viewset.py
+++ b/sme_ptrf_apps/users/api/views/senha_viewset.py
@@ -57,7 +57,3 @@ class RedefinirSenhaViewSet(viewsets.ModelViewSet):
             logger.error(f'Erro ao alterar a senha: {result}')
             return result
         return Response({'detail': 'Senha redefinida com sucesso'}, status=status.HTTP_200_OK)
-
-
-
-


### PR DESCRIPTION
Esse PR:

Adiciona Parâmetros de URL na documentação Swagger nas seguintes views:
DemonstrativoFinanceiroViewSet
actions:
 - previa()
 - documento_final()
 - documento_previa()
 - acoes()
 - demonstrativo_info()
 - pdf()

RelacaoBensViewSet
actions:
 - previa()
 - documento_final()
 - documento_previa()
 - relacao_bens_info()
 - pdf()

AtasViewSet
 - ata_despesas_com_pagamento_antecipado()
 - gerar_arquivo_ata()
 - download_arquivo_ata()
 - tabelas()

ConciliacoesViewSet
 - tabela_valores_pendentes()
 - receitas()
 - despesas()
 - observacoes()
 - download_extrato_bancario()


História AB#130911