### PR TITLE
feat(131974): Corrige cenário de acerto em extrato

### DIFF
--- a/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/conciliacoes_viewset.py
@@ -489,18 +489,10 @@ class ConciliacoesViewSet(GenericViewSet):
         }
 
         # Regra US #129997
-        # 1º: Data de encerramento da conta, caso tenha solicitação de encerramento.
-        # 2º: Última dia do período selecionado.
-        # 3º: Data extrato
-
-        if observacao and observacao.data_extrato:
-            result['data_extrato'] = observacao.data_extrato
-        elif info_solicitacao["possui_solicitacao_encerramento"]:
+        if info_solicitacao["possui_solicitacao_encerramento"]:
             result['data_extrato'] = info_solicitacao["data_encerramento"]
-        elif periodo.data_fim_realizacao_despesas:
-            result['data_extrato'] = periodo.data_fim_realizacao_despesas
         else:
-            result['data_extrato'] = None
+            result['data_extrato'] = periodo.data_fim_realizacao_despesas
 
         return Response(result, status=status.HTTP_200_OK)
 

--- a/sme_ptrf_apps/core/models/analise_prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/analise_prestacao_conta.py
@@ -198,11 +198,6 @@ class AnalisePrestacaoConta(ModeloBase):
 
         return tem_analises_de_lancamentos_pendentes or tem_analises_de_documentos_pendentes
 
-    def tem_acertos_extratos_bancarios(self, conta_associacao):
-        acerto_extrato_bancario = self.analises_de_extratos.filter(conta_associacao=conta_associacao).exists()
-
-        return acerto_extrato_bancario
-
     def __str__(self):
         return f"{self.prestacao_conta.periodo} - Análise #{self.pk}"
 

--- a/sme_ptrf_apps/core/models/conta_associacao.py
+++ b/sme_ptrf_apps/core/models/conta_associacao.py
@@ -431,6 +431,7 @@ class ContaAssociacao(ModeloBase):
 
     def get_info_solicitacao_encerramento(self, periodo):
         from sme_ptrf_apps.core.models import SolicitacaoEncerramentoContaAssociacao
+        from sme_ptrf_apps.core.models import Periodo
 
         info = {
             "data_encerramento": None,
@@ -442,11 +443,11 @@ class ContaAssociacao(ModeloBase):
             if (
                 self.solicitacao_encerramento.status != SolicitacaoEncerramentoContaAssociacao.STATUS_REJEITADA
             ):
-                saldo = 0
+                periodo_encerramento = Periodo.da_data(self.solicitacao_encerramento.data_de_encerramento_na_agencia)
 
-                if self.solicitacao_encerramento.data_de_encerramento_na_agencia <= periodo.data_fim_realizacao_despesas:
+                if periodo_encerramento and periodo_encerramento.referencia == periodo.referencia:
                     info["data_encerramento"] = self.solicitacao_encerramento.data_de_encerramento_na_agencia
-                    info["saldo"] = saldo
+                    info["saldo"] = 0
                     info["possui_solicitacao_encerramento"] = True
 
         return info

--- a/sme_ptrf_apps/core/services/conciliacao_services.py
+++ b/sme_ptrf_apps/core/services/conciliacao_services.py
@@ -662,6 +662,7 @@ def salva_conciliacao_bancaria(justificativa_ou_extrato_bancario, texto_observac
 
 
 def permite_editar_campos_extrato(associacao, periodo, conta_associacao):
+    from sme_ptrf_apps.core.services.prestacao_contas_services import pc_requer_acerto_em_extrato
     prestacao_conta = PrestacaoConta.objects.filter(
         associacao=associacao,
         periodo=periodo
@@ -669,19 +670,16 @@ def permite_editar_campos_extrato(associacao, periodo, conta_associacao):
 
     if not prestacao_conta:
         return True
-    
+
     criada_no_periodo = False
     if periodo and conta_associacao and conta_associacao.data_inicio:
         criada_no_periodo = periodo == Periodo.da_data(conta_associacao.data_inicio)
         if criada_no_periodo and (not periodo.encerrado or prestacao_conta.status in [PrestacaoConta.STATUS_DEVOLVIDA, PrestacaoConta.STATUS_NAO_APRESENTADA]):
             return True
-        
+
     if prestacao_conta.status != PrestacaoConta.STATUS_DEVOLVIDA:
         return False
 
-    ultima_analise = prestacao_conta.analises_da_prestacao.last()
+    requer_acertos_em_extrato = pc_requer_acerto_em_extrato(prestacao_conta)
 
-    tem_acertos_de_extrato = ultima_analise.tem_acertos_extratos_bancarios(conta_associacao) if \
-        ultima_analise is not None else False
-
-    return tem_acertos_de_extrato
+    return requer_acertos_em_extrato

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/conftest.py
@@ -553,3 +553,16 @@ def fechamento_periodo_2019_2_role_1000(periodo_2019_2, associacao, conta_associ
         total_receitas_capital=1000,
         status='FECHADO'
     )
+
+
+@pytest.fixture
+def observacao_conciliacao_periodo_2020_1(periodo_2020_1, conta_associacao):
+    return baker.make(
+        'ObservacaoConciliacao',
+        periodo=periodo_2020_1,
+        associacao=conta_associacao.associacao,
+        conta_associacao=conta_associacao,
+        texto="Uma bela observação.",
+        data_extrato='2020-05-30',
+        saldo_extrato=1000
+    )

--- a/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_get_observacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_conciliacoes/test_get_observacoes.py
@@ -35,13 +35,13 @@ def test_api_get_observacoes_sem_observacoes_e_encerramento(jwt_authenticated_cl
 
 
 def test_api_get_com_observacoes(jwt_authenticated_client_a,
-                                 periodo,
+                                 periodo_2020_1,
                                  conta_associacao,
-                                 observacao_conciliacao
+                                 observacao_conciliacao_periodo_2020_1
                                  ):
     conta_uuid = conta_associacao.uuid
 
-    url = f'/api/conciliacoes/observacoes/?periodo={periodo.uuid}&conta_associacao={conta_uuid}&associacao={conta_associacao.associacao.uuid}'
+    url = f'/api/conciliacoes/observacoes/?periodo={periodo_2020_1.uuid}&conta_associacao={conta_uuid}&associacao={conta_associacao.associacao.uuid}'
 
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
 
@@ -50,10 +50,10 @@ def test_api_get_com_observacoes(jwt_authenticated_client_a,
     assert response.status_code == status.HTTP_200_OK
 
     assert result == {
-        'observacao_uuid': f'{observacao_conciliacao.uuid}',
+        'observacao_uuid': f'{observacao_conciliacao_periodo_2020_1.uuid}',
         'observacao': 'Uma bela observação.',
         'saldo_extrato': 1000.0,
-        'data_extrato': '2020-07-01',
+        'data_extrato': '2020-06-30',
         'comprovante_extrato': '',
         'data_atualizacao_comprovante_extrato': None,
         'data_encerramento': None,


### PR DESCRIPTION
- Corrige cenário em que a DRE não solicita acerto para todas as contas e os campos da conciliação ficam desabilitados, impossibilitando a UE de gerar documentos.

[AB#131974](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/131974)