### PR TITLE
feature(127462): Inclusão de Livre aplicação de Acoes PDDE

### DIFF
--- a/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
+++ b/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
@@ -404,6 +404,12 @@ class ResumoPrioridadesService:
             )['total'] or 0
             acao['total_valor_capital'] += valores_capital
 
+            # Somar somente livre aplicacao
+            valores_livre = receitas_previstas_pdde.aggregate(
+                total=Sum('saldo_livre') + Sum('previsao_valor_livre')
+            )['total'] or 0
+            acao['total_valor_livre_aplicacao'] += valores_livre
+
             # Node 3 - Valores da Receita (Custeio, Capital, Livre)
             # Valores relacionados aos totais do service de programa_pdde
             receitas = calcula_receitas(acao)

--- a/sme_ptrf_apps/paa/tests/services/conftest.py
+++ b/sme_ptrf_apps/paa/tests/services/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from model_bakery import baker
+
+
+@pytest.fixture
+def receita_prevista_pdde_resumo_recursos(resumo_recursos_paa, acao_pdde):
+    return baker.make(
+        'ReceitaPrevistaPdde',
+        paa=resumo_recursos_paa,
+        acao_pdde=acao_pdde,
+        previsao_valor_custeio=1000.,
+        previsao_valor_capital=1000.,
+        previsao_valor_livre=1000.,
+        saldo_custeio=1000.,
+        saldo_capital=1000.,
+        saldo_livre=1000.)

--- a/sme_ptrf_apps/paa/tests/services/test_resumo_prioridades.py
+++ b/sme_ptrf_apps/paa/tests/services/test_resumo_prioridades.py
@@ -104,6 +104,12 @@ def test_calcula_node_pdde(receita_prevista_pdde_resumo_recursos):
     ])
     assert result["children"][0]["capital"] == capital
 
+    livre = sum([
+        receita_prevista_pdde_resumo_recursos.previsao_valor_livre,
+        receita_prevista_pdde_resumo_recursos.saldo_livre
+    ])
+    assert result["children"][0]["livre_aplicacao"] == livre
+
 
 @pytest.mark.django_db
 @patch("sme_ptrf_apps.paa.api.serializers.RecursoProprioPaaListSerializer")


### PR DESCRIPTION
Esse PR:

Adiciona o cálculo de Livre aplicação para Ações PDDE no Resumo de Recursos de PAA

Historia [AB#127462](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/127462)