### PR TITLE
hotfix(134733): Ajuste no recebimento após acerto

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -9,6 +9,7 @@ from sme_ptrf_apps.core.api.serializers import (
     DevolucaoAoTesouroRetrieveSerializer
 )
 from sme_ptrf_apps.core.services.processos_services import get_processo_sei_da_prestacao
+from sme_ptrf_apps.core.services.ajuste_services import possui_apenas_categorias_que_nao_requerem_ata
 
 from sme_ptrf_apps.dre.api.serializers.motivo_aprovacao_ressalva_serializer import MotivoAprovacaoRessalvaSerializer
 from sme_ptrf_apps.dre.api.serializers.motivo_reprovacao_serializer import MotivoReprovacaoSerializer
@@ -112,7 +113,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     devolucao_atual = serializers.SerializerMethodField('get_devolucao_atual')
     ata_aprensentacao_gerada = serializers.SerializerMethodField('get_ata_aprensentacao_gerada')
     ata_retificacao_gerada = serializers.SerializerMethodField('get_ata_retificacao_gerada')
-    tem_apenas_ajustes_externos = serializers.SerializerMethodField('get_tem_apenas_ajustes_externos')
+    possui_apenas_categorias_que_nao_requerem_ata = serializers.SerializerMethodField('get_possui_apenas_categorias_que_nao_requerem_ata')
 
     def get_ata_aprensentacao_gerada(self, obj):
         return obj.ata_apresentacao_gerada()
@@ -120,9 +121,8 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     def get_ata_retificacao_gerada(self, obj):
         return obj.ata_retificacao_gerada()
 
-    def get_tem_apenas_ajustes_externos(self, obj):
-        from sme_ptrf_apps.core.services.ajuste_services import tem_apenas_ajustes_externos
-        return tem_apenas_ajustes_externos(obj)
+    def get_possui_apenas_categorias_que_nao_requerem_ata(self, obj):
+        return possui_apenas_categorias_que_nao_requerem_ata(obj)
 
     def get_periodo_uuid(self, obj):
         return obj.periodo.uuid
@@ -310,7 +310,7 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
             'periodo_referencia',
             'ata_aprensentacao_gerada',
             'ata_retificacao_gerada',
-            'tem_apenas_ajustes_externos'
+            'possui_apenas_categorias_que_nao_requerem_ata'
         )
 
 

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -7,7 +7,7 @@ from django.db.utils import IntegrityError
 from django_filters import rest_framework as filters
 from rest_framework import mixins, status, serializers
 from rest_framework.decorators import action
-from sme_ptrf_apps.core.services.ajuste_services import tem_apenas_ajustes_externos
+from sme_ptrf_apps.core.services.ajuste_services import possui_apenas_categorias_que_nao_requerem_ata
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -2055,7 +2055,10 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
-        if not prestacao_conta.ata_retificacao_gerada() and not tem_apenas_ajustes_externos(prestacao_conta):
+        if (
+            not prestacao_conta.ata_retificacao_gerada()
+            and not possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta)
+        ):
             response = {
                 'uuid': f'{uuid}',
                 'erro': 'pendencias',

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -7,6 +7,7 @@ from django.db.utils import IntegrityError
 from django_filters import rest_framework as filters
 from rest_framework import mixins, status, serializers
 from rest_framework.decorators import action
+from sme_ptrf_apps.core.services.ajuste_services import tem_apenas_ajustes_externos
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -2054,7 +2055,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
-        if not prestacao_conta.ata_retificacao_gerada():
+        if not prestacao_conta.ata_retificacao_gerada() and not tem_apenas_ajustes_externos(prestacao_conta):
             response = {
                 'uuid': f'{uuid}',
                 'erro': 'pendencias',

--- a/sme_ptrf_apps/core/services/ajuste_services.py
+++ b/sme_ptrf_apps/core/services/ajuste_services.py
@@ -1,56 +1,59 @@
 from sme_ptrf_apps.core.models import TipoAcertoDocumento, TipoAcertoLancamento
 
 
-def tem_apenas_ajustes_externos(prestacao_conta):
+def possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta):
     """
-    Verifica se a prestação de contas tem APENAS ajustes externos (sem outras categorias de ajuste)
-    
-    Args:
-        prestacao_conta: Instância de PrestacaoConta
-        
-    Returns:
-        bool: True se tem apenas ajustes externos, False caso contrário
+    Retorna True quando a prestação possui SOMENTE categorias que não
+    geram ata de retificação (AJUSTES_EXTERNOS e SOLICITACAO_ESCLARECIMENTO)
+    e não possui nenhuma outra categoria.
     """
     if not prestacao_conta:
         return False
-    
+
     ultima_analise = prestacao_conta.analises_da_prestacao.last()
     if not ultima_analise:
         return False
-    
+
     tem_ajustes_externos_documentos = ultima_analise.analises_de_documento.filter(
         solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS
     ).exists()
-    
     tem_ajustes_externos_lancamentos = ultima_analise.analises_de_lancamentos.filter(
         solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS
     ).exists()
-    
-    tem_ajustes_externos = tem_ajustes_externos_documentos or tem_ajustes_externos_lancamentos
-    
-    if not tem_ajustes_externos:
+
+    tem_solic_esclarecimento_documentos = ultima_analise.analises_de_documento.filter(
+        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+    ).exists()
+    tem_solic_esclarecimento_lancamentos = ultima_analise.analises_de_lancamentos.filter(
+        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+    ).exists()
+
+    tem_alguma_nao_gera_ata = (
+        tem_ajustes_externos_documentos or tem_ajustes_externos_lancamentos or
+        tem_solic_esclarecimento_documentos or tem_solic_esclarecimento_lancamentos
+    )
+
+    if not tem_alguma_nao_gera_ata:
         return False
-    
-    tem_outros_ajustes_documentos = ultima_analise.analises_de_documento.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=[
-            TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO,
-            TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO,
-            TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO,
-            TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO
-        ]
+
+    categorias_documento_que_geram_ata = [
+        TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO,
+        TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO,
+        TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO,
+    ]
+    categorias_lancamento_que_geram_ata = [
+        TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
+        TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
+        TipoAcertoLancamento.CATEGORIA_CONCILIACAO_LANCAMENTO,
+        TipoAcertoLancamento.CATEGORIA_DESCONCILIACAO_LANCAMENTO,
+        TipoAcertoLancamento.CATEGORIA_DEVOLUCAO,
+    ]
+
+    tem_outros_documentos = ultima_analise.analises_de_documento.filter(
+        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_documento_que_geram_ata
     ).exists()
-    
-    tem_outros_ajustes_lancamentos = ultima_analise.analises_de_lancamentos.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=[
-            TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO,
-            TipoAcertoLancamento.CATEGORIA_CONCILIACAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_DESCONCILIACAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
-            TipoAcertoLancamento.CATEGORIA_DEVOLUCAO
-        ]
+    tem_outros_lancamentos = ultima_analise.analises_de_lancamentos.filter(
+        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_lancamento_que_geram_ata
     ).exists()
-    
-    tem_outros_ajustes = tem_outros_ajustes_documentos or tem_outros_ajustes_lancamentos
-    
-    return tem_ajustes_externos and not tem_outros_ajustes
+
+    return not (tem_outros_documentos or tem_outros_lancamentos)

--- a/sme_ptrf_apps/core/tests/services/test_ajuste_services.py
+++ b/sme_ptrf_apps/core/tests/services/test_ajuste_services.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sme_ptrf_apps.core.services.ajuste_services import tem_apenas_ajustes_externos
+from sme_ptrf_apps.core.services.ajuste_services import possui_apenas_categorias_que_nao_requerem_ata
 from sme_ptrf_apps.core.models import (
     PrestacaoConta, 
     AnalisePrestacaoConta, 
@@ -58,16 +58,16 @@ def tipo_acerto_lancamento_edicao():
     )
 
 
-class TestTemApenasAjustesExternos:
+class TestPossuiApenasCategoriasQueNaoRequeremAta:
 
     def test_prestacao_conta_none(self):
-        assert tem_apenas_ajustes_externos(None) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(None) is False
 
     def test_prestacao_conta_sem_analises(self, prestacao_conta):
-        assert tem_apenas_ajustes_externos(prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta) is False
 
     def test_analise_sem_ajustes(self, analise_prestacao_conta):
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_apenas_ajustes_externos_documentos(self, analise_prestacao_conta, tipo_acerto_documento_ajustes_externos):
         from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
@@ -82,7 +82,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is True
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_apenas_ajustes_externos_lancamentos(self, analise_prestacao_conta, tipo_acerto_lancamento_ajustes_externos):
         from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
@@ -97,7 +97,27 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is True
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_apenas_solicitacao_de_esclarecimento_documentos(self, analise_prestacao_conta):
+        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
+        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
+        from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
+
+        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+
+        tipo_acerto_esclarecimento = TipoAcertoDocumentoFactory(
+            categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+        )
+
+        SolicitacaoAcertoDocumentoFactory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_esclarecimento
+        )
+
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_ajustes_externos_com_outros_ajustes_documentos(self, analise_prestacao_conta, 
                                                            tipo_acerto_documento_ajustes_externos,
@@ -119,7 +139,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_documento_edicao
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_ajustes_externos_com_outros_ajustes_lancamentos(self, analise_prestacao_conta,
                                                            tipo_acerto_lancamento_ajustes_externos,
@@ -141,7 +161,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_lancamento_edicao
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_apenas_outros_ajustes_documentos(self, analise_prestacao_conta, tipo_acerto_documento_edicao):
         from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
@@ -156,7 +176,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_documento_edicao
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_apenas_outros_ajustes_lancamentos(self, analise_prestacao_conta, tipo_acerto_lancamento_edicao):
         from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
@@ -171,7 +191,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_lancamento_edicao
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_ajustes_externos_documentos_e_lancamentos(self, analise_prestacao_conta,
                                                       tipo_acerto_documento_ajustes_externos,
@@ -199,7 +219,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is True
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_ajustes_externos_com_solicitacao_esclarecimento(self, analise_prestacao_conta,
                                                            tipo_acerto_documento_ajustes_externos):
@@ -225,7 +245,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_esclarecimento
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_ajustes_externos_com_inclusao_credito(self, analise_prestacao_conta,
                                                   tipo_acerto_documento_ajustes_externos):
@@ -251,7 +271,7 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_inclusao_credito
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
     def test_ajustes_externos_com_devolucao(self, analise_prestacao_conta,
                                            tipo_acerto_lancamento_ajustes_externos):
@@ -277,4 +297,4 @@ class TestTemApenasAjustesExternos:
             tipo_acerto=tipo_acerto_devolucao
         )
         
-        assert tem_apenas_ajustes_externos(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta_apos_acertos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta_apos_acertos.py
@@ -195,3 +195,95 @@ def test_api_recebe_sem_ata_quando_apenas_ajustes_externos(
 
     prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_retornada_apos_acerto.uuid)
     assert prestacao_atualizada.status == PrestacaoConta.STATUS_DEVOLVIDA_RECEBIDA
+
+
+def test_api_recebe_sem_ata_quando_apenas_solicitacao_de_esclarecimento(
+    jwt_authenticated_client_a,
+    prestacao_conta_retornada_apos_acerto,
+    analise_prestacao_conta_factory,
+    analise_documento_prestacao_conta_factory,
+    solicitacao_acerto_documento_factory,
+    tipo_acerto_documento_factory,
+):
+    analise = analise_prestacao_conta_factory(
+        prestacao_conta=prestacao_conta_retornada_apos_acerto,
+        status=AnalisePrestacaoConta.STATUS_DEVOLVIDA,
+    )
+
+    analise_doc = analise_documento_prestacao_conta_factory(
+        analise_prestacao_conta=analise
+    )
+    tipo_doc_escl = tipo_acerto_documento_factory(
+        categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+    )
+    solicitacao_acerto_documento_factory(
+        analise_documento=analise_doc,
+        tipo_acerto=tipo_doc_escl,
+    )
+
+    payload = {
+        'data_recebimento_apos_acertos': '2020-10-01',
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_retornada_apos_acerto.uuid}/receber-apos-acertos/'
+    response = jwt_authenticated_client_a.patch(
+        url, data=json.dumps(payload), content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_retornada_apos_acerto.uuid)
+    assert prestacao_atualizada.status == PrestacaoConta.STATUS_DEVOLVIDA_RECEBIDA
+
+
+def test_api_recebe_sem_ata_quando_ajustes_externos_e_solicitacao_de_esclarecimento(
+    jwt_authenticated_client_a,
+    prestacao_conta_retornada_apos_acerto,
+    analise_prestacao_conta_factory,
+    analise_documento_prestacao_conta_factory,
+    analise_lancamento_prestacao_conta_factory,
+    solicitacao_acerto_documento_factory,
+    solicitacao_acerto_lancamento_factory,
+    tipo_acerto_documento_factory,
+    tipo_acerto_lancamento_factory
+):
+    analise = analise_prestacao_conta_factory(
+        prestacao_conta=prestacao_conta_retornada_apos_acerto,
+        status=AnalisePrestacaoConta.STATUS_DEVOLVIDA,
+    )
+
+    analise_doc = analise_documento_prestacao_conta_factory(
+        analise_prestacao_conta=analise
+    )
+    tipo_doc_escl = tipo_acerto_documento_factory(
+        categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+    )
+    solicitacao_acerto_documento_factory(
+        analise_documento=analise_doc,
+        tipo_acerto=tipo_doc_escl,
+    )
+
+    analise_lanc = analise_lancamento_prestacao_conta_factory(
+        analise_prestacao_conta=analise
+    )
+    tipo_lanc_ext = tipo_acerto_lancamento_factory(
+        categoria=TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS
+    )
+    solicitacao_acerto_lancamento_factory(
+        analise_lancamento=analise_lanc,
+        tipo_acerto=tipo_lanc_ext,
+    )
+
+    payload = {
+        'data_recebimento_apos_acertos': '2020-10-01',
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_retornada_apos_acerto.uuid}/receber-apos-acertos/'
+    response = jwt_authenticated_client_a.patch(
+        url, data=json.dumps(payload), content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_retornada_apos_acerto.uuid)
+    assert prestacao_atualizada.status == PrestacaoConta.STATUS_DEVOLVIDA_RECEBIDA

--- a/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta_apos_acertos.py
+++ b/sme_ptrf_apps/core/tests/tests_api_prestacoes_contas/test_recebe_prestacao_conta_apos_acertos.py
@@ -6,6 +6,8 @@ from datetime import date
 from model_bakery import baker
 from rest_framework import status
 
+from sme_ptrf_apps.core.models import AnalisePrestacaoConta, TipoAcertoDocumento, TipoAcertoLancamento
+
 from ...models import PrestacaoConta
 from sme_ptrf_apps.core.models import Ata
 pytestmark = pytest.mark.django_db
@@ -138,3 +140,58 @@ def test_api_prestacao_conta_apos_acertos_exige_ata_retificacao_gerada(jwt_authe
     prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_retornada_apos_acerto.uuid)
 
     assert prestacao_atualizada.status == PrestacaoConta.STATUS_DEVOLVIDA_RETORNADA, 'Status não deveria ter sido alterado.'
+
+
+def test_api_recebe_sem_ata_quando_apenas_ajustes_externos(
+    jwt_authenticated_client_a,
+    prestacao_conta_retornada_apos_acerto,
+    analise_prestacao_conta_factory,
+    analise_documento_prestacao_conta_factory,
+    analise_lancamento_prestacao_conta_factory,
+    solicitacao_acerto_documento_factory,
+    solicitacao_acerto_lancamento_factory,
+    tipo_acerto_documento_factory,
+    tipo_acerto_lancamento_factory
+):
+    # configura apenas ajustes externos na última análise
+    analise = analise_prestacao_conta_factory(
+        prestacao_conta=prestacao_conta_retornada_apos_acerto,
+        status=AnalisePrestacaoConta.STATUS_DEVOLVIDA,
+    )
+
+    analise_doc = analise_documento_prestacao_conta_factory(
+        analise_prestacao_conta=analise
+    )
+    tipo_doc_ext = tipo_acerto_documento_factory(
+        categoria=TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS
+    )
+    solicitacao_acerto_documento_factory(
+        analise_documento=analise_doc,
+        tipo_acerto=tipo_doc_ext,
+    )
+
+    analise_lanc = analise_lancamento_prestacao_conta_factory(
+        analise_prestacao_conta=analise
+    )
+    tipo_lanc_ext = tipo_acerto_lancamento_factory(
+        categoria=TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS
+    )
+    solicitacao_acerto_lancamento_factory(
+        analise_lancamento=analise_lanc,
+        tipo_acerto=tipo_lanc_ext,
+    )
+
+    # sem criar Ata de retificação; deve permitir recebimento
+    payload = {
+        'data_recebimento_apos_acertos': '2020-10-01',
+    }
+
+    url = f'/api/prestacoes-contas/{prestacao_conta_retornada_apos_acerto.uuid}/receber-apos-acertos/'
+    response = jwt_authenticated_client_a.patch(
+        url, data=json.dumps(payload), content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    prestacao_atualizada = PrestacaoConta.by_uuid(prestacao_conta_retornada_apos_acerto.uuid)
+    assert prestacao_atualizada.status == PrestacaoConta.STATUS_DEVOLVIDA_RECEBIDA


### PR DESCRIPTION
Esse PR:

- Adiciona um ajuste que permite o recebimento de PC após acerto quando possui apenas ajuste externo e/ou solicitação de esclarecimento.

História: AB#134733