### PR TITLE
hotfix(134733): Ajuste para exigir ata ret. apenas com acertos realizados

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.23.2"
+__version__ = "9.23.3"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.23.1"
+__version__ = "9.23.2"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/services/ajuste_services.py
+++ b/sme_ptrf_apps/core/services/ajuste_services.py
@@ -3,44 +3,52 @@ from sme_ptrf_apps.core.models import TipoAcertoDocumento, TipoAcertoLancamento
 
 def possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta):
     """
-    Retorna True quando a prestação possui SOMENTE categorias que não
-    geram ata de retificação (AJUSTES_EXTERNOS e SOLICITACAO_ESCLARECIMENTO)
-    e não possui nenhuma outra categoria.
+    Verifica se a prestação de contas possui apenas categorias que não requerem
+    geração de ata de retificação.
+    
+    A função retorna True quando:
+    - Não há acertos
+    - Há apenas ajustes externos ou solicitações de esclarecimento
+    - Há acertos que normalmente gerariam ata, mas não foram realizados
+    
+    A função retorna False quando:
+    - Há acertos de categorias que geram ata e foram realizados
+    
+    Args:
+        prestacao_conta: Instância de PrestacaoConta
+        
+    Returns:
+        bool: True se não requer ata de retificação, False caso contrário
     """
     if not prestacao_conta:
         return False
 
-    ultima_analise = prestacao_conta.analises_da_prestacao.last()
+    ultima_analise = prestacao_conta.analises_da_prestacao.filter(status='DEVOLVIDA').last()
     if not ultima_analise:
         return False
 
-    tem_ajustes_externos_documentos = ultima_analise.analises_de_documento.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS
-    ).exists()
-    tem_ajustes_externos_lancamentos = ultima_analise.analises_de_lancamentos.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS
-    ).exists()
-
-    tem_solic_esclarecimento_documentos = ultima_analise.analises_de_documento.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
-    ).exists()
-    tem_solic_esclarecimento_lancamentos = ultima_analise.analises_de_lancamentos.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
-    ).exists()
-
-    tem_alguma_nao_gera_ata = (
-        tem_ajustes_externos_documentos or tem_ajustes_externos_lancamentos or
-        tem_solic_esclarecimento_documentos or tem_solic_esclarecimento_lancamentos
-    )
-
-    if not tem_alguma_nao_gera_ata:
+    if _tem_acertos_realizados_que_geram_ata(ultima_analise):
         return False
 
+    return True
+
+
+def _tem_acertos_realizados_que_geram_ata(ultima_analise):
+    """
+    Verifica se há acertos realizados de categorias que geram ata de retificação.
+    
+    Args:
+        ultima_analise: Instância de AnalisePrestacaoConta
+        
+    Returns:
+        bool: True se há acertos realizados que geram ata
+    """
     categorias_documento_que_geram_ata = [
         TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO,
         TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO,
         TipoAcertoDocumento.CATEGORIA_INCLUSAO_GASTO,
     ]
+    
     categorias_lancamento_que_geram_ata = [
         TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
         TipoAcertoLancamento.CATEGORIA_EXCLUSAO_LANCAMENTO,
@@ -49,11 +57,42 @@ def possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta):
         TipoAcertoLancamento.CATEGORIA_DEVOLUCAO,
     ]
 
-    tem_outros_documentos = ultima_analise.analises_de_documento.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_documento_que_geram_ata
-    ).exists()
-    tem_outros_lancamentos = ultima_analise.analises_de_lancamentos.filter(
-        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias_lancamento_que_geram_ata
-    ).exists()
+    if _tem_solicitacoes_realizadas_por_categoria(
+        ultima_analise.analises_de_documento, 
+        categorias_documento_que_geram_ata
+    ):
+        return True
 
-    return not (tem_outros_documentos or tem_outros_lancamentos)
+    if _tem_solicitacoes_realizadas_por_categoria(
+        ultima_analise.analises_de_lancamentos, 
+        categorias_lancamento_que_geram_ata
+    ):
+        return True
+
+    return False
+
+
+def _tem_solicitacoes_realizadas_por_categoria(analises_queryset, categorias):
+    """
+    Verifica se há solicitações realizadas para as categorias especificadas.
+    
+    Args:
+        analises_queryset: QuerySet de análises (documento ou lançamento)
+        categorias: Lista de categorias a verificar
+        
+    Returns:
+        bool: True se há solicitações realizadas para as categorias
+    """
+    analises_com_categorias = analises_queryset.filter(
+        solicitacoes_de_ajuste_da_analise__tipo_acerto__categoria__in=categorias
+    )
+    
+    for analise in analises_com_categorias:
+        solicitacoes_realizadas = analise.solicitacoes_de_ajuste_da_analise.filter(
+            tipo_acerto__categoria__in=categorias,
+            status_realizacao='REALIZADO'
+        )
+        if solicitacoes_realizadas.exists():
+            return True
+    
+    return False

--- a/sme_ptrf_apps/core/tests/services/test_ajuste_services.py
+++ b/sme_ptrf_apps/core/tests/services/test_ajuste_services.py
@@ -2,7 +2,6 @@ import pytest
 
 from sme_ptrf_apps.core.services.ajuste_services import possui_apenas_categorias_que_nao_requerem_ata
 from sme_ptrf_apps.core.models import (
-    PrestacaoConta, 
     AnalisePrestacaoConta, 
     TipoAcertoDocumento, 
     TipoAcertoLancamento
@@ -12,48 +11,42 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def prestacao_conta():
-    from sme_ptrf_apps.core.fixtures.factories.prestacao_conta_factory import PrestacaoContaFactory
-    return PrestacaoContaFactory()
+def prestacao_conta(prestacao_conta_factory):
+    return prestacao_conta_factory()
 
 
 @pytest.fixture
-def analise_prestacao_conta(prestacao_conta):
-    from sme_ptrf_apps.core.fixtures.factories.analise_prestacao_conta_factory import AnalisePrestacaoContaFactory
-    return AnalisePrestacaoContaFactory(
+def analise_prestacao_conta(prestacao_conta, analise_prestacao_conta_factory):
+    return analise_prestacao_conta_factory(
         prestacao_conta=prestacao_conta,
         status=AnalisePrestacaoConta.STATUS_DEVOLVIDA
     )
 
 
 @pytest.fixture
-def tipo_acerto_documento_ajustes_externos():
-    from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
-    return TipoAcertoDocumentoFactory(
+def tipo_acerto_documento_ajustes_externos(tipo_acerto_documento_factory):
+    return tipo_acerto_documento_factory(
         categoria=TipoAcertoDocumento.CATEGORIA_AJUSTES_EXTERNOS
     )
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_ajustes_externos():
-    from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_lancamento_factory import TipoAcertoLancamentoFactory
-    return TipoAcertoLancamentoFactory(
+def tipo_acerto_lancamento_ajustes_externos(tipo_acerto_lancamento_factory):
+    return tipo_acerto_lancamento_factory(
         categoria=TipoAcertoLancamento.CATEGORIA_AJUSTES_EXTERNOS
     )
 
 
 @pytest.fixture
-def tipo_acerto_documento_edicao():
-    from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
-    return TipoAcertoDocumentoFactory(
+def tipo_acerto_documento_edicao(tipo_acerto_documento_factory):
+    return tipo_acerto_documento_factory(
         categoria=TipoAcertoDocumento.CATEGORIA_EDICAO_INFORMACAO
     )
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_edicao():
-    from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_lancamento_factory import TipoAcertoLancamentoFactory
-    return TipoAcertoLancamentoFactory(
+def tipo_acerto_lancamento_edicao(tipo_acerto_lancamento_factory):
+    return tipo_acerto_lancamento_factory(
         categoria=TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO
     )
 
@@ -67,154 +60,219 @@ class TestPossuiApenasCategoriasQueNaoRequeremAta:
         assert possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta) is False
 
     def test_analise_sem_ajustes(self, analise_prestacao_conta):
-        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
-    def test_apenas_ajustes_externos_documentos(self, analise_prestacao_conta, tipo_acerto_documento_ajustes_externos):
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
+    def test_apenas_ajustes_externos_documentos(self, analise_prestacao_conta, tipo_acerto_documento_ajustes_externos, analise_documento_prestacao_conta_factory, solicitacao_acerto_documento_factory):
         
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
-    def test_apenas_ajustes_externos_lancamentos(self, analise_prestacao_conta, tipo_acerto_lancamento_ajustes_externos):
-        from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
+    def test_apenas_ajustes_externos_lancamentos(self, analise_prestacao_conta, tipo_acerto_lancamento_ajustes_externos, analise_lancamento_prestacao_conta_factory, solicitacao_acerto_lancamento_factory):
         
-        analise_lancamento = AnaliseLancamentoPrestacaoContaFactory(
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoLancamentoFactory(
+        solicitacao_acerto_lancamento_factory(
             analise_lancamento=analise_lancamento,
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
-    def test_apenas_solicitacao_de_esclarecimento_documentos(self, analise_prestacao_conta):
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
-        from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
+    def test_apenas_solicitacao_de_esclarecimento_documentos(self, analise_prestacao_conta, analise_documento_prestacao_conta_factory, tipo_acerto_documento_factory, solicitacao_acerto_documento_factory):
 
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
 
-        tipo_acerto_esclarecimento = TipoAcertoDocumentoFactory(
+        tipo_acerto_esclarecimento = tipo_acerto_documento_factory(
             categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
         )
 
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_esclarecimento
         )
 
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
-    def test_ajustes_externos_com_outros_ajustes_documentos(self, analise_prestacao_conta, 
+    def test_ajustes_externos_com_outros_ajustes_documentos_realizados(self, analise_prestacao_conta, 
                                                            tipo_acerto_documento_ajustes_externos,
-                                                           tipo_acerto_documento_edicao):
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
+                                                           tipo_acerto_documento_edicao,
+                                                           analise_documento_prestacao_conta_factory, solicitacao_acerto_documento_factory):
         
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        # Acerto de edição REALIZADO - deve gerar ata
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
-            tipo_acerto=tipo_acerto_documento_edicao
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
-    def test_ajustes_externos_com_outros_ajustes_lancamentos(self, analise_prestacao_conta,
-                                                           tipo_acerto_lancamento_ajustes_externos,
-                                                           tipo_acerto_lancamento_edicao):
-        from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
+    def test_ajustes_externos_com_outros_ajustes_documentos_nao_realizados(self, analise_prestacao_conta, 
+                                                           tipo_acerto_documento_ajustes_externos,
+                                                           tipo_acerto_documento_edicao,
+                                                           analise_documento_prestacao_conta_factory, solicitacao_acerto_documento_factory):
         
-        analise_lancamento = AnaliseLancamentoPrestacaoContaFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoLancamentoFactory(
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_ajustes_externos
+        )
+        
+        # Acerto de edição NÃO REALIZADO - não deve gerar ata
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='PENDENTE'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_ajustes_externos_com_outros_ajustes_lancamentos_realizados(self, analise_prestacao_conta,
+                                                           tipo_acerto_lancamento_ajustes_externos,
+                                                           tipo_acerto_lancamento_edicao,
+                                                           analise_lancamento_prestacao_conta_factory, solicitacao_acerto_lancamento_factory):
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        solicitacao_acerto_lancamento_factory(
             analise_lancamento=analise_lancamento,
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
         
-        SolicitacaoAcertoLancamentoFactory(
+        # Acerto de edição REALIZADO - deve gerar ata
+        solicitacao_acerto_lancamento_factory(
             analise_lancamento=analise_lancamento,
-            tipo_acerto=tipo_acerto_lancamento_edicao
+            tipo_acerto=tipo_acerto_lancamento_edicao,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
-    def test_apenas_outros_ajustes_documentos(self, analise_prestacao_conta, tipo_acerto_documento_edicao):
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
-        
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+    def test_ajustes_externos_com_outros_ajustes_lancamentos_nao_realizados(self, analise_prestacao_conta,
+                                                           tipo_acerto_lancamento_ajustes_externos,
+                                                           tipo_acerto_lancamento_edicao,
+                                                           analise_lancamento_prestacao_conta_factory, solicitacao_acerto_lancamento_factory):
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_lancamento_factory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_lancamento_ajustes_externos
+        )
+        
+        # Acerto de edição NÃO REALIZADO - não deve gerar ata
+        solicitacao_acerto_lancamento_factory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_lancamento_edicao,
+            status_realizacao='JUSTIFICADO'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_apenas_outros_ajustes_documentos_realizados(self, analise_prestacao_conta, tipo_acerto_documento_edicao, analise_documento_prestacao_conta_factory, solicitacao_acerto_documento_factory):
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        # Acerto de edição REALIZADO - deve gerar ata
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
-            tipo_acerto=tipo_acerto_documento_edicao
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
-    def test_apenas_outros_ajustes_lancamentos(self, analise_prestacao_conta, tipo_acerto_lancamento_edicao):
-        from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
+    def test_apenas_outros_ajustes_documentos_nao_realizados(self, analise_prestacao_conta, tipo_acerto_documento_edicao, analise_documento_prestacao_conta_factory, solicitacao_acerto_documento_factory):
         
-        analise_lancamento = AnaliseLancamentoPrestacaoContaFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoLancamentoFactory(
+        # Acerto de edição NÃO REALIZADO - não deve gerar ata
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='PENDENTE'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_apenas_outros_ajustes_lancamentos_realizados(self, analise_prestacao_conta, tipo_acerto_lancamento_edicao, analise_lancamento_prestacao_conta_factory, solicitacao_acerto_lancamento_factory):
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        # Acerto de edição REALIZADO - deve gerar ata
+        solicitacao_acerto_lancamento_factory(
             analise_lancamento=analise_lancamento,
-            tipo_acerto=tipo_acerto_lancamento_edicao
+            tipo_acerto=tipo_acerto_lancamento_edicao,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
+
+    def test_apenas_outros_ajustes_lancamentos_nao_realizados(self, analise_prestacao_conta, tipo_acerto_lancamento_edicao, analise_lancamento_prestacao_conta_factory, solicitacao_acerto_lancamento_factory):
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        # Acerto de edição NÃO REALIZADO - não deve gerar ata
+        solicitacao_acerto_lancamento_factory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_lancamento_edicao,
+            status_realizacao='JUSTIFICADO'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_ajustes_externos_documentos_e_lancamentos(self, analise_prestacao_conta,
                                                       tipo_acerto_documento_ajustes_externos,
-                                                      tipo_acerto_lancamento_ajustes_externos):
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
-        
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+                                                        tipo_acerto_lancamento_ajustes_externos,
+                                                      analise_documento_prestacao_conta_factory,
+                                                      analise_lancamento_prestacao_conta_factory,
+                                                      solicitacao_acerto_documento_factory,
+                                                      solicitacao_acerto_lancamento_factory):
+        analise_documento = analise_documento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        analise_lancamento = AnaliseLancamentoPrestacaoContaFactory(
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
-        SolicitacaoAcertoLancamentoFactory(
+        solicitacao_acerto_lancamento_factory(
             analise_lancamento=analise_lancamento,
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
@@ -222,32 +280,41 @@ class TestPossuiApenasCategoriasQueNaoRequeremAta:
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
     def test_ajustes_externos_com_solicitacao_esclarecimento(self, analise_prestacao_conta,
-                                                           tipo_acerto_documento_ajustes_externos):
-        from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
-        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
-        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
-        
-        tipo_acerto_esclarecimento = TipoAcertoDocumentoFactory(
-            categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
-        )
-        
-        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+                                                           tipo_acerto_documento_ajustes_externos,
+                                                           analise_documento_prestacao_conta_factory,
+                                                           analise_lancamento_prestacao_conta_factory,
+                                                           solicitacao_acerto_documento_factory,
+                                                           solicitacao_acerto_lancamento_factory,
+                                                           tipo_acerto_documento_factory):
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
             analise_prestacao_conta=analise_prestacao_conta
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        tipo_acerto_esclarecimento = tipo_acerto_documento_factory(
+            categoria=TipoAcertoDocumento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+        )
+        
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
-        SolicitacaoAcertoDocumentoFactory(
+        solicitacao_acerto_documento_factory(
             analise_documento=analise_documento,
             tipo_acerto=tipo_acerto_esclarecimento
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
 
-    def test_ajustes_externos_com_inclusao_credito(self, analise_prestacao_conta,
+    def test_ajustes_externos_com_inclusao_credito_realizada(self, analise_prestacao_conta,
                                                   tipo_acerto_documento_ajustes_externos):
         from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
         from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
@@ -266,15 +333,45 @@ class TestPossuiApenasCategoriasQueNaoRequeremAta:
             tipo_acerto=tipo_acerto_documento_ajustes_externos
         )
         
+        # Inclusão de crédito REALIZADA - deve gerar ata
         SolicitacaoAcertoDocumentoFactory(
             analise_documento=analise_documento,
-            tipo_acerto=tipo_acerto_inclusao_credito
+            tipo_acerto=tipo_acerto_inclusao_credito,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
 
-    def test_ajustes_externos_com_devolucao(self, analise_prestacao_conta,
-                                           tipo_acerto_lancamento_ajustes_externos):
+    def test_ajustes_externos_com_inclusao_credito_nao_realizada(self, analise_prestacao_conta,
+                                                  tipo_acerto_documento_ajustes_externos):
+        from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_documento_factory import TipoAcertoDocumentoFactory
+        from sme_ptrf_apps.core.fixtures.factories.analise_documento_prestacao_conta_factory import AnaliseDocumentoPrestacaoContaFactory
+        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_documento_factory import SolicitacaoAcertoDocumentoFactory
+        
+        tipo_acerto_inclusao_credito = TipoAcertoDocumentoFactory(
+            categoria=TipoAcertoDocumento.CATEGORIA_INCLUSAO_CREDITO
+        )
+        
+        analise_documento = AnaliseDocumentoPrestacaoContaFactory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        SolicitacaoAcertoDocumentoFactory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_ajustes_externos
+        )
+        
+        # Inclusão de crédito NÃO REALIZADA - não deve gerar ata
+        SolicitacaoAcertoDocumentoFactory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_inclusao_credito,
+            status_realizacao='PENDENTE'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_ajustes_externos_com_devolucao_realizada(self, analise_prestacao_conta,
+                                                tipo_acerto_lancamento_ajustes_externos):
         from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_lancamento_factory import TipoAcertoLancamentoFactory
         from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
         from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
@@ -292,9 +389,112 @@ class TestPossuiApenasCategoriasQueNaoRequeremAta:
             tipo_acerto=tipo_acerto_lancamento_ajustes_externos
         )
         
+        # Devolução REALIZADA - deve gerar ata
         SolicitacaoAcertoLancamentoFactory(
             analise_lancamento=analise_lancamento,
-            tipo_acerto=tipo_acerto_devolucao
+            tipo_acerto=tipo_acerto_devolucao,
+            status_realizacao='REALIZADO'
         )
         
         assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
+
+    def test_ajustes_externos_com_devolucao_nao_realizada(self, analise_prestacao_conta,
+                                            tipo_acerto_lancamento_ajustes_externos):
+        from sme_ptrf_apps.core.fixtures.factories.tipo_acerto_lancamento_factory import TipoAcertoLancamentoFactory
+        from sme_ptrf_apps.core.fixtures.factories.analise_lancamento_prestacao_conta_factory import AnaliseLancamentoPrestacaoContaFactory
+        from sme_ptrf_apps.core.fixtures.factories.solicitacao_acerto_lancamento_factory import SolicitacaoAcertoLancamentoFactory
+        
+        tipo_acerto_devolucao = TipoAcertoLancamentoFactory(
+            categoria=TipoAcertoLancamento.CATEGORIA_DEVOLUCAO
+        )
+        
+        analise_lancamento = AnaliseLancamentoPrestacaoContaFactory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        SolicitacaoAcertoLancamentoFactory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_lancamento_ajustes_externos
+        )
+        
+        # Devolução NÃO REALIZADA - não deve gerar ata
+        SolicitacaoAcertoLancamentoFactory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_devolucao,
+            status_realizacao='JUSTIFICADO'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_analise_sem_ajustes_retorna_true(self, analise_prestacao_conta):
+        """
+        Testa que uma análise sem nenhum acerto retorna True (não requer ata)
+        """
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True
+
+    def test_multiplos_acertos_misturados_realizados_e_nao_realizados(self, analise_prestacao_conta,
+                                                                    tipo_acerto_documento_edicao,
+                                                                    tipo_acerto_lancamento_edicao,
+                                                                    analise_documento_prestacao_conta_factory,
+                                                                    analise_lancamento_prestacao_conta_factory,
+                                                                    solicitacao_acerto_documento_factory,
+                                                                    solicitacao_acerto_lancamento_factory):
+        """
+        Testa cenário com múltiplos acertos: alguns realizados e outros não realizados
+        """
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        # Acerto de documento REALIZADO - deve gerar ata
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='REALIZADO'
+        )
+        
+        # Acerto de lançamento NÃO REALIZADO - não deve gerar ata
+        solicitacao_acerto_lancamento_factory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_acerto_lancamento_edicao,
+            status_realizacao='PENDENTE'
+        )
+        
+        # Como tem pelo menos um acerto realizado que gera ata, deve retornar False
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is False
+
+    def test_apenas_acertos_justificados_retorna_true(self, analise_prestacao_conta,
+                                                     tipo_acerto_documento_edicao,
+                                                     analise_documento_prestacao_conta_factory,
+                                                     solicitacao_acerto_documento_factory):
+        """
+        Testa que apenas acertos justificados (não realizados) retornam True
+        """
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise_prestacao_conta
+        )
+        
+        # Acerto apenas JUSTIFICADO - não deve gerar ata
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_acerto_documento_edicao,
+            status_realizacao='JUSTIFICADO'
+        )
+        
+        assert possui_apenas_categorias_que_nao_requerem_ata(analise_prestacao_conta.prestacao_conta) is True


### PR DESCRIPTION
Esse PR:

- Apenas exige a ata de retificação quando existe acertos diferentes de ajuste externo ou esclarecimento e estejam realizados.

História: AB#134733