### PR TITLE
feat(134188): Acompanhamento de PC: Incluir alerta sobre a inclusão de acertos que podem alterar a conciliação bancária

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -36,7 +36,8 @@ from sme_ptrf_apps.core.fixtures.factories import (
     SolicitacaoAcertoDocumentoFactory, ProcessoAssociacaoFactory,
     PrestacaoContaReprovadaNaoApresentacaoFactory, DemonstrativoFinanceiroFactory,
     ItemResumoPorAcaoFactory, ItemDespesaFactory, ItemCreditoFactory, ArquivoDownloadFactory,
-    TipoDevolucaoAoTesouroFactory, FlagFactory, AtaFactory, ParticipanteFactory
+    TipoDevolucaoAoTesouroFactory, FlagFactory, AtaFactory, ParticipanteFactory,
+    AnaliseContaPrestacaoContaFactory, PDFFactory
 )
 from sme_ptrf_apps.users.fixtures.factories import (
     UsuarioFactory, UnidadeEmSuporteFactory, GrupoAcessoFactory, VisaoFactory,
@@ -85,7 +86,8 @@ factories_to_register = [
     FonteRecursoPaaFactory, RecursoProprioPaaFactory, PeriodoPaaFactory, PaaFactory,
     ParametroPaaFactory, BemProduzidoFactory, ReceitaPrevistaPddeFactory, BemProduzidoDespesaFactory,
     BemProduzidoRateioFactory, BemProduzidoItemFactory, EspecificacaoMaterialServicoFactory,
-    PrioridadePaaFactory, AtaFactory, ParticipanteFactory
+    PrioridadePaaFactory, AtaFactory, ParticipanteFactory, AnaliseContaPrestacaoContaFactory,
+    PDFFactory
 ]
 
 for factory in factories_to_register:

--- a/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/prestacao_conta_serializer.py
@@ -81,11 +81,27 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
 
     class AnalisePrestacaoContaSerializer(serializers.ModelSerializer):
         devolucao_prestacao_conta = DevolucaoPrestacaoContaRetrieveSerializer(many=False)
+        acertos_podem_alterar_saldo_conciliacao = serializers.SerializerMethodField(
+            'get_acertos_podem_alterar_saldo_conciliacao')
+        tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta = serializers.SerializerMethodField(
+            'get_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta')
+        contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta = serializers.SerializerMethodField(
+            'get_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta')
 
         class Meta:
             from sme_ptrf_apps.core.models import AnalisePrestacaoConta
             model = AnalisePrestacaoConta
-            fields = ('uuid', 'id', 'devolucao_prestacao_conta', 'status', 'criado_em')
+            fields = ('uuid', 'id', 'devolucao_prestacao_conta', 'status', 'criado_em', 'acertos_podem_alterar_saldo_conciliacao',
+                      'tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta', 'contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta')
+
+        def get_acertos_podem_alterar_saldo_conciliacao(self, obj):
+            return obj.tem_acertos_que_podem_alterar_saldo_conciliacao()
+
+        def get_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(self, obj):
+            return obj.tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta()
+
+        def get_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(self, obj):
+            return [conta.uuid for conta in obj.contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta()]
 
     class ConciliacaoBancariaSerializer(serializers.ModelSerializer):
         class Meta:
@@ -113,7 +129,8 @@ class PrestacaoContaRetrieveSerializer(serializers.ModelSerializer):
     devolucao_atual = serializers.SerializerMethodField('get_devolucao_atual')
     ata_aprensentacao_gerada = serializers.SerializerMethodField('get_ata_aprensentacao_gerada')
     ata_retificacao_gerada = serializers.SerializerMethodField('get_ata_retificacao_gerada')
-    possui_apenas_categorias_que_nao_requerem_ata = serializers.SerializerMethodField('get_possui_apenas_categorias_que_nao_requerem_ata')
+    possui_apenas_categorias_que_nao_requerem_ata = serializers.SerializerMethodField(
+        'get_possui_apenas_categorias_que_nao_requerem_ata')
 
     def get_ata_aprensentacao_gerada(self, obj):
         return obj.ata_apresentacao_gerada()

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -246,8 +246,15 @@ class AssociacoesViewSet(ModelViewSet):
             gerar_previas = pc_requer_geracao_documentos(prestacao_conta)
 
         pendencias_dados = associacao.pendencias_dados_da_associacao()
-        pendencias_conciliacao = associacao.pendencias_conciliacao_bancaria_por_periodo_para_geracao_de_documentos(
+        contas_pendentes = associacao.pendencias_conciliacao_bancaria_por_periodo_para_geracao_de_documentos(
             periodo)
+
+        pendencias_conciliacao = None
+
+        if len(contas_pendentes) > 0:
+            pendencias_conciliacao = {
+                'contas_pendentes': [conta.uuid for conta in contas_pendentes]
+            }
 
         if pendencias_dados or pendencias_conciliacao:
             pendencias_cadastrais = {

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -710,7 +710,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
         motivos_reprovacao_uuid = request.data.get('motivos_reprovacao', [])
         outros_motivos_reprovacao = request.data.get('outros_motivos_reprovacao', '')
 
-        if resultado_analise == PrestacaoConta.STATUS_REPROVADA and not motivos_reprovacao_uuid and not outros_motivos_reprovacao: # noqa
+        if resultado_analise == PrestacaoConta.STATUS_REPROVADA and not motivos_reprovacao_uuid and not outros_motivos_reprovacao:  # noqa
             response = {
                 'uuid': f'{uuid}',
                 'erro': 'falta_de_informacoes',
@@ -768,6 +768,19 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                         'Essa prestação de contas não pode ser devolvida, ou reaberta porque há prestação de contas '
                         'dessa associação de um período posterior. Se necessário, reabra ou devolva primeiro a '
                         'prestação de contas mais recente.'
+                    )
+                }
+                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+
+        if resultado_analise == PrestacaoConta.STATUS_DEVOLVIDA:
+            if prestacao_conta.analise_atual and prestacao_conta.analise_atual.tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta():
+                response = {
+                    'uuid': f'{uuid}',
+                    'erro': 'devolucao_invalida',
+                    'operacao': 'concluir-analise',
+                    'mensagem': (
+                        'Não é possível devolver esta prestação de contas, pois há pendências na conciliação bancária '
+                        'sem solicitação de acerto. Para prosseguir, solicite o acerto das contas pendentes.'
                     )
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
@@ -2056,8 +2069,8 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
 
         if (
-            not prestacao_conta.ata_retificacao_gerada()
-            and not possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta)
+            not prestacao_conta.ata_retificacao_gerada() and
+            not possui_apenas_categorias_que_nao_requerem_ata(prestacao_conta)
         ):
             response = {
                 'uuid': f'{uuid}',
@@ -2067,7 +2080,7 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
                 'mensagem': 'É necessário gerar ata de retificação para realizar o recebimento.'
             }
             return Response(response, status=status.HTTP_400_BAD_REQUEST)
-        
+
         prestacao_recebida = prestacao_conta.receber_apos_acertos(data_recebimento_apos_acertos=data_recebimento)
 
         return Response(PrestacaoContaRetrieveSerializer(prestacao_recebida, many=False).data,

--- a/sme_ptrf_apps/core/fixtures/factories/__init__.py
+++ b/sme_ptrf_apps/core/fixtures/factories/__init__.py
@@ -27,3 +27,5 @@ from .arquivo_download_factory import *
 from .tipo_devolucao_ao_tesouro_factory import *
 from .flag_factory import *
 from .ata_factory import *
+from .analise_conta_prestacao_conta_factory import *
+from .pdf_factory import *

--- a/sme_ptrf_apps/core/fixtures/factories/analise_conta_prestacao_conta_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/analise_conta_prestacao_conta_factory.py
@@ -1,0 +1,9 @@
+from factory.django import DjangoModelFactory
+from faker import Faker
+from sme_ptrf_apps.core.models.analise_conta_prestacao_conta import AnaliseContaPrestacaoConta
+fake = Faker("pt_BR")
+
+
+class AnaliseContaPrestacaoContaFactory(DjangoModelFactory):
+    class Meta:
+        model = AnaliseContaPrestacaoConta

--- a/sme_ptrf_apps/core/fixtures/factories/pdf_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/pdf_factory.py
@@ -1,0 +1,14 @@
+# tests/factories.py
+import factory
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+
+class PDFFactory(factory.Factory):
+    class Meta:
+        model = SimpleUploadedFile
+
+    name = "comprovante.pdf"
+    content = factory.LazyAttribute(
+        lambda _: bytes("CONTEUDO TESTE TESTE TESTE", encoding="utf-8")
+    )
+    content_type = "application/pdf"

--- a/sme_ptrf_apps/core/tests/services/test_analise_prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/tests/services/test_analise_prestacao_conta_service.py
@@ -1,0 +1,32 @@
+import pytest
+from datetime import datetime, date
+from sme_ptrf_apps.core.models import AnaliseContaPrestacaoConta
+from sme_ptrf_apps.core.services.analise_prestacao_conta_service import cria_solicitacao_acerto_em_contas_com_pendencia
+
+pytestmark = pytest.mark.django_db
+
+
+def test_cria_solicitacao_acerto_em_contas_com_pendencia(
+    periodo_factory,
+    prestacao_conta_factory,
+    analise_prestacao_conta_factory,
+    conta_associacao_factory,
+
+):
+    periodo_2023_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2023, 1, 1),
+                                            data_fim_realizacao_despesas=datetime(2023, 5, 30))
+    pc = prestacao_conta_factory(periodo=periodo_2023_1, status="DEVOLVIDA", analise_atual=None)
+    analise = analise_prestacao_conta_factory(prestacao_conta=pc)
+
+    conta_associacao_factory(associacao=pc.associacao, data_inicio=date(2019, 2, 2))
+    conta_associacao_factory(associacao=pc.associacao, data_inicio=date(2019, 2, 2))
+
+    cria_solicitacao_acerto_em_contas_com_pendencia(analise)
+
+    registros = AnaliseContaPrestacaoConta.objects.filter(analise_prestacao_conta=analise)
+
+    assert registros.count() == 2
+    assert all(
+        r.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta == "Corrigir pendências na conciliação"
+        for r in registros
+    )

--- a/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
@@ -1,9 +1,16 @@
 import pytest
+from datetime import datetime, date
 from django.contrib import admin
 
 from ...models import PrestacaoConta, AnalisePrestacaoConta, DevolucaoPrestacaoConta
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def periodo_2023_1(periodo_factory):
+    return periodo_factory.create(data_inicio_realizacao_despesas=datetime(2023, 1, 1),
+                                  data_fim_realizacao_despesas=datetime(2023, 5, 30))
 
 
 def test_instance_model(analise_prestacao_conta_2020_1):
@@ -118,6 +125,8 @@ def test_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
     com_pendencia,
     com_solicitacao_de_acerto_em_conta,
     esperado,
+    periodo_2023_1,
+    prestacao_conta_factory,
     analise_prestacao_conta_factory,
     observacao_conciliacao_factory,
     conta_associacao_factory,
@@ -125,9 +134,14 @@ def test_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
     pdf_factory
 ):
 
-    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+    pc = prestacao_conta_factory(periodo=periodo_2023_1, status="EM_ANALISE")
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE", prestacao_conta=pc)
+    pc.analise_atual = analise
+    pc.save()
+
     conta_associacao = conta_associacao_factory.create(
-        associacao=analise.prestacao_conta.associacao
+        associacao=analise.prestacao_conta.associacao,
+        data_inicio=date(2019, 2, 2)
     )
     if com_pendencia:
         observacao_conciliacao_factory(
@@ -155,15 +169,22 @@ def test_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
 
 
 def test_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
+    periodo_2023_1,
+    prestacao_conta_factory,
     analise_prestacao_conta_factory,
     observacao_conciliacao_factory,
-    conta_associacao_factory,
+    conta_associacao_factory
 ):
+    pc = prestacao_conta_factory(periodo=periodo_2023_1, status="EM_ANALISE")
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE", prestacao_conta=pc)
+    pc.analise_atual = analise
+    pc.save()
 
-    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
     conta_associacao = conta_associacao_factory.create(
-        associacao=analise.prestacao_conta.associacao
+        associacao=analise.prestacao_conta.associacao,
+        data_inicio=date(2019, 2, 2)
     )
+
     observacao_conciliacao_factory(
         conta_associacao=conta_associacao,
         associacao=analise.prestacao_conta.associacao,
@@ -174,15 +195,22 @@ def test_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
 
 
 def test_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta_sem_pendencias(
+    periodo_2023_1,
+    prestacao_conta_factory,
     analise_prestacao_conta_factory,
     analise_conta_prestacao_conta_factory,
     observacao_conciliacao_factory,
-    conta_associacao_factory,
+    conta_associacao_factory
 ):
 
-    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+    pc = prestacao_conta_factory(periodo=periodo_2023_1, status="EM_ANALISE")
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE", prestacao_conta=pc)
+    pc.analise_atual = analise
+    pc.save()
+
     conta_associacao = conta_associacao_factory.create(
-        associacao=analise.prestacao_conta.associacao
+        associacao=analise.prestacao_conta.associacao,
+        data_inicio=date(2019, 2, 2)
     )
     observacao_conciliacao_factory(
         conta_associacao=conta_associacao,

--- a/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
+++ b/sme_ptrf_apps/core/tests/tests_analise_prestacao_conta/test_analise_prestacao_conta_model.py
@@ -15,7 +15,8 @@ def test_instance_model(analise_prestacao_conta_2020_1):
 
 
 def test_srt_model(analise_prestacao_conta_2020_1):
-    assert analise_prestacao_conta_2020_1.__str__() == f'2020.1 - 2020-01-01 a 2020-06-30 - Análise #{analise_prestacao_conta_2020_1.id}'
+    assert analise_prestacao_conta_2020_1.__str__(
+    ) == f'2020.1 - 2020-01-01 a 2020-06-30 - Análise #{analise_prestacao_conta_2020_1.id}'
 
 
 def test_admin():
@@ -32,3 +33,167 @@ def test_audit_log(analise_prestacao_conta_2020_1):
     assert analise_prestacao_conta_2020_1.history.count() == 2  # Um log de inclusão e outro de edição
     assert analise_prestacao_conta_2020_1.history.latest().action == 1  # 1-Edição
 
+
+@pytest.mark.parametrize(
+    "tem_documento, doc_pode_alterar, tem_lancamento, lanc_pode_alterar, esperado",
+    [
+        (True, True, False, False, True),   # documento_pode_alterar
+        (True, False, False, False, False),  # documento_nao_altera
+
+        (False, False, True, True, True),   # lancamento_pode_alterar
+        (False, False, True, False, False),  # lancamento_nao_altera
+
+        (True, True, True, False, True),   # doc_altera_lanc_nao
+        (True, False, True, True, True),   # doc_nao_lanc_altera
+        (True, False, True, False, False),  # doc_nao_lanc_nao
+
+        (False, False, False, False, False),  # nenhum
+    ],
+    ids=[
+        "documento_pode_alterar",
+        "documento_nao_altera",
+        "lancamento_pode_alterar",
+        "lancamento_nao_altera",
+        "doc_altera_lanc_nao",
+        "doc_nao_lanc_altera",
+        "doc_nao_lanc_nao",
+        "nenhum",
+    ],
+)
+def test_tem_acertos_que_podem_alterar_saldo_conciliacao(
+    tem_documento,
+    doc_pode_alterar,
+    tem_lancamento,
+    lanc_pode_alterar,
+    esperado,
+    analise_prestacao_conta_factory,
+    analise_documento_prestacao_conta_factory,
+    analise_lancamento_prestacao_conta_factory,
+    tipo_acerto_documento_factory,
+    tipo_acerto_lancamento_factory,
+    solicitacao_acerto_documento_factory,
+    solicitacao_acerto_lancamento_factory,
+):
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+
+    if tem_documento:
+        analise_documento = analise_documento_prestacao_conta_factory(
+            analise_prestacao_conta=analise
+        )
+        tipo_doc = tipo_acerto_documento_factory(
+            pode_alterar_saldo_conciliacao=doc_pode_alterar
+        )
+        solicitacao_acerto_documento_factory(
+            analise_documento=analise_documento,
+            tipo_acerto=tipo_doc,
+            status_realizacao='PENDENTE'
+        )
+
+    if tem_lancamento:
+        analise_lancamento = analise_lancamento_prestacao_conta_factory(
+            analise_prestacao_conta=analise
+        )
+        tipo_lanc = tipo_acerto_lancamento_factory(
+            pode_alterar_saldo_conciliacao=lanc_pode_alterar
+        )
+        solicitacao_acerto_lancamento_factory(
+            analise_lancamento=analise_lancamento,
+            tipo_acerto=tipo_lanc,
+            status_realizacao='PENDENTE'
+        )
+
+    assert analise.tem_acertos_que_podem_alterar_saldo_conciliacao() is esperado
+
+
+@pytest.mark.parametrize(
+    "com_pendencia, com_solicitacao_de_acerto_em_conta, esperado",
+    [
+        (True, False, True),   # tem_pendencia_sem_solicitacao
+        (True, True, False),   # tem_pendencia_com_solicitacao
+        (False, False, False),   # nao_tem_pendencia
+    ],
+    ids=["tem_pendencia_sem_solicitacao", "tem_pendencia_com_solicitacao", "nao_tem_pendencia"],
+)
+def test_tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
+    com_pendencia,
+    com_solicitacao_de_acerto_em_conta,
+    esperado,
+    analise_prestacao_conta_factory,
+    observacao_conciliacao_factory,
+    conta_associacao_factory,
+    analise_conta_prestacao_conta_factory,
+    pdf_factory
+):
+
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+    conta_associacao = conta_associacao_factory.create(
+        associacao=analise.prestacao_conta.associacao
+    )
+    if com_pendencia:
+        observacao_conciliacao_factory(
+            conta_associacao=conta_associacao,
+            associacao=analise.prestacao_conta.associacao,
+            periodo=analise.prestacao_conta.periodo,
+        )
+    else:
+        observacao_conciliacao_factory(
+            data_extrato=analise.prestacao_conta.periodo.data_fim_realizacao_despesas,
+            saldo_extrato=1000,
+            periodo=analise.prestacao_conta.periodo,
+            associacao=analise.prestacao_conta.associacao,
+            conta_associacao=conta_associacao,
+            comprovante_extrato=pdf_factory())
+
+    if com_solicitacao_de_acerto_em_conta:
+        analise_conta_prestacao_conta_factory(
+            analise_prestacao_conta=analise,
+            prestacao_conta=analise.prestacao_conta,
+            conta_associacao=conta_associacao,
+        )
+
+    assert analise.tem_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta() is esperado
+
+
+def test_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta(
+    analise_prestacao_conta_factory,
+    observacao_conciliacao_factory,
+    conta_associacao_factory,
+):
+
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+    conta_associacao = conta_associacao_factory.create(
+        associacao=analise.prestacao_conta.associacao
+    )
+    observacao_conciliacao_factory(
+        conta_associacao=conta_associacao,
+        associacao=analise.prestacao_conta.associacao,
+        periodo=analise.prestacao_conta.periodo,
+    )
+
+    assert analise.contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta()[0].uuid == conta_associacao.uuid
+
+
+def test_contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta_sem_pendencias(
+    analise_prestacao_conta_factory,
+    analise_conta_prestacao_conta_factory,
+    observacao_conciliacao_factory,
+    conta_associacao_factory,
+):
+
+    analise = analise_prestacao_conta_factory(status="EM_ANALISE")
+    conta_associacao = conta_associacao_factory.create(
+        associacao=analise.prestacao_conta.associacao
+    )
+    observacao_conciliacao_factory(
+        conta_associacao=conta_associacao,
+        associacao=analise.prestacao_conta.associacao,
+        periodo=analise.prestacao_conta.periodo,
+    )
+
+    analise_conta_prestacao_conta_factory(
+        analise_prestacao_conta=analise,
+        prestacao_conta=analise.prestacao_conta,
+        conta_associacao=conta_associacao,
+    )
+
+    assert analise.contas_pendencia_conciliacao_sem_solicitacao_de_acerto_em_conta() == []


### PR DESCRIPTION
Esse PR:

- Atualiza retrieve de prestação de contas com informações sobre acertos que podem alterar saldo da conciliação e contas com pendência sem solicitação de acerto
- Implementa função para criar solicitação de acerto em cenários de PCs devolvidas com pendências
- Implementa testes unitários para os novos métodos da class de análise da prestação de conta e service

[AB#134188](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/134188)