### PR TITLE
feat(134189): Comentar: Concluir acerto: Validar se houve alteração no saldo bancário e não permitir a conclusão dos acertos

### DIFF
--- a/sme_ptrf_apps/core/services/prestacao_conta_service.py
+++ b/sme_ptrf_apps/core/services/prestacao_conta_service.py
@@ -614,4 +614,6 @@ class PrestacaoContaService:
                 if saldo_fechamento is not None and saldo_fechamento != saldo_calculado and not requer_acertos:
                     contas_alteradas.append(conta)
 
-        return contas_alteradas
+        # [HISTÓRIA #134189] DESCONSIDERA VALIDAÇÃO TEMPORARIAMENTE DEVIDO A INSCONSISTÊNCIAS NO FLUXO DE ANÁLISE DRE
+        # return contas_alteradas
+        return []

--- a/sme_ptrf_apps/core/services/resumo_rescursos_service.py
+++ b/sme_ptrf_apps/core/services/resumo_rescursos_service.py
@@ -28,9 +28,7 @@ class ResumoDespesas:
         self.data_fim = data_fim
         self.acao_associacao = acao_associacao
         self.conta_associacao = conta_associacao
-        self.total_custeio = Decimal(0.00)
-        self.total_capital = Decimal(0.00)
-        self.total_geral = Decimal(0.00)
+        self.__set_totais_despesas_com_zero()
 
         self.fechamentos_no_periodo = fechamentos_no_periodo
 
@@ -43,6 +41,11 @@ class ResumoDespesas:
             self.__set_total_despesas_pelo_movimento_do_periodo()
 
         self.total_geral += self.total_custeio + self.total_capital
+
+    def __set_totais_despesas_com_zero(self):
+        self.total_custeio = Decimal(0.00)
+        self.total_capital = Decimal(0.00)
+        self.total_geral = Decimal(0.00)
 
     def __set_totais_despesas_pelos_fechamentos(self):
         self.total_custeio = Decimal(0.00)
@@ -60,8 +63,8 @@ class ResumoDespesas:
             data_fim=self.data_fim
         )
 
-        totais_despesa_por_aplicacao = despesas.values('aplicacao_recurso').order_by('aplicacao_recurso').annotate(
-            valor_total_aplicacao=Sum('valor_rateio'))
+        totais_despesa_por_aplicacao = despesas.values('aplicacao_recurso').order_by(
+            'aplicacao_recurso').annotate(valor_total_aplicacao=Sum('valor_rateio'))
 
         for total in totais_despesa_por_aplicacao:
             if total['aplicacao_recurso'] == 'CUSTEIO':
@@ -73,11 +76,14 @@ class ResumoDespesas:
                 raise ResumoRecursosException(erro)
 
     def get_totais_despesas_pelos_fechamentos(self):
+        self.__set_totais_despesas_com_zero()
         self.__set_totais_despesas_pelos_fechamentos()
 
         self.total_geral += self.total_custeio + self.total_capital
 
     def get_totais_despesas_pelo_movimento(self):
+        self.__set_totais_despesas_com_zero()
+
         self.__set_total_despesas_pelo_movimento_do_periodo()
 
         self.total_geral += self.total_custeio + self.total_capital

--- a/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/test_prestacao_de_contas_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_prestacao_de_contas_services/test_prestacao_de_contas_service.py
@@ -6,6 +6,7 @@ from sme_ptrf_apps.core.services.prestacao_conta_service import PrestacaoContaSe
 pytestmark = pytest.mark.django_db
 
 
+# [HISTÓRIA #134189] DESCONSIDERA VALIDAÇÃO TEMPORARIAMENTE DEVIDO A INSCONSISTÊNCIAS NO FLUXO DE ANÁLISE DRE
 def test_contas_com_saldo_alterado_sem_solicitacao(
     associacao_factory,
     periodo_factory,
@@ -54,4 +55,5 @@ def test_contas_com_saldo_alterado_sem_solicitacao(
             periodo_uuid=periodo_2024_1.uuid,
             logger=fake_logger
         )
-        assert pc_service.contas_com_saldo_alterado_sem_solicitacao() == [conta_associacao]
+        # assert pc_service.contas_com_saldo_alterado_sem_solicitacao() == [conta_associacao]
+        assert pc_service.contas_com_saldo_alterado_sem_solicitacao() == []


### PR DESCRIPTION
- Comenta retorno de contas pendentes para inibir validação até que as regras de acertos sejam revisadas

[AB#134189](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/134189)