### PR TITLE
feature(144948): verifica recurso associado em acoes

### DIFF
--- a/sme_ptrf_apps/core/api/views/acao_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/acao_associacao_viewset.py
@@ -43,7 +43,7 @@ class AcaoAssociacaoViewSet(mixins.RetrieveModelMixin,
     pagination_class = AcaoAssociacaoPagination
 
     def get_queryset(self):
-        qs = AcaoAssociacao.objects.all()
+        qs = AcaoAssociacao.objects.filter(acao__recurso=self.request.recurso)
 
         nome = self.request.query_params.get('nome')
         filtro_informacoes = self.request.query_params.get('filtro_informacoes')

--- a/sme_ptrf_apps/core/tests/tests_acao_associacao/test_acao_associacao_viewset.py
+++ b/sme_ptrf_apps/core/tests/tests_acao_associacao/test_acao_associacao_viewset.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.django_db
 
 def test_view_set(acao_associacao, usuario_permissao_associacao):
     request = APIRequestFactory().get("")
+    request.recurso = acao_associacao.acao.recurso
     detalhe = AcaoAssociacaoViewSet.as_view({'get': 'retrieve'})
     force_authenticate(request, user=usuario_permissao_associacao)
     response = detalhe(request, uuid=acao_associacao.uuid)

--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -246,7 +246,7 @@ class PaaViewSet(WaffleFlagMixin, ModelViewSet):
         from sme_ptrf_apps.core.api.serializers.acao_associacao_serializer import AcaoAssociacaoRetrieveSerializer
 
         paa = self.get_object()
-        acoes_associacoes = paa.associacao.acoes.all()
+        acoes_associacoes = paa.associacao.acoes.filter(acao__recurso__legado=True)
 
         serializer_acao_associacao = AcaoAssociacaoRetrieveSerializer(acoes_associacoes, many=True)
         for acao_assoc in serializer_acao_associacao.data:

--- a/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
+++ b/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
@@ -72,7 +72,12 @@ class ResumoPrioridadesService:
 
         # Queryset de Ações de Associação do PAA ordenados por nome da Ação.
         # Ignorar Açoes com o campo exibir_paa = False (História 134829)
-        acoes_associacoes_qs = self.paa.associacao.acoes.exclude(acao__exibir_paa=False).order_by('acao__nome')
+        acoes_associacoes_qs = (
+            self.paa.associacao.acoes
+            .exclude(acao__exibir_paa=False)
+            .filter(acao__recurso__legado=True)
+            .order_by("acao__nome")
+        )
 
         # Dados Serializados
         acoes_associacoes_data = AcaoAssociacaoRetrieveSerializer(acoes_associacoes_qs, many=True).data


### PR DESCRIPTION
# O que este PR faz

- Ajusta receitas_previstas para trazer apenas ações associadas ao recurso legado
- Adiciona em ação associação o filtro por recurso ativo das ações
- Ajusta resumo-prioridades (calcula_node_ptrf) para pegar apenas o recurso legado.

Referência Azure: [AB#144948](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/144948)