### PR TITLE
feat(140717): Altera título da página do pdf de ata parecer técnico por recurso.

### DIFF
--- a/sme_ptrf_apps/core/models/associacao.py
+++ b/sme_ptrf_apps/core/models/associacao.py
@@ -565,12 +565,6 @@ class Associacao(ModeloIdNome):
         return associacoes_ativas
 
     @classmethod
-    def get_associacoes_ativas_by_dre_and_recurso(cls, dre, recurso):
-        associacoes_ativas = cls.ativas.filter(unidade__dre=dre)
-        associacoes_por_recurso = cls.filter_by_recurso(associacoes_ativas, recurso)
-        return associacoes_por_recurso
-
-    @classmethod
     def filtro_informacoes_to_json(cls):
         return FiltroInformacoesAssociacao.choices()
 

--- a/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
+++ b/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
@@ -65,6 +65,7 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
 
     cabecalho = {
         "titulo": periodo.recurso.nome,
+        "recurso": periodo.recurso.nome,
         "sub_titulo": f"Diretoria Regional de Educação - {formata_nome_dre(dre.nome)}",
         "nome_ata": f"Ata de Parecer Técnico Conclusivo",
         "nome_dre": f"{formata_nome_dre(dre.nome)}",

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -567,14 +567,8 @@ def cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, e
 
     eh_relatorio_consolidado_publicacoes_parciais = verifica_se_eh_relatorio_publicacoes_parciais(dre, periodo)
 
-    # Implementa o método filter_by_recurso
-    associacoes_ativas_por_recurso = Associacao.get_associacoes_ativas_by_dre_and_recurso(
-        dre=dre,
-        recurso=periodo.recurso
-    )
-
     execucao_fisica = {
-        "ues_da_dre": associacoes_ativas_por_recurso.count(),
+        "ues_da_dre": quantidade_associacoes_ativas,
         "ues_com_associacao": quantidade_associacoes_ativas,
         "associacoes_regulares": quantidade_regular,
         "aprovada": quantidade_aprovada,

--- a/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
@@ -12,7 +12,7 @@
     <link href="{{ base_static_url }}/css/bootstrap/bootstrap-4.6.0.min.css" rel="stylesheet">
     <link href="{{ base_static_url }}/css/ata-parecer-tecnico-pdf.css" rel="stylesheet">
 
-  <title>Ata Parecer Técnico PTRF</title>
+  <title>Ata Parecer Técnico {{ dados.cabecalho.recurso }}</title>
 </head>
 <body>
 


### PR DESCRIPTION
Este PR inclui:

- Altera título do pdf de Ata Parecer Técnico aberto no navegador, para incluir nome do recurso da PC.
- Remove função inutilizada para obter UEs da DRE por recurso no demonstrativo físico-financeiro.
- Validação de testes unitários.

História: [AB#140717](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/140717)
Task: [AB#145104](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145104)