### PR TITLE
feature(144896): permite adicionar informação vazia no parametro do paa - Hom

### DIFF
--- a/sme_ptrf_apps/paa/api/serializers/parametro_paa_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/parametro_paa_serializer.py
@@ -3,33 +3,26 @@ from rest_framework import serializers
 
 
 class ParametroPaaSerializer(serializers.ModelSerializer):
-    texto_pagina_paa_ue = serializers.CharField(error_messages={
-        'null': ('O campo Explicação sobre o PAA não foi informado.'),
-        'blank': ('O campo Explicação sobre o PAA não foi informado.')})
+    texto_pagina_paa_ue = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Explicação sobre o PAA não foi informado.')})
 
-    texto_atividades_previstas = serializers.CharField(error_messages={
-        'null': ('O campo Atividades previstas não foi informado.'),
-        'blank': ('O campo Atividades previstas não foi informado.')})
+    texto_atividades_previstas = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Atividades previstas não foi informado.')})
 
-    texto_levantamento_prioridades = serializers.CharField(error_messages={
-        'null': ('O campo Levantamento de Prioridades não foi informado.'),
-        'blank': ('O campo Levantamento de Prioridades não foi informado.')})
+    texto_levantamento_prioridades = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Levantamento de Prioridades não foi informado.')})
 
-    introducao_do_paa_ue_1 = serializers.CharField(error_messages={
-        'null': ('O campo Introdução 1 da aba Relatórios não foi informado.'),
-        'blank': ('O campo Introdução 1 da aba Relatórios não foi informado.')})
+    introducao_do_paa_ue_1 = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Introdução 1 da aba Relatórios não foi informado.')})
 
-    introducao_do_paa_ue_2 = serializers.CharField(error_messages={
-        'null': ('O campo Introdução 2 da aba Relatórios não foi informado.'),
-        'blank': ('O campo Introdução 2 da aba Relatórios não foi informado.')})
+    introducao_do_paa_ue_2 = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Introdução 2 da aba Relatórios não foi informado.')})
 
-    conclusao_do_paa_ue_1 = serializers.CharField(error_messages={
-        'null': ('O campo Conclusão do PAA 1 não foi informado.'),
-        'blank': ('O campo Conclusão do PAA 1 não foi informado.')})
+    conclusao_do_paa_ue_1 = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Conclusão do PAA 1 não foi informado.')})
 
-    conclusao_do_paa_ue_2 = serializers.CharField(error_messages={
-        'null': ('O campo Conclusão da aba Relatórios não foi informado.'),
-        'blank': ('O campo Conclusão da aba Relatórios não foi informado.')})
+    conclusao_do_paa_ue_2 = serializers.CharField(allow_blank=True, error_messages={
+        'null': ('O campo Conclusão da aba Relatórios não foi informado.')})
 
     """
     Serializer para o modelo ParametroPaa.

--- a/sme_ptrf_apps/paa/tests/parametro_paa/test_textos_paa_ue_api.py
+++ b/sme_ptrf_apps/paa/tests/parametro_paa/test_textos_paa_ue_api.py
@@ -109,6 +109,12 @@ class TestTextosPaaUeAPI:
         """Testa PATCH update-textos-paa-ue com strings vazias (deve funcionar)"""
         data = {
             'texto_pagina_paa_ue': '',
+            'texto_atividades_previstas': '',
+            'texto_levantamento_prioridades': '',
+            'introducao_do_paa_ue_1': '',
+            'introducao_do_paa_ue_2': '',
+            'conclusao_do_paa_ue_1': '',
+            'conclusao_do_paa_ue_2': ''
         }
 
         response = jwt_authenticated_client_sme.patch(
@@ -116,8 +122,19 @@ class TestTextosPaaUeAPI:
             data=json.dumps(data),
             content_type='application/json'
         )
+        content = json.loads(response.content)
+        parametro_paa.refresh_from_db()
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_200_OK
+        assert content['detail'] == 'Textos atualizados com sucesso'
+
+        assert parametro_paa.texto_pagina_paa_ue == ''
+        assert parametro_paa.texto_atividades_previstas == ''
+        assert parametro_paa.texto_levantamento_prioridades == ''
+        assert parametro_paa.introducao_do_paa_ue_1 == ''
+        assert parametro_paa.introducao_do_paa_ue_2 == ''
+        assert parametro_paa.conclusao_do_paa_ue_1 == ''
+        assert parametro_paa.conclusao_do_paa_ue_2 == ''
 
     def test_patch_update_textos_paa_ue_mixed_none_and_values(self, jwt_authenticated_client_sme, flag_paa,
                                                               parametro_paa):
@@ -125,7 +142,6 @@ class TestTextosPaaUeAPI:
         data = {
             'texto_pagina_paa_ue': '<p>Texto atualizado</p>',
             'introducao_do_paa_ue_1': None,
-            'introducao_do_paa_ue_2': ''
         }
 
         response = jwt_authenticated_client_sme.patch(
@@ -139,7 +155,36 @@ class TestTextosPaaUeAPI:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert 'introducao_do_paa_ue_1' in content
         assert content['introducao_do_paa_ue_1'][0] == 'O campo Introdução 1 da aba Relatórios não foi informado.'
+
+    def test_patch_update_textos_paa_ue_none_values(self, jwt_authenticated_client_sme, flag_paa,
+                                                    parametro_paa):
+        """Testa PATCH update-textos-paa-ue com alguns campos None e outros com valores"""
+        data = {
+            'texto_pagina_paa_ue': None,
+            'texto_atividades_previstas': None,
+            'texto_levantamento_prioridades': None,
+            'introducao_do_paa_ue_1': None,
+            'introducao_do_paa_ue_2': None,
+            'conclusao_do_paa_ue_1': None,
+            'conclusao_do_paa_ue_2': None
+        }
+
+        response = jwt_authenticated_client_sme.patch(
+            '/api/parametros-paa/update-textos-paa-ue/',
+            data=json.dumps(data),
+            content_type='application/json'
+        )
+
+        content = json.loads(response.content)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert content['texto_pagina_paa_ue'][0] == 'O campo Explicação sobre o PAA não foi informado.'
+        assert content['texto_atividades_previstas'][0] == 'O campo Atividades previstas não foi informado.'
+        assert content['texto_levantamento_prioridades'][0] == 'O campo Levantamento de Prioridades não foi informado.'
+        assert content['introducao_do_paa_ue_1'][0] == 'O campo Introdução 1 da aba Relatórios não foi informado.'
         assert content['introducao_do_paa_ue_2'][0] == 'O campo Introdução 2 da aba Relatórios não foi informado.'
+        assert content['conclusao_do_paa_ue_1'][0] == 'O campo Conclusão do PAA 1 não foi informado.'
+        assert content['conclusao_do_paa_ue_2'][0] == 'O campo Conclusão da aba Relatórios não foi informado.'
 
     def test_patch_update_textos_paa_ue_all_fields(self, jwt_authenticated_client_sme, flag_paa, parametro_paa):
         """Testa PATCH update-textos-paa-ue atualizando todos os campos"""


### PR DESCRIPTION
Esse PR:

- Permite adicionar texto vazio nos Parâmetros do PAA

História: [AB#144896](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/144896)
Tarefa: [AB#145917](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145917)