### PR TITLE
bugfix(145255): erro coresso cadastro usuario

### DIFF
--- a/sme_ptrf_apps/users/services/sme_integracao_service.py
+++ b/sme_ptrf_apps/users/services/sme_integracao_service.py
@@ -102,7 +102,12 @@ class SmeIntegracaoService:
         try:
             response = requests.get(f'{settings.SME_INTEGRACAO_URL}/api/AutenticacaoSgp/{login}/dados', headers=cls.headers)
             if response.status_code == status.HTTP_200_OK:
-                return response.json()
+                response_parsed = response.json()
+                
+                if not response_parsed.get("nome"):
+                    return None
+                
+                return response_parsed
             else:
                 logger.info(f"Usuário {login} não encontrado no CoreSSO: {response}")
                 return None

--- a/sme_ptrf_apps/users/tests/test_services/test_sme_integracao_service.py
+++ b/sme_ptrf_apps/users/tests/test_services/test_sme_integracao_service.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch, Mock
+from sme_ptrf_apps.users.services.sme_integracao_service import SmeIntegracaoService
+
+
+@patch("sme_ptrf_apps.users.services.sme_integracao_service.requests.get")
+def test_usuario_core_sso_retorna_none_quando_nome_nulo(mock_get):
+
+    login = "usuario_teste"
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "nome": None,
+        "email": "teste@email.com"
+    }
+
+    mock_get.return_value = mock_response
+    result = SmeIntegracaoService.usuario_core_sso_or_none(login)
+
+    assert result is None
+    mock_get.assert_called_once()


### PR DESCRIPTION
# O que este PR faz

- Foi realizada uma melhoria na lógica da função cria_ou_atualiza_usuario_core_sso, passando a considerar que o usuário não existe quando a API /api/AutenticacaoSgp/{login}/dados retornar status code 200 com o campo nome vazio.

Referência Azure: [AB#145255](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/145255)