### PR TITLE
hotfix(146592): não exibir programa pdde correção da lógica de verifi…

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.36.1"
+__version__ = "9.36.2"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/services/paa_service.py
+++ b/sme_ptrf_apps/paa/services/paa_service.py
@@ -85,7 +85,7 @@ class PaaService:
                 qs_acoes_pdde = qs_programa.acaopdde_set.all()
 
             # Não exibir Programa quando não houver ações utilizando-o
-            if not qs_acoes_pdde:
+            if not qs_acoes_pdde.exists():
                 continue
 
             # Objeto padrão por programa


### PR DESCRIPTION
# O que este PR faz

- Corrige lógica de verificação das ações de um programa para não inseri-lo na lista de programas PDDE caso não possua ações associadas.

Referência Azure: [AB#146592](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/146592)
