### PR TITLE
feature(145888): Adiciona Atividades estatutárias e objetivos separados por paa e globais ao snapshot de retificação.

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.36.0"
+__version__ = "9.36.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/despesas/admin.py
+++ b/sme_ptrf_apps/despesas/admin.py
@@ -44,6 +44,7 @@ class TipoCusteioAdmin(admin.ModelAdmin):
 class RateioDespesaAdmin(admin.ModelAdmin):
     list_display = (
         "uuid", 'numero_documento', 'associacao', 'acao', 'valor_rateio', 'quantidade_itens_capital', 'status',)
+    list_select_related = ('despesa', 'associacao', 'acao_associacao', 'acao_associacao__acao')
     search_fields = (
         'despesa__numero_documento', 'despesa__nome_fornecedor', 'especificacao_material_servico__descricao',
         'associacao__unidade__codigo_eol', 'associacao__unidade__nome',)
@@ -75,13 +76,17 @@ class RateioDespesaAdmin(admin.ModelAdmin):
 
 class RateioDespesaInLine(admin.TabularInline):
     model = RateioDespesa
-    extra = 1  # Quantidade de linhas que serão exibidas.
+    extra = 0
 
     search_fields = (
         'despesa__numero_documento', 'despesa__nome_fornecedor', 'especificacao_material_servico__descricao',
         'associacao__unidade__codigo_eol', 'associacao__unidade__nome',)
 
     autocomplete_fields = ['associacao', 'despesa', 'conta_associacao', 'acao_associacao']
+    raw_id_fields = [
+        'associacao', 'despesa', 'conta_associacao', 'acao_associacao',
+        'especificacao_material_servico', 'tag', 'periodo_conciliacao',
+    ]
 
 
 class PeriodoDaDespesaFilter(admin.SimpleListFilter):
@@ -107,6 +112,8 @@ class DespesaAdmin(admin.ModelAdmin):
         'tipo_documento', 'numero_documento', 'data_documento', 'nome_fornecedor', 'valor_total', 'status',
         'associacao', 'retem_imposto', 'despesa_anterior_ao_uso_do_sistema',
         'despesa_anterior_ao_uso_do_sistema_pc_concluida', 'recurso')
+    list_select_related = ('tipo_documento', 'associacao', 'recurso')
+    show_full_result_count = False
     ordering = ('-data_documento',)
     search_fields = (
         'numero_documento',

--- a/sme_ptrf_apps/paa/admin.py
+++ b/sme_ptrf_apps/paa/admin.py
@@ -278,6 +278,9 @@ class AtaPaaAdmin(admin.ModelAdmin):
         'parecer_conselho',
         'previa',
     )
+    list_select_related = (
+        'paa', 'paa__periodo_paa', 'paa__associacao', 'paa__associacao__unidade',
+        'composicao', 'presidente_da_reuniao', 'secretario_da_reuniao')
 
     list_filter = (
         'paa__periodo_paa',
@@ -379,4 +382,4 @@ class ReplicaPaaAdmin(admin.ModelAdmin):
         return False
 
     def has_change_permission(self, request, obj=None):
-        return request.user.is_superuser
+        return False

--- a/sme_ptrf_apps/paa/admin_inlines.py
+++ b/sme_ptrf_apps/paa/admin_inlines.py
@@ -1,45 +1,70 @@
 from django.contrib import admin
 from sme_ptrf_apps.paa.models import (
+    Paa,
     ReceitaPrevistaPaa,
     RecursoProprioPaa,
     ReceitaPrevistaPdde,
     PrioridadePaa,
-    ObjetivoPaa,
     AtaPaa,
-    AtividadeEstatutariaPaa,
     DocumentoPaa,
     ReceitaPrevistaOutroRecursoPeriodo
 )
 
 
 class ObjetivosPaaInline(admin.TabularInline):
-    model = ObjetivoPaa
+    model = Paa.objetivos.through
     extra = 0
     fields = (
-        'uuid',
-        'nome',
-        'status',
+        'get_uuid',
+        'get_nome',
+        'get_status',
+        'get_objetivo_do_paa',
     )
     readonly_fields = fields
     can_delete = False
+    verbose_name = 'Objetivo'
+    verbose_name_plural = 'Objetivos'
 
-    def has_add_permission(self, request, obj):
+    def has_add_permission(self, request, obj=None):
         return False
+
+    def get_uuid(self, obj):
+        return obj.objetivopaa.uuid
+    get_uuid.short_description = 'UUID'
+
+    def get_nome(self, obj):
+        return obj.objetivopaa.nome
+    get_nome.short_description = 'Nome'
+
+    def get_status(self, obj):
+        return obj.objetivopaa.get_status_display()
+    get_status.short_description = 'Status'
+
+    def get_objetivo_do_paa(self, obj):
+        return obj.objetivopaa.paa_id is not None
+    get_objetivo_do_paa.short_description = 'Criado no PAA'
+    get_objetivo_do_paa.boolean = True
 
 
 class AtividadeEstatutariaPaaInline(admin.TabularInline):
-    model = AtividadeEstatutariaPaa
+    model = Paa.atividades_estatutarias.through
     extra = 0
     fields = (
         'uuid',
         'atividade_estatutaria',
         'data',
+        'get_atividade_estatutaria_do_paa',
     )
     readonly_fields = fields
     can_delete = False
 
     def has_add_permission(self, request, obj):
         return False
+
+    def get_atividade_estatutaria_do_paa(self, obj):
+        return obj.atividade_estatutaria.paa_id is not None
+    get_atividade_estatutaria_do_paa.short_description = 'Criada no PAA'
+    get_atividade_estatutaria_do_paa.boolean = True
 
 
 class ReceitasPrevistasPTRFInline(admin.TabularInline):
@@ -128,13 +153,7 @@ class PrioridadesPaaInline(admin.TabularInline):
         'uuid',
         'prioridade',
         'recurso',
-        # 'acao_associacao',
-        # 'programa_pdde',
-        # 'acao_pdde',
-        # 'outro_recurso',
         'tipo_aplicacao',
-        # 'tipo_despesa_custeio',
-        # 'especificacao_material',
         'valor_total',
     )
     readonly_fields = fields

--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -508,12 +508,16 @@ class PaaViewSet(WaffleFlagMixin, ModelViewSet):
         """
 
         from sme_ptrf_apps.paa.models import ReplicaPaa
+        from sme_ptrf_apps.paa.enums import PaaStatusEnum
 
         paa = self.get_object()
 
         try:
+            # Valida se existe Réplica
             paa.replica
-        except ReplicaPaa.DoesNotExist:
+            # Valida se o PAA foi iniciado para retificação
+            Paa.objects.get(uuid=uuid, status=PaaStatusEnum.EM_RETIFICACAO.name)
+        except (ReplicaPaa.DoesNotExist, Paa.DoesNotExist):
             return Response(
                 {'erro': 'sem_retificacao', 'mensagem': 'Nenhuma retificação iniciada para este PAA.'},
                 status=status.HTTP_404_NOT_FOUND

--- a/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from sme_ptrf_apps.paa.models import AtaPaa, ParticipanteAtaPaa
+from sme_ptrf_apps.paa.models import AtaPaa, ParticipanteAtaPaa, PeriodoPaa
 from sme_ptrf_apps.paa.services.dados_documento_paa_service import (
     criar_grupos_prioridades,
     criar_atividades_estatutarias
@@ -143,6 +143,7 @@ def dados_texto_ata_paa(ata_paa: AtaPaa, usuario=None):
         "unidade_nome": associacao.unidade.nome if associacao.unidade.nome else "___",
         "local_reuniao": ata_paa.local_reuniao if ata_paa.local_reuniao else "___",
         "periodo_referencia": paa.periodo_paa.referencia if paa.periodo_paa.referencia else "___",
+        "datas_limite_periodo_por_extenso": formatar_datas_periodo(paa.periodo_paa) if paa.periodo_paa else "___",
         "presidente_reuniao": ata_paa.presidente_da_reuniao.nome if ata_paa.presidente_da_reuniao else "___",
         "cargo_presidente_reuniao": ata_paa.presidente_da_reuniao.cargo if ata_paa.presidente_da_reuniao else "___",
         "secretario_reuniao": ata_paa.secretario_da_reuniao.nome if ata_paa.secretario_da_reuniao else "___",
@@ -239,6 +240,27 @@ def formatar_hora_ata(hora):
                 return "00h00"
 
     return hora.strftime('%Hh%M')
+
+
+def formatar_datas_periodo(periodo_paa: PeriodoPaa) -> str:
+    """
+    Dado data inicia e final de um periodo, retorna por extenso deste modo:
+    1º de maio de 2026 a 30 de abril de 2027 por exemplo
+    """
+    meses = {
+        1: "janeiro", 2: "fevereiro", 3: "março", 4: "abril",
+        5: "maio", 6: "junho", 7: "julho", 8: "agosto",
+        9: "setembro", 10: "outubro", 11: "novembro", 12: "dezembro",
+    }
+
+    def formatar(data):
+        if not data:
+            return ""
+
+        dia = "1º" if data.day == 1 else str(data.day)
+        return f"{dia} de {meses[data.month]} de {data.year}"
+
+    return f"{formatar(periodo_paa.data_inicial)} a {formatar(periodo_paa.data_final)}"
 
 
 def criar_identificacao_associacao_ata(paa):

--- a/sme_ptrf_apps/paa/services/retificacao_paa_service.py
+++ b/sme_ptrf_apps/paa/services/retificacao_paa_service.py
@@ -19,11 +19,64 @@ class RetificacaoPaaService:
             username=getattr(usuario, 'username', str(usuario))
         )
 
-    def _snapshot_objetivos(self):
-        return {
+    def _snapshot_objetivos_globais(self):
+        result = {}
+        # Lista de objetivos criados dentro do PAA (diferencia dos objetivos globais)
+        objs_paa = self.paa.objetivopaa_set.values_list('uuid', flat=True)
+        objs_globais = self.paa.objetivos.exclude(uuid__in=objs_paa)
+        for obj in objs_globais:
+            result[str(obj.uuid)] = {'nome': obj.nome}
+        return result
+
+    def _snapshot_objetivos_paa(self):
+        result = {
             str(obj.uuid): {'nome': obj.nome}
-            for obj in self.paa.objetivos.all()
+            for obj in self.paa.objetivopaa_set.all()
         }
+        return result
+
+    def _snapshot_atividades_estatutarias_paa(self):
+        result = {}
+        # Atividade Estatutárias(Instância AtividadePrevista) Globais (Não relacionadasa nenhum PAA)
+        _atvs_paa = self.paa.atividades_estatutarias.select_related('paa').filter(paa__isnull=False).all()
+
+        # filtra todas as atividades estatutárias(Instância AtividadePrevistaPaa) relacionadas ao m2m no PAA,
+        # filtrando apenas as atividades acima
+        atvs_paa = self.paa.atividadeestatutariapaa_set \
+            .select_related('paa', 'atividade_estatutaria') \
+            .filter(atividade_estatutaria__in=_atvs_paa) \
+            .all()
+        for atividadepaa in atvs_paa:
+            result[str(atividadepaa.atividade_estatutaria.uuid)] = {
+                'nome': str(atividadepaa.atividade_estatutaria.nome),
+                'tipo': str(atividadepaa.atividade_estatutaria.tipo),
+                'ano': str(atividadepaa.atividade_estatutaria.ano),
+                'mes': str(atividadepaa.atividade_estatutaria.mes),
+                'status': str(atividadepaa.atividade_estatutaria.status),
+                'data': str(atividadepaa.data),
+            }
+        return result
+
+    def _snapshot_atividades_estatutarias_globais(self):
+        result = {}
+        # Atividade Estatutárias Globais (Não relacionadas a nenhum PAA)
+        _atvs_globais = self.paa.atividades_estatutarias.select_related('paa').filter(paa__isnull=True).all()
+
+        # filtra todas as atividades estatutárias relacionadas ao m2m no PAA, filtrando apenas as atividades globais
+        atvs_globais = self.paa.atividadeestatutariapaa_set \
+            .select_related('paa', 'atividade_estatutaria') \
+            .filter(atividade_estatutaria__in=_atvs_globais) \
+            .all()
+        for atividadepaa in atvs_globais:
+            result[str(atividadepaa.atividade_estatutaria.uuid)] = {
+                'nome': str(atividadepaa.atividade_estatutaria.nome),
+                'tipo': str(atividadepaa.atividade_estatutaria.tipo),
+                'ano': str(atividadepaa.atividade_estatutaria.ano),
+                'mes': str(atividadepaa.atividade_estatutaria.mes),
+                'status': str(atividadepaa.atividade_estatutaria.status),
+                'data': str(atividadepaa.data),
+            }
+        return result
 
     def _snapshot_receitas_ptrf(self):
         result = {}
@@ -102,7 +155,10 @@ class RetificacaoPaaService:
         snapshot = {
             'texto_introducao': self.paa.texto_introducao or '',
             'texto_conclusao': self.paa.texto_conclusao or '',
-            'objetivos': self._snapshot_objetivos(),
+            'atividades_estatutarias_globais': self._snapshot_atividades_estatutarias_globais(),
+            'atividades_estatutarias_paa': self._snapshot_atividades_estatutarias_paa(),
+            'objetivos_globais': self._snapshot_objetivos_globais(),
+            'objetivos_paa': self._snapshot_objetivos_paa(),
             'receitas_ptrf': self._snapshot_receitas_ptrf(),
             'receitas_pdde': self._snapshot_receitas_pdde(),
             'receitas_recurso_proprio': self._snapshot_receitas_recurso_proprio(),
@@ -193,7 +249,17 @@ class RetificacaoPaaService:
 
         alteracoes = self._comparar_campos_texto(historico, snapshot_atual)
 
-        secoes_dict = ('objetivos', 'receitas_ptrf', 'receitas_pdde', 'receitas_outros_recursos', 'prioridades')
+        secoes_dict = (
+            'objetivos_paa',
+            'objetivos_globais',
+            'atividades_estatutarias_paa',
+            'atividades_estatutarias_globais',
+            'receitas_ptrf',
+            'receitas_pdde',
+            'receitas_recurso_proprio',
+            'receitas_outros_recursos',
+            'prioridades',
+        )
         for secao in secoes_dict:
             secao_alteracoes = self._comparar_secao_dict(
                 historico.get(secao, {}),

--- a/sme_ptrf_apps/paa/tests/retificacao/test_retificacao_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/retificacao/test_retificacao_paa_service.py
@@ -19,9 +19,13 @@ class TestGerarSnapshot:
 
         assert 'texto_introducao' in snapshot
         assert 'texto_conclusao' in snapshot
-        assert 'objetivos' in snapshot
+        assert 'objetivos_paa' in snapshot
+        assert 'objetivos_globais' in snapshot
+        assert 'atividades_estatutarias_paa' in snapshot
+        assert 'atividades_estatutarias_globais' in snapshot
         assert 'receitas_ptrf' in snapshot
         assert 'receitas_pdde' in snapshot
+        assert 'receitas_recurso_proprio' in snapshot
         assert 'receitas_outros_recursos' in snapshot
         assert 'prioridades' in snapshot
 
@@ -36,12 +40,12 @@ class TestGerarSnapshot:
     def test_snapshot_captura_objetivo(self, paa_retificacao, objetivo_no_paa):
         snapshot = _service(paa_retificacao).gerar_snapshot()
 
-        assert str(objetivo_no_paa.uuid) in snapshot['objetivos']
-        assert snapshot['objetivos'][str(objetivo_no_paa.uuid)]['nome'] == objetivo_no_paa.nome
+        assert str(objetivo_no_paa.uuid) in snapshot['objetivos_paa']
+        assert snapshot['objetivos_paa'][str(objetivo_no_paa.uuid)]['nome'] == objetivo_no_paa.nome
 
     def test_snapshot_sem_objetivos_retorna_dict_vazio(self, paa_retificacao):
         snapshot = _service(paa_retificacao).gerar_snapshot()
-        assert snapshot['objetivos'] == {}
+        assert snapshot['objetivos_paa'] == {}
 
     def test_snapshot_captura_receita_ptrf(self, paa_retificacao, receita_ptrf_no_paa):
         snapshot = _service(paa_retificacao).gerar_snapshot()
@@ -244,9 +248,9 @@ class TestIdentificarAlteracoes:
 
         resultado = _service(paa_retificacao).identificar_alteracoes()
 
-        assert 'objetivos' in resultado
-        assert str(novo_objetivo.uuid) in resultado['objetivos']
-        assert resultado['objetivos'][str(novo_objetivo.uuid)]['acao'] == 'adicionado'
+        assert 'objetivos_paa' in resultado
+        assert str(novo_objetivo.uuid) in resultado['objetivos_paa']
+        assert resultado['objetivos_paa'][str(novo_objetivo.uuid)]['acao'] == 'adicionado'
 
     def test_detecta_receita_ptrf_adicionada(self, paa_retificacao, replica_paa, receita_ptrf_no_paa):
         resultado = _service(paa_retificacao).identificar_alteracoes()
@@ -265,6 +269,6 @@ class TestIdentificarAlteracoes:
     def test_secoes_inalteradas_nao_aparecem(self, paa_retificacao, replica_paa):
         resultado = _service(paa_retificacao).identificar_alteracoes()
 
-        assert 'objetivos' not in resultado
+        assert 'objetivos_paa' not in resultado
         assert 'receitas_ptrf' not in resultado
         assert 'prioridades' not in resultado

--- a/sme_ptrf_apps/paa/tests/retificacao/test_retificacao_paa_viewset.py
+++ b/sme_ptrf_apps/paa/tests/retificacao/test_retificacao_paa_viewset.py
@@ -9,8 +9,9 @@ pytestmark = pytest.mark.django_db
 
 HISTORICO_VAZIO = {
     'texto_introducao': '', 'texto_conclusao': '',
-    'objetivos': {}, 'receitas_ptrf': {},
-    'receitas_pdde': {}, 'receitas_outros_recursos': {},
+    'objetivos_paa': {}, 'objetivos_globais': {}, 'receitas_ptrf': {},
+    'atividades_estatutarias_paa': {}, 'atividades_estatutarias_globais': {},
+    'receitas_pdde': {}, 'receitas_outros_recursos': {}, 'receitas_recurso_proprio': {},
     'prioridades': {},
 }
 
@@ -257,7 +258,7 @@ class TestPaaRetificacaoAction:
     def test_retorna_200_quando_replica_existe(
         self, jwt_authenticated_client_sme, flag_paa, flag_paa_retificacao, paa_factory, replica_paa_factory
     ):
-        paa = paa_factory()
+        paa = paa_factory(status='EM_RETIFICACAO')
         replica_paa_factory(paa=paa, historico=HISTORICO_VAZIO)
 
         response = jwt_authenticated_client_sme.get(
@@ -269,7 +270,7 @@ class TestPaaRetificacaoAction:
     def test_resposta_contem_campo_alteracoes(
         self, jwt_authenticated_client_sme, flag_paa, flag_paa_retificacao, paa_factory, replica_paa_factory
     ):
-        paa = paa_factory()
+        paa = paa_factory(status='EM_RETIFICACAO')
         replica_paa_factory(paa=paa, historico=HISTORICO_VAZIO)
 
         response = jwt_authenticated_client_sme.get(
@@ -281,7 +282,7 @@ class TestPaaRetificacaoAction:
     def test_alteracoes_e_dict(
         self, jwt_authenticated_client_sme, flag_paa, flag_paa_retificacao, paa_factory, replica_paa_factory
     ):
-        paa = paa_factory()
+        paa = paa_factory(status='EM_RETIFICACAO')
         replica_paa_factory(paa=paa, historico=HISTORICO_VAZIO)
 
         response = jwt_authenticated_client_sme.get(
@@ -293,7 +294,7 @@ class TestPaaRetificacaoAction:
     def test_alteracoes_detecta_mudanca_em_texto(
         self, jwt_authenticated_client_sme, flag_paa, flag_paa_retificacao, paa_factory, replica_paa_factory
     ):
-        paa = paa_factory(texto_introducao='Texto novo.')
+        paa = paa_factory(texto_introducao='Texto novo.', status='EM_RETIFICACAO')
         replica_paa_factory(paa=paa, historico={
             **HISTORICO_VAZIO,
             'texto_introducao': 'Texto original.',
@@ -308,7 +309,7 @@ class TestPaaRetificacaoAction:
     def test_resposta_contem_campos_do_paa(
         self, jwt_authenticated_client_sme, flag_paa, flag_paa_retificacao, paa_factory, replica_paa_factory
     ):
-        paa = paa_factory()
+        paa = paa_factory(status='EM_RETIFICACAO',)
         replica_paa_factory(paa=paa, historico=HISTORICO_VAZIO)
 
         response = jwt_authenticated_client_sme.get(

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
@@ -8,6 +8,7 @@ from sme_ptrf_apps.paa.services.ata_paa_dados_service import (
     formata_data,
     formatar_hora_ata,
     criar_identificacao_associacao_ata,
+    formatar_datas_periodo,
 )
 
 from unittest.mock import patch, MagicMock
@@ -444,3 +445,8 @@ class TestCriarIdentificacaoAssociacaoAta:
         assert 'codigo_eol' in resultado
         assert 'dre' in resultado
         assert len(resultado) == 4
+
+
+def test_formatar_datas_periodo_padrao(periodo_paa_completo):
+    resultado = formatar_datas_periodo(periodo_paa_completo)
+    assert resultado == "1º de janeiro de 2024 a 31 de dezembro de 2024"

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-introducao.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-introducao.html
@@ -15,6 +15,9 @@
       <p class="font-12 texto-justificado pb-2 mb-0">
         Após análise e discussão, foram estabelecidos pelos presentes as seguintes prioridades para os recursos relacionados abaixo:
       </p>
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        Foi apresentado o seguinte cronograma para as atividades de {{dados.dados_texto_da_ata.datas_limite_periodo_por_extenso}}
+      </p>
     </div>
   </article>
 </section>


### PR DESCRIPTION

Esse PR:

- Adiciona validação de status EM_RETIFICACAO ao carregar PAA em retificação
- Separação de Objetivos do PAA com Objetivos Globais
- Adiciona Atividades estatutárias ao snapshot de retificação, separadas por PAA e Globais
- Desabilita Importação de Prioridades na tela de Prioridades quando PAA tem o status 'EM_RETIFICACAO'
- Testes unitários adicionais


História [AB#145888](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145888)
