### PR TITLE
hotfix(146476): posicionamento do texto atividades estatutarias geração ata paa

### DIFF
--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-atividades-estatutarias.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-atividades-estatutarias.html
@@ -2,6 +2,9 @@
 {% if dados.atividades_estatutarias|length > 0 %}
 <section class="row mt-4">
   <article class="col mb-3 border p-0">
+    <p class="font-12 texto-justificado pb-2 mb-0">
+        Foi apresentado o seguinte cronograma para as atividades de {{dados.dados_texto_da_ata.datas_limite_periodo_por_extenso}}
+    </p>
     <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0"><strong>Atividades estatutárias</strong></p>
     <table class="table tabela-atividades tabela-zebra">
       <thead>

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-introducao.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-introducao.html
@@ -14,10 +14,7 @@
       </p>
       <p class="font-12 texto-justificado pb-2 mb-0">
         Após análise e discussão, foram estabelecidos pelos presentes as seguintes prioridades para os recursos relacionados abaixo:
-      </p>
-      <p class="font-12 texto-justificado pb-2 mb-0">
-        Foi apresentado o seguinte cronograma para as atividades de {{dados.dados_texto_da_ata.datas_limite_periodo_por_extenso}}
-      </p>
+      </p>      
     </div>
   </article>
 </section>


### PR DESCRIPTION
# O que este PR faz

- Reposiciona texto cronograma de atividades anterior a atividades estatutarias na geração da ata paa

Referência: [AB#146476](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/146476)