### PR TITLE
hotfix(146593): bloqueia geração da prévia de relação de bens

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.37.0"
+__version__ = "9.37.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/api/views/relacao_bens_viewset.py
+++ b/sme_ptrf_apps/core/api/views/relacao_bens_viewset.py
@@ -87,6 +87,29 @@ class RelacaoBensViewSet(GenericViewSet):
             }
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
+        # Validações extras
+        conta_associacao = ContaAssociacao.objects.filter(uuid=conta_associacao_uuid)\
+            .only('associacao_id')\
+            .first()
+
+        if conta_associacao:
+            prestacao_conta = PrestacaoConta.objects.filter(
+                periodo_id=periodo.id,
+                associacao_id=conta_associacao.associacao_id
+            ).only('id', 'status').first()
+
+            if prestacao_conta:
+                existe_doc_final = RelacaoBens.objects.filter(
+                    prestacao_conta_id=prestacao_conta.id,
+                    versao=RelacaoBens.VERSAO_FINAL
+                ).exists()
+
+                if existe_doc_final and prestacao_conta.status != PrestacaoConta.STATUS_DEVOLVIDA:
+                    return Response({
+                        'erro': 'erro_status_pc',
+                        'mensagem': 'O status da PC não permite a geração da prévia'
+                    }, status=status.HTTP_400_BAD_REQUEST)
+
         gerar_previa_relacao_de_bens_async.delay(periodo_uuid=periodo_uuid,
                                                  conta_associacao_uuid=conta_associacao_uuid,
                                                  data_inicio=data_inicio,

--- a/sme_ptrf_apps/core/tests/tests_relacao_bens/test_api.py
+++ b/sme_ptrf_apps/core/tests/tests_relacao_bens/test_api.py
@@ -93,6 +93,38 @@ def test_previa_data_fim_maior_que_fim_realizacao_retorna_400(jwt_authenticated_
     assert response.json()['erro'] == 'erro_nas_datas'
 
 
+def test_previa_com_documento_final_e_pc_nao_devolvida_retorna_400(
+    jwt_authenticated_client_a,
+    periodo,
+    conta_associacao,
+    prestacao_conta_factory,
+    relacao_bens_factory
+):
+    prestacao_conta = prestacao_conta_factory(
+        periodo=periodo,
+        associacao=conta_associacao.associacao,
+        status='EM_ANALISE'
+    )
+
+    relacao_bens_factory(
+        prestacao_conta=prestacao_conta,
+        versao='FINAL'
+    )
+
+    url = (
+        f"/api/relacao-bens/previa/"
+        f"?conta-associacao={conta_associacao.uuid}"
+        f"&periodo={periodo.uuid}"
+        f"&data_inicio=2019-09-01"
+        f"&data_fim=2019-09-30"
+    )
+
+    response = jwt_authenticated_client_a.get(url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()['erro'] == 'erro_status_pc'
+
+
 def test_previa_parametros_validos_retorna_200(jwt_authenticated_client_a, periodo, conta_associacao):
     url = (
         f"/api/relacao-bens/previa/"


### PR DESCRIPTION
# O que este PR faz
- Esse ajuste adiciona uma validação na geração de prévia de relação bens para garantir consistência do fluxo: agora, quando já existe um documento final de relação de bens, o sistema bloqueia a criação de uma nova prévia caso não haja novos acertos (representados pelo status diferente de DEVOLVIDA). Com isso, evita-se a geração de prévias após a consolidação dos dados, impedindo inconsistências entre documento final e versões prévias.

Referência Azure: [AB#146593](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/146593)