### PR TITLE
feat(143915): Permite processar repasses previstos quando há PC diferente de não apresentada - Hom

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -53,7 +53,8 @@ from sme_ptrf_apps.despesas.fixtures.factories import (
 )
 from sme_ptrf_apps.receitas.fixtures.factories import (
     TipoReceitaFactory,
-    ReceitaFactory
+    ReceitaFactory,
+    RepasseFactory,
 )
 from sme_ptrf_apps.paa.fixtures.factories import (
     PeriodoPaaFactory, PaaFactory, ParametroPaaFactory, ReceitaPrevistaPaaFactory,
@@ -83,7 +84,7 @@ factories_to_register = [
     SolicitacaoAcertoLancamentoFactory, SolicitacaoAcertoDocumentoFactory,
     TipoTransacaoFactory, ProcessoAssociacaoFactory, OcupanteCargoFactory,
     CargoComposicaoFactory, DemonstrativoFinanceiroFactory, ItemResumoPorAcaoFactory,
-    ItemDespesaFactory, ItemCreditoFactory, TipoReceitaFactory, ReceitaFactory, RelacaoBensFactory,
+    ItemDespesaFactory, ItemCreditoFactory, TipoReceitaFactory, ReceitaFactory, RelacaoBensFactory, RepasseFactory,
     RelatorioRelacaoBensFactory, ItemRelatorioRelacaoDeBensFactory,
     SolicitacaoEncerramentoContaAssociacaoFactory, ArquivoDownloadFactory,
     TipoDevolucaoAoTesouroFactory, TipoDocumentoFactory, MotivoPagamentoAntecipadoFactory,

--- a/sme_ptrf_apps/core/tests/tests_api_periodos/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_periodos/conftest.py
@@ -5,6 +5,7 @@ from datetime import date
 UUID_DRE_TESTE = '93759585-8a8b-4c8e-9b1a-9f0c5d2e6b1a'
 UUID_RECURSO_A = '923c9c89-cba9-48f1-8b86-97ae97946356'
 
+
 @pytest.fixture
 def periodo_2020_4(periodo_factory):
     return periodo_factory(
@@ -56,9 +57,11 @@ def periodo_2021_2_aberto(periodo_factory, periodo_2021_1):
         periodo_anterior=periodo_2021_1,
     )
 
+
 @pytest.fixture
 def recurso_a(recurso_factory):
-    return recurso_factory.create(uuid=UUID_RECURSO_A, nome='Recurso A', ativo=True)
+    return recurso_factory.create(uuid=UUID_RECURSO_A, nome='Recurso A', ativo=True, cor='#3982AC')
+
 
 @pytest.fixture
 def periodo_2020_4_com_recurso_a(periodo_factory, recurso_a):
@@ -72,6 +75,7 @@ def periodo_2020_4_com_recurso_a(periodo_factory, recurso_a):
         periodo_anterior=None,
         recurso=recurso_a
     )
+
 
 @pytest.fixture
 def periodo_2021_1_com_recurso_a(periodo_factory, periodo_2020_4_com_recurso_a):
@@ -101,6 +105,7 @@ def periodo_2021_2_com_recurso_legado_ptrf(periodo_factory):
         periodo_anterior=None
     )
 
+
 @pytest.fixture
 def periodo_2021_3_com_recurso_legado_ptrf(periodo_factory, periodo_2021_2_com_recurso_legado_ptrf):
     return periodo_factory(
@@ -113,13 +118,16 @@ def periodo_2021_3_com_recurso_legado_ptrf(periodo_factory, periodo_2021_2_com_r
         periodo_anterior=periodo_2021_2_com_recurso_legado_ptrf
     )
 
+
 @pytest.fixture
 def unidade_dre_teste(dre_factory):
     return dre_factory.create(uuid=UUID_DRE_TESTE, nome="DRE Teste")
 
+
 @pytest.fixture
 def unidade_ue_teste(unidade_factory, unidade_dre_teste):
     return unidade_factory.create(dre=unidade_dre_teste, tipo_unidade='UE', nome="UE Teste")
+
 
 @pytest.fixture
 def associacao_periodo_inicial_teste(associacao_factory, unidade_ue_teste, periodo_2021_2_com_recurso_legado_ptrf):
@@ -129,8 +137,10 @@ def associacao_periodo_inicial_teste(associacao_factory, unidade_ue_teste, perio
         periodo_inicial=periodo_2021_2_com_recurso_legado_ptrf
     )
 
+
 @pytest.fixture
-def periodo_inicial_associacao_teste(periodo_inicial_associacao_factory, periodo_2020_4_com_recurso_a, associacao_periodo_inicial_teste):
+def periodo_inicial_associacao_teste(
+        periodo_inicial_associacao_factory, periodo_2020_4_com_recurso_a, associacao_periodo_inicial_teste):
     return periodo_inicial_associacao_factory(
         periodo_inicial=periodo_2020_4_com_recurso_a,
         associacao=associacao_periodo_inicial_teste,

--- a/sme_ptrf_apps/paa/admin.py
+++ b/sme_ptrf_apps/paa/admin.py
@@ -106,17 +106,11 @@ class PaaAdmin(admin.ModelAdmin):
         AtaPAAInline,
         PrioridadesPaaInline,
     ]
-    actions = ["gerar_documento"]
 
     def status_andamento(self, obj):
         from sme_ptrf_apps.paa.enums import PaaStatusAndamentoEnum
         return PaaStatusAndamentoEnum[obj.get_status_andamento()].value
     status_andamento.short_description = 'Status Andamento'
-
-    def gerar_documento(self, request, queryset):
-        from sme_ptrf_apps.paa.services.documento_paa_pdf_service import gerar_arquivo_documento_paa_pdf
-        for paa in queryset:
-            return gerar_arquivo_documento_paa_pdf(paa)
 
 
 @admin.register(ProgramaPdde)

--- a/sme_ptrf_apps/receitas/fixtures/factories/__init__.py
+++ b/sme_ptrf_apps/receitas/fixtures/factories/__init__.py
@@ -1,2 +1,4 @@
+# flake8: noqa
 from .tipo_receita_factory import *
-from .receita_factory import  *
+from .receita_factory import *
+from .repasse_factory import *

--- a/sme_ptrf_apps/receitas/fixtures/factories/repasse_factory.py
+++ b/sme_ptrf_apps/receitas/fixtures/factories/repasse_factory.py
@@ -1,0 +1,30 @@
+from factory import SubFactory, LazyFunction
+from factory.django import DjangoModelFactory
+from faker import Faker
+from sme_ptrf_apps.receitas.models.repasse import Repasse, StatusRepasse
+from sme_ptrf_apps.core.fixtures.factories.associacao_factory import AssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.conta_associacao_factory import ContaAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.acao_associacao_factory import AcaoAssociacaoFactory
+from sme_ptrf_apps.core.fixtures.factories.periodo_factory import PeriodoFactory
+
+fake = Faker("pt_BR")
+
+
+class RepasseFactory(DjangoModelFactory):
+    class Meta:
+        model = Repasse
+
+    associacao = SubFactory(AssociacaoFactory)
+    conta_associacao = SubFactory(ContaAssociacaoFactory)
+    acao_associacao = SubFactory(AcaoAssociacaoFactory)
+    periodo = SubFactory(PeriodoFactory)
+
+    valor_capital = LazyFunction(lambda: fake.pydecimal(left_digits=6, right_digits=2, positive=True))
+    valor_custeio = LazyFunction(lambda: fake.pydecimal(left_digits=6, right_digits=2, positive=True))
+    valor_livre = LazyFunction(lambda: fake.pydecimal(left_digits=6, right_digits=2, positive=True))
+
+    status = StatusRepasse.PENDENTE.name
+
+    realizado_capital = False
+    realizado_custeio = False
+    realizado_livre = False

--- a/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
@@ -2,17 +2,15 @@ import csv
 import datetime
 import enum
 import logging
-import os
 from uuid import UUID
 
-from sme_ptrf_apps.core.models import Acao, AcaoAssociacao, Associacao, ContaAssociacao, Periodo, TipoConta, \
-    PrestacaoConta
+from sme_ptrf_apps.core.models import Acao, AcaoAssociacao, Associacao, ContaAssociacao, Periodo, TipoConta
 from sme_ptrf_apps.core.models.arquivo import (
     DELIMITADOR_PONTO_VIRGULA,
     DELIMITADOR_VIRGULA,
     ERRO,
-    PROCESSADO_COM_ERRO,
     SUCESSO,
+    PROCESSADO_COM_ERRO,
 )
 
 from ..models import Repasse
@@ -24,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class CargaRepassePrevistoException(Exception):
     pass
+
 
 class StatusRepasse(enum.Enum):
     PENDENTE = 'Previsto'
@@ -40,45 +39,43 @@ def get_valor(val):
 
 
 def get_associacao(eol):
-    if Associacao.objects.filter(unidade__codigo_eol=eol).exists():
-        return Associacao.objects.filter(unidade__codigo_eol=eol).get()
-
-    return None
+    try:
+        return Associacao.objects.get(unidade__codigo_eol=eol)
+    except Associacao.DoesNotExist:
+        return None
 
 
 def get_acao(nome):
-    if Acao.objects.filter(nome=nome).exists():
-        return Acao.objects.filter(nome=nome).get()
-    else:
+    try:
+        return Acao.objects.get(nome=nome)
+    except Acao.DoesNotExist:
         raise CargaRepassePrevistoException(f"Ação {nome} não encontrada.")
 
 
-def verifica_tipo_aplicacao(nome, valor_capital, valor_custeio, valor_livre):
-    if valor_capital:
-        if Acao.objects.filter(nome=nome).filter(aceita_capital=False):
-            raise CargaRepassePrevistoException(f"Ação {nome} não permite capital.")
+def verifica_tipo_aplicacao(acao, valor_capital, valor_custeio, valor_livre):
+    if valor_capital and not acao.aceita_capital:
+        raise CargaRepassePrevistoException(f"Ação {acao.nome} não permite capital.")
 
-    if valor_custeio:
-        if Acao.objects.filter(nome=nome).filter(aceita_custeio=False):
-            raise CargaRepassePrevistoException(f"Ação {nome} não permite custeio.")
+    if valor_custeio and not acao.aceita_custeio:
+        raise CargaRepassePrevistoException(f"Ação {acao.nome} não permite custeio.")
 
-    if valor_livre:
-        if Acao.objects.filter(nome=nome).filter(aceita_livre=False):
-            raise CargaRepassePrevistoException(f"Ação {nome} não permite livre aplicação.")
+    if valor_livre and not acao.aceita_livre:
+        raise CargaRepassePrevistoException(f"Ação {acao.nome} não permite livre aplicação.")
 
 
 def get_tipo_conta(uuid):
-    if TipoConta.objects.filter(uuid=uuid).exists():
-        return TipoConta.objects.filter(uuid=uuid).get()
-    else:
+    try:
+        return TipoConta.objects.get(uuid=uuid)
+    except TipoConta.DoesNotExist:
         raise CargaRepassePrevistoException(f"Tipo de conta de uuid {uuid} não encontrado.")
 
-def get_acao_associacao(acao, associacao):
-    if AcaoAssociacao.objects.filter(acao=acao, associacao=associacao).exists():
-        return AcaoAssociacao.objects.filter(acao=acao, associacao=associacao).get()
 
-    logger.info(f"Ação Associação {acao.nome} não encontrada. Registro será criado.")
-    return AcaoAssociacao.objects.create(acao=acao, associacao=associacao)
+def get_acao_associacao(acao, associacao):
+    try:
+        return AcaoAssociacao.objects.get(acao=acao, associacao=associacao)
+    except AcaoAssociacao.DoesNotExist:
+        logger.info(f"Ação Associação {acao.nome} não encontrada. Registro será criado.")
+        return AcaoAssociacao.objects.create(acao=acao, associacao=associacao)
 
 
 def get_conta_associacao(tipo_conta, associacao, periodo):
@@ -87,7 +84,7 @@ def get_conta_associacao(tipo_conta, associacao, periodo):
     except TipoConta.DoesNotExist:
         logger.error(f"TipoConta com id {tipo_conta} não existe.")
         return None
-    
+
     try:
         conta_associacao = ContaAssociacao.objects.filter(tipo_conta=tipo_conta_obj, associacao=associacao).first()
         if conta_associacao:
@@ -96,15 +93,18 @@ def get_conta_associacao(tipo_conta, associacao, periodo):
         else:
             logger.info("Não encontrou ContaAssociacao.")
             if periodo:
-                return ContaAssociacao.objects.create(tipo_conta=tipo_conta_obj, associacao=associacao, data_inicio=periodo.data_inicio_realizacao_despesas)
+                return ContaAssociacao.objects.create(
+                    tipo_conta=tipo_conta_obj,
+                    associacao=associacao,
+                    data_inicio=periodo.data_inicio_realizacao_despesas)
             else:
                 return ContaAssociacao.objects.create(tipo_conta=tipo_conta_obj, associacao=associacao)
     except Exception as e:
         logger.error(f"Error resgate ContaAssociacao: {e}")
         return None
 
+
 def get_datas_periodo(periodo):
-    periodo = Periodo.objects.filter(uuid=periodo.uuid).get()
     start = periodo.data_inicio_realizacao_despesas
     end = periodo.data_fim_realizacao_despesas
 
@@ -112,9 +112,9 @@ def get_datas_periodo(periodo):
 
 
 def get_periodo(uuid):
-    if Periodo.objects.filter(uuid=uuid).exists():
-        return Periodo.objects.filter(uuid=uuid).get()
-    else:
+    try:
+        return Periodo.objects.get(uuid=uuid)
+    except Periodo.DoesNotExist:
         raise CargaRepassePrevistoException(f"Periodo de uuid {uuid} não encontrado.")
 
 
@@ -132,7 +132,7 @@ def associacao_periodo_tem_pc(associacao, periodo):
     return associacao.prestacoes_de_conta_da_associacao.filter(periodo=periodo).exists()
 
 
-def processa_repasse(reader, tipo_conta_uuid, nome_tipo_conta, arquivo, periodo):
+def processa_repasse(reader, tipo_conta_uuid, instance_tipo_conta, arquivo, periodo):
     __ID_LINHA = 0
     __CODIGO_EOL = 1
     __VR_CAPITAL = 2
@@ -140,95 +140,104 @@ def processa_repasse(reader, tipo_conta_uuid, nome_tipo_conta, arquivo, periodo)
     __VR_LIVRE = 4
     __ACAO = 5
 
-    nome_arquivo = arquivo.identificador
-
-    if PrestacaoConta.objects.filter(periodo=periodo).exists():
-        raise CargaRepassePrevistoException(f"Já existe prestações de conta para o período {periodo.referencia}.")
-
     logs = []
     importados = 0
 
     for index, row in enumerate(reader):
         try:
             if len(row) != 6:
-                msg_erro = f'Linha deveria ter seis colunas: id_linha, eol, capital, custeio, livre e ação.'
-                raise Exception(msg_erro)
+                msg_erro = 'Linha deveria ter seis colunas: id_linha, eol, capital, custeio, livre e ação.'
+                raise CargaRepassePrevistoException(msg_erro)
 
-            if index != 0:
-                logger.info('Linha %s: %s', index, row)
+            if index == 0:
+                continue  # Cabeçalho
 
-                associacao = get_associacao(row[__CODIGO_EOL])
-                if not associacao:
-                    msg_erro = f'Associação com código eol: {row[__CODIGO_EOL]} não encontrado.'
-                    raise Exception(msg_erro)
+            logger.info('Linha %s: %s', index, row)
 
-                valor_capital = get_valor(row[__VR_CAPITAL])
-                valor_custeio = get_valor(row[__VR_CUSTEIO])
-                valor_livre = get_valor(row[__VR_LIVRE])
+            associacao = get_associacao(row[__CODIGO_EOL])
+            if not associacao:
+                msg_erro = f'Associação com código eol: {row[__CODIGO_EOL]} não encontrado.'
+                raise CargaRepassePrevistoException(msg_erro)
 
-                acao = get_acao(row[__ACAO])
+            valor_capital = get_valor(row[__VR_CAPITAL])
+            valor_custeio = get_valor(row[__VR_CUSTEIO])
+            valor_livre = get_valor(row[__VR_LIVRE])
 
-                verifica_tipo_aplicacao(row[__ACAO], valor_capital, valor_custeio, valor_livre)
+            acao = get_acao(row[__ACAO])
 
-                acao_associacao = get_acao_associacao(acao, associacao)
-                conta_associacao = get_conta_associacao(tipo_conta_uuid, associacao, periodo)
-                
-                if not conta_associacao:
-                    msg_erro = f'A associação não possui a conta do tipo {nome_tipo_conta} ativa no período selecionado.'
-                    raise Exception(msg_erro)
+            verifica_tipo_aplicacao(acao, valor_capital, valor_custeio, valor_livre)
 
-                id_linha = get_id_linha(row[__ID_LINHA])
+            acao_associacao = get_acao_associacao(acao, associacao)
+            conta_associacao = get_conta_associacao(tipo_conta_uuid, associacao, periodo)
 
-                repasse_anterior = Repasse.objects.filter(
+            if not conta_associacao:
+                msg_erro = (
+                    f'A associação não possui a conta do tipo {instance_tipo_conta} ativa no período selecionado.')
+                raise CargaRepassePrevistoException(msg_erro)
+
+            id_linha = get_id_linha(row[__ID_LINHA])
+
+            repasse_anterior = Repasse.objects.filter(
+                carga_origem=arquivo,
+                carga_origem_linha_id=id_linha,
+            ).first()
+
+            if repasse_anterior and repasse_anterior.valor_realizado:
+                msg_erro = (
+                    f'O repasse da linha de id {id_linha} já foi importado anteriormente e já teve '
+                    'realização. Linha ignorada.')
+                raise CargaRepassePrevistoException(msg_erro)
+
+            if repasse_anterior and not repasse_anterior.valor_realizado:
+                repasse_anterior.delete()
+                logger.info(f'O repasse da linha de id {id_linha} já foi importado anteriormente. Anterior apagado.'
+                            f'{id_linha if id_linha else ""}')
+
+            if associacao.encerrada:
+                msg_erro = (
+                    f'A associação foi encerrada em {associacao.data_de_encerramento.strftime("%d/%m/%Y")}. '
+                    f'Linha ID:{index}')
+                raise CargaRepassePrevistoException(msg_erro)
+
+            if conta_associacao and conta_associacao.data_inicio:
+                start, _ = get_datas_periodo(periodo)
+
+                if start < conta_associacao.data_inicio:
+                    msg_erro = "O período informado de repasse é anterior ao período de criação da conta."
+                    raise CargaRepassePrevistoException(msg_erro)
+
+                if hasattr(conta_associacao, 'solicitacao_encerramento') \
+                    and conta_associacao.solicitacao_encerramento \
+                    and conta_associacao.solicitacao_encerramento.aprovada:  # noqa
+                    msg_erro = "A conta possui pedido de encerramento aprovado pela DRE."
+                    raise CargaRepassePrevistoException(msg_erro)
+
+            if associacao_periodo_tem_pc(associacao, periodo):
+                msg_erro = (
+                    f"A associação {associacao.unidade.codigo_eol} já possui PC gerada no "
+                    f"período {periodo.referencia}.")
+                raise CargaRepassePrevistoException(msg_erro)
+
+            if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
+                Repasse.objects.create(
+                    associacao=associacao,
+                    valor_capital=valor_capital,
+                    valor_custeio=valor_custeio,
+                    valor_livre=valor_livre,
+                    conta_associacao=conta_associacao,
+                    acao_associacao=acao_associacao,
+                    periodo=periodo,
+                    status=StatusRepasse.PENDENTE.name,
                     carga_origem=arquivo,
                     carga_origem_linha_id=id_linha,
-                ).first()
-
-                if repasse_anterior and repasse_anterior.valor_realizado:
-                    msg_erro = f'O repasse da linha de id {id_linha} já foi importado anteriormente e já teve realização. Linha ignorada.'
-                    raise Exception(msg_erro)
-
-                if repasse_anterior and not repasse_anterior.valor_realizado:
-                    repasse_anterior.delete()
-                    logger.info(f'O repasse da linha de id {id_linha} já foi importado anteriormente. Anterior apagado.'
-                                f'{id_linha if id_linha else ""}')
-
-                if associacao.encerrada:
-                    msg_erro = f'A associação foi encerrada em {associacao.data_de_encerramento.strftime("%d/%m/%Y")}. Linha ID:{index}'
-                    raise Exception(msg_erro)
-
-                if conta_associacao and conta_associacao.data_inicio:
-                    start, end = get_datas_periodo(periodo)
-                    start_converted_date = start
-                    if start_converted_date < conta_associacao.data_inicio:
-                        msg_erro = f"O período informado de repasse é anterior ao período de criação da conta."
-                        raise Exception(msg_erro)
-
-                    if hasattr(conta_associacao, 'solicitacao_encerramento') and conta_associacao.solicitacao_encerramento.aprovada:
-                        msg_erro = "A conta possui pedido de encerramento aprovado pela DRE."
-                        raise Exception(msg_erro)
-
-                if associacao_periodo_tem_pc(associacao, periodo):
-                    msg_erro = f"A associação {associacao.unidade.codigo_eol} já possui PC gerada no período {periodo.referencia}."
-                    raise Exception(msg_erro)
-
-                if valor_capital > 0 or valor_custeio > 0 or valor_livre > 0:
-                    Repasse.objects.create(
-                        associacao=associacao,
-                        valor_capital=valor_capital,
-                        valor_custeio=valor_custeio,
-                        valor_livre=valor_livre,
-                        conta_associacao=conta_associacao,
-                        acao_associacao=acao_associacao,
-                        periodo=periodo,
-                        status=StatusRepasse.PENDENTE.name,
-                        carga_origem=arquivo,
-                        carga_origem_linha_id=id_linha,
-                    )
-                    logger.info(f"Repasse referente a linha de id {id_linha} criado. Capital={valor_capital} Custeio={valor_custeio} RLA={valor_livre}")
-                    importados += 1
-                else:
-                    logger.info(f"A linha de id {id_linha} está sem valores. Nenhum repasse criado.")
+                )
+                logger.info(
+                    (
+                        f"Repasse referente a linha de id {id_linha} criado. Capital={valor_capital} "
+                        f"Custeio={valor_custeio} RLA={valor_livre}"))
+                importados += 1
+            else:
+                logger.info(f"A linha de id {id_linha} está sem valores. Nenhum repasse criado.")
 
         except Exception as e:
             msg_erro = f"Erro na linha {index}: {str(e)}"
@@ -259,14 +268,14 @@ def carrega_repasses_previstos(arquivo):
             tipo_conta = get_tipo_conta(arquivo.tipo_de_conta.uuid)
             logger.info(f"Tipo de conta do arquivo: {tipo_conta}.")
         else:
-            msg_erro = f"É necessário fornecer um tipo de conta válido."
+            msg_erro = "É necessário fornecer um tipo de conta válido."
             raise Exception(msg_erro)
-        
+
         if arquivo.periodo:
             periodo = get_periodo(arquivo.periodo.uuid)
             logger.info(f"Periodo do arquivo: {periodo}.")
         else:
-            msg_erro = f"É necessário fornecer um periodo válido."
+            msg_erro = "É necessário fornecer um periodo válido."
             raise Exception(msg_erro)
 
         with open(arquivo.conteudo.path, 'r', encoding="utf-8") as f:
@@ -274,7 +283,9 @@ def carrega_repasses_previstos(arquivo):
             f.seek(0)
 
             if __DELIMITADORES[sniffer.delimiter] != arquivo.tipo_delimitador:
-                msg_erro = f"Formato definido ({arquivo.tipo_delimitador}) é diferente do formato do arquivo csv ({__DELIMITADORES[sniffer.delimiter]})"
+                msg_erro = (
+                    f"Formato definido ({arquivo.tipo_delimitador}) é diferente do formato do "
+                    f"arquivo csv ({__DELIMITADORES[sniffer.delimiter]})")
                 logger.info(msg_erro)
                 raise Exception(msg_erro)
 

--- a/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
+++ b/sme_ptrf_apps/receitas/services/carga_repasses_previstos.py
@@ -214,7 +214,8 @@ def processa_repasse(reader, tipo_conta_uuid, instance_tipo_conta, arquivo, peri
 
             if associacao_periodo_tem_pc(associacao, periodo):
                 msg_erro = (
-                    f"A associação {associacao.unidade.codigo_eol} já possui PC gerada no "
+                    "Não foi possível realizar a carga. "
+                    f"Unidade {associacao.unidade.codigo_eol} já possui PC gerada no "
                     f"período {periodo.referencia}.")
                 raise CargaRepassePrevistoException(msg_erro)
 

--- a/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_previstos.py
+++ b/sme_ptrf_apps/receitas/tests/test_repasse/test_carga_repasse_previstos.py
@@ -1,10 +1,27 @@
 import pytest
 import datetime
+from unittest.mock import patch
+from uuid import uuid4
+from decimal import Decimal
 
+from sme_ptrf_apps.receitas.services.carga_repasses_previstos import (
+    CargaRepassePrevistoException,
+    associacao_periodo_tem_pc,
+    carrega_repasses_previstos,
+    get_acao,
+    get_acao_associacao,
+    get_conta_associacao,
+    get_datas_periodo,
+    get_id_linha,
+    get_periodo,
+    get_tipo_conta,
+    get_valor,
+    processa_repasse,
+    verifica_tipo_aplicacao,
+)
+from sme_ptrf_apps.receitas.models import Repasse
 from sme_ptrf_apps.core.models import ContaAssociacao
-from sme_ptrf_apps.receitas.services.carga_repasses_previstos import carrega_repasses_previstos
 from django.core.files.uploadedfile import SimpleUploadedFile
-from model_bakery import baker
 
 from sme_ptrf_apps.core.models.arquivo import (
     DELIMITADOR_PONTO_VIRGULA,
@@ -21,36 +38,49 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def arquivo():
     return SimpleUploadedFile(
-        f'2020_01_01_a_2020_06_30_cheque.csv',
+        '2020_01_01_a_2020_06_30_cheque.csv',
         bytes(
-            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,93238,99000.98,99000.98,,Role Cultural""",
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,93238,99000.98,99000.98,,Role Cultural"
+            ),
             encoding="utf-8"))
 
 
 @pytest.fixture
 def arquivo_deve_criar_conta():
     return SimpleUploadedFile(
-        f'2023_01_01_a_2023_06_30_cartao.csv',
+        '2023_01_01_a_2023_06_30_cartao.csv',
         bytes(
-            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,123456,99000.98,99000.98,,PTRF Básico""",
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,123456,99000.98,99000.98,,PTRF Básico"
+            ),
             encoding="utf-8"))
 
 
 @pytest.fixture
 def arquivo_processado():
     return SimpleUploadedFile(
-        f'carga_repasse_cheque.csv',
+        'carga_repasse_cheque.csv',
         bytes(
-            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,123456,99000.98,99000.98,,Role Cultural\n20,93238,99000.98,99000.98,,Role Cultural""",
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,123456,99000.98,99000.98,,Role Cultural\n"
+                "20,93238,99000.98,99000.98,,Role Cultural"
+            ),
             encoding="utf-8"))
 
 
 @pytest.fixture
 def arquivo_associacao_encerrada():
     return SimpleUploadedFile(
-        f'carga_repasse_cheque_2.csv',
+        'carga_repasse_cheque_2.csv',
         bytes(
-            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,999999,99000.98,99000.98,,PTRF Básico""",
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,999999,99000.98,99000.98,,PTRF Básico"
+            ),
             encoding="utf-8"))
 
 
@@ -75,9 +105,8 @@ def tipo_conta(tipo_conta_factory):
 
 
 @pytest.fixture
-def arquivo_carga(arquivo, tipo_conta, periodo_teste_2):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga(arquivo, tipo_conta, periodo_teste_2, arquivo_factory):
+    return arquivo_factory(
         identificador='2020_01_01_a_2020_06_30_cheque',
         conteudo=arquivo,
         tipo_carga=CARGA_REPASSE_PREVISTO,
@@ -97,7 +126,7 @@ def periodo_2024(periodo_factory):
 
 
 @pytest.fixture
-def periodo_teste_2(periodo_factory):
+def periodo_teste_2023(periodo_factory):
     return periodo_factory(
         referencia='2023.1',
         data_inicio_realizacao_despesas=datetime.date(2023, 1, 1),
@@ -106,15 +135,15 @@ def periodo_teste_2(periodo_factory):
 
 
 @pytest.fixture
-def arquivo_carga_cartao_deve_criar_conta(arquivo_deve_criar_conta, tipo_conta, periodo_teste_2):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga_cartao_deve_criar_conta(arquivo_deve_criar_conta,
+                                          tipo_conta, periodo_teste_2023, arquivo_factory):
+    return arquivo_factory(
         identificador='2023_01_01_a_2023_06_30_cartao',
         conteudo=arquivo_deve_criar_conta,
         tipo_carga=CARGA_REPASSE_PREVISTO,
         tipo_delimitador=DELIMITADOR_VIRGULA,
         tipo_de_conta=tipo_conta,
-        periodo=periodo_teste_2
+        periodo=periodo_teste_2023
     )
 
 
@@ -128,9 +157,8 @@ def periodo_teste_4(periodo_factory):
 
 
 @pytest.fixture
-def arquivo_carga_virgula(arquivo, tipo_conta, periodo_teste_4):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga_virgula(arquivo, tipo_conta, periodo_teste_4, arquivo_factory):
+    return arquivo_factory(
         identificador='2020_01_01_a_2020_06_30_cheque',
         conteudo=arquivo,
         tipo_carga=CARGA_REPASSE_PREVISTO,
@@ -150,9 +178,8 @@ def periodo_teste_5(periodo_factory):
 
 
 @pytest.fixture
-def arquivo_carga_virgula_processado(arquivo_processado, periodo_teste_5, tipo_conta):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga_virgula_processado(arquivo_processado, periodo_teste_5, tipo_conta, arquivo_factory):
+    return arquivo_factory(
         identificador='2019_01_01_a_2019_11_30_cheque',
         conteudo=arquivo_processado,
         tipo_carga=CARGA_REPASSE_PREVISTO,
@@ -172,9 +199,9 @@ def periodo_teste_1(periodo_factory):
 
 
 @pytest.fixture
-def arquivo_carga_virgula_processado_com_associacao_encerrada(arquivo_associacao_encerrada, periodo_teste_1, tipo_conta):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga_virgula_processado_com_associacao_encerrada(
+        arquivo_associacao_encerrada, periodo_teste_1, tipo_conta, arquivo_factory):
+    return arquivo_factory(
         identificador='2019_01_01_a_2019_11_30_cheque_2',
         conteudo=arquivo_associacao_encerrada,
         tipo_carga=CARGA_REPASSE_PREVISTO,
@@ -186,14 +213,17 @@ def arquivo_carga_virgula_processado_com_associacao_encerrada(arquivo_associacao
 
 def test_carga_com_erro_formatacao(arquivo_carga, tipo_conta_cheque):
     carrega_repasses_previstos(arquivo_carga)
-    assert arquivo_carga.log == 'Erro ao processar repasses previstos: Formato definido (DELIMITADOR_PONTO_VIRGULA) é diferente do formato do arquivo csv (DELIMITADOR_VIRGULA)'
+    assert arquivo_carga.log == (
+        'Erro ao processar repasses previstos: Formato definido '
+        '(DELIMITADOR_PONTO_VIRGULA) é diferente do formato do arquivo csv (DELIMITADOR_VIRGULA)')
     assert arquivo_carga.status == ERRO
 
 
 def test_carga_com_erro(arquivo_carga_virgula, tipo_conta_cheque):
     carrega_repasses_previstos(arquivo_carga_virgula)
-    msg = """Erro na linha 1: Associação com código eol: 93238 não encontrado.
-Foram criados 0 repasses. Erro na importação de 1 repasse(s)."""
+    msg = (
+        "Erro na linha 1: Associação com código eol: 93238 não encontrado.\n"
+        "Foram criados 0 repasses. Erro na importação de 1 repasse(s).")
     assert arquivo_carga_virgula.log == msg
     assert arquivo_carga_virgula.status == ERRO
 
@@ -211,9 +241,8 @@ def acao_ptrf_basico(acao_factory):
 
 
 @pytest.fixture
-def conta_associacao_cartao_teste_data_inicio(associacao, tipo_conta):
-    return baker.make(
-        'ContaAssociacao',
+def conta_associacao_cartao_teste_data_inicio(associacao, tipo_conta, conta_associacao_factory):
+    return conta_associacao_factory(
         associacao=associacao,
         tipo_conta=tipo_conta,
         data_inicio=datetime.date(2024, 1, 1)
@@ -223,9 +252,12 @@ def conta_associacao_cartao_teste_data_inicio(associacao, tipo_conta):
 def test_carga_processado_com_erro(arquivo_carga_virgula_processado, periodo_teste_1, associacao, tipo_receita_repasse,
                                    tipo_conta_cheque, acao_role_cultural, acao_role_cultural_teste):
     carrega_repasses_previstos(arquivo_carga_virgula_processado)
-    msg = """Erro na linha 1: Ação Role Cultural não permite capital.\nErro na linha 2: Associação com código eol: 93238 não encontrado.
-Foram criados 0 repasses. Erro na importação de 2 repasse(s)."""
-    assert arquivo_carga_virgula_processado.log == msg
+    msg = (
+        "Erro na linha 1: Ação Role Cultural não permite capital.\n"
+        "Erro na linha 2: Associação com código eol: 93238 não encontrado.\n"
+        "Foram criados 0 repasses. Erro na importação de 2 repasse(s)."
+    )
+    assert arquivo_carga_virgula_processado.log == msg, arquivo_carga_virgula_processado.log
     assert arquivo_carga_virgula_processado.status == ERRO
 
 
@@ -274,8 +306,12 @@ Foram criados 0 repasses. Erro na importação de 1 repasse(s)."""
     assert arquivo_carga_cartao_deve_criar_conta.status == ERRO
 
 
-def test_carga_em_conta_encerrada_deve_gerar_erro(periodos_de_2019_ate_2023, acao_factory, acao_associacao_factory, associacao_factory, arquivo_factory, unidade_factory, tipo_conta_factory, conta_associacao_factory, solicitacao_encerramento_conta_associacao_factory, periodo_factory):
-    from sme_ptrf_apps.core.models.solicitacao_encerramento_conta_associacao import SolicitacaoEncerramentoContaAssociacao
+def test_carga_em_conta_encerrada_deve_gerar_erro(
+        periodos_de_2019_ate_2023, acao_factory, acao_associacao_factory, associacao_factory,
+        arquivo_factory, unidade_factory, tipo_conta_factory, conta_associacao_factory,
+        solicitacao_encerramento_conta_associacao_factory, periodo_factory):
+    from sme_ptrf_apps.core.models.solicitacao_encerramento_conta_associacao import (
+        SolicitacaoEncerramentoContaAssociacao)
 
     unidade = unidade_factory(codigo_eol='666666')
     associacao = associacao_factory(unidade=unidade)
@@ -288,15 +324,23 @@ def test_carga_em_conta_encerrada_deve_gerar_erro(periodos_de_2019_ate_2023, aca
     periodo = periodo_factory.create(data_inicio_realizacao_despesas=datetime.date(
         2023, 1, 1), data_fim_realizacao_despesas=datetime.date(2023, 5, 30))
 
-    conteudo_arquivo = SimpleUploadedFile(f'2020_01_01_a_2020_06_30_cheque.csv',
-                                          bytes(f"""Linha_ID,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,666666,200,200,,Acao teste""", encoding="utf-8"))
+    conteudo_arquivo = SimpleUploadedFile(
+        '2020_01_01_a_2020_06_30_cheque.csv',
+        bytes(
+            (
+                "Linha_ID,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,666666,200,200,,Acao teste"
+            ), encoding="utf-8"))
 
     arquivo = arquivo_factory.create(identificador='2020_01_01_a_2020_06_30_cheque', conteudo=conteudo_arquivo,
-                                     tipo_carga=CARGA_REPASSE_PREVISTO, tipo_delimitador=DELIMITADOR_VIRGULA, tipo_de_conta=tipo_conta, periodo=periodo)
+                                     tipo_carga=CARGA_REPASSE_PREVISTO, tipo_delimitador=DELIMITADOR_VIRGULA,
+                                     tipo_de_conta=tipo_conta, periodo=periodo)
 
     carrega_repasses_previstos(arquivo)
 
-    msg = """Erro na linha 1: A conta possui pedido de encerramento aprovado pela DRE.\nForam criados 0 repasses. Erro na importação de 1 repasse(s)."""
+    msg = (
+        "Erro na linha 1: A conta possui pedido de encerramento aprovado pela DRE.\n"
+        "Foram criados 0 repasses. Erro na importação de 1 repasse(s).")
 
     assert arquivo.log == msg
     assert arquivo.status == ERRO
@@ -305,16 +349,19 @@ def test_carga_em_conta_encerrada_deve_gerar_erro(periodos_de_2019_ate_2023, aca
 @pytest.fixture
 def arquivo_associacao_periodo_com_pc():
     return SimpleUploadedFile(
-        f'carga_repasse_cheque_2.csv',
+        'carga_repasse_cheque_2.csv',
         bytes(
-            f"""Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n10,123456,99000.98,99000.98,,PTRF Básico""",
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "10,123456,99000.98,99000.98,,PTRF Básico"
+            ),
             encoding="utf-8"))
 
 
 @pytest.fixture
-def arquivo_carga_associacao_periodo_com_pc(arquivo_associacao_periodo_com_pc, tipo_conta, periodo_2024):
-    return baker.make(
-        'Arquivo',
+def arquivo_carga_associacao_periodo_com_pc(
+        arquivo_associacao_periodo_com_pc, tipo_conta, periodo_2024, arquivo_factory):
+    return arquivo_factory(
         identificador='cheque_2',
         conteudo=arquivo_associacao_periodo_com_pc,
         tipo_carga=CARGA_REPASSE_PREVISTO,
@@ -334,9 +381,8 @@ def periodo_pc(periodo_factory):
 
 
 @pytest.fixture
-def pc_teste(periodo_2024, associacao):
-    return baker.make(
-        'PrestacaoConta',
+def pc_teste(periodo_2024, associacao, prestacao_conta_factory):
+    return prestacao_conta_factory(
         periodo=periodo_2024,
         associacao=associacao,
         data_recebimento=datetime.date(2020, 1, 1),
@@ -354,6 +400,619 @@ def test_carga_processado_com_erro_associacao_periodo_com_pc(
     acao_ptrf_basico
 ):
     carrega_repasses_previstos(arquivo_carga_associacao_periodo_com_pc)
-    msg = "Erro ao processar repasses previstos: Já existe prestações de conta para o período 2024.1."
-    assert arquivo_carga_associacao_periodo_com_pc.log == msg
-    assert arquivo_carga_associacao_periodo_com_pc.status == ERRO
+    assert "já possui PC gerada" in arquivo_carga_associacao_periodo_com_pc.log
+    assert arquivo_carga_associacao_periodo_com_pc.status == ERRO, arquivo_carga_associacao_periodo_com_pc.status
+
+
+class TestGetValor:
+    def test_retorna_zero_para_valor_vazio(self):
+        assert get_valor('') == 0
+
+    def test_retorna_zero_para_none(self):
+        assert get_valor(None) == 0
+
+    def test_converte_string_com_ponto(self):
+        assert get_valor('100.50') == Decimal('100.50')
+
+    def test_converte_string_com_virgula(self):
+        assert get_valor('100,50') == Decimal('100.50')
+
+    def test_converte_inteiro(self):
+        assert get_valor('99000') == Decimal('99000.0')
+
+    def test_levanta_value_error_para_string_invalida(self):
+        with pytest.raises(ValueError, match="Não foi possível converter"):
+            get_valor('abc')
+
+
+class TestGetIdLinha:
+    def test_retorna_zero_para_string_vazia(self):
+        assert get_id_linha('') == 0
+
+    def test_retorna_zero_para_somente_espacos(self):
+        assert get_id_linha('   ') == 0
+
+    def test_converte_string_numerica(self):
+        assert get_id_linha('10') == 10
+
+    def test_converte_com_espacos(self):
+        assert get_id_linha('  5  ') == 5
+
+    def test_levanta_value_error_para_string_invalida(self):
+        with pytest.raises(ValueError, match="Não foi possível converter"):
+            get_id_linha('abc')
+
+
+class TestGetAcao:
+    def test_retorna_acao_existente(self, acao):
+        resultado = get_acao(acao.nome)
+        assert resultado == acao
+
+    def test_levanta_excecao_para_acao_inexistente(self):
+        with pytest.raises(CargaRepassePrevistoException, match="não encontrada"):
+            get_acao('Ação Inexistente')
+
+
+class TestVerificaTipoAplicacao:
+    @pytest.fixture
+    def acao_sem_capital(self, acao_factory):
+        return acao_factory(nome='Acao Sem Capital', aceita_capital=False, aceita_custeio=True, aceita_livre=True)
+
+    @pytest.fixture
+    def acao_sem_custeio(self, acao_factory):
+        return acao_factory(nome='Acao Sem Custeio', aceita_capital=True, aceita_custeio=False, aceita_livre=True)
+
+    @pytest.fixture
+    def acao_sem_livre(self, acao_factory):
+        return acao_factory(nome='Acao Sem Livre', aceita_capital=True, aceita_custeio=True, aceita_livre=False)
+
+    @pytest.fixture
+    def acao_completa(self, acao_factory):
+        return acao_factory(nome='Acao Completa', aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+
+    def test_levanta_excecao_quando_capital_nao_permitido(self, acao_sem_capital):
+        with pytest.raises(CargaRepassePrevistoException, match="não permite capital"):
+            verifica_tipo_aplicacao(acao_sem_capital, 100.0, 0, 0)
+
+    def test_levanta_excecao_quando_custeio_nao_permitido(self, acao_sem_custeio):
+        with pytest.raises(CargaRepassePrevistoException, match="não permite custeio"):
+            verifica_tipo_aplicacao(acao_sem_custeio, 0, 100.0, 0)
+
+    def test_levanta_excecao_quando_livre_nao_permitido(self, acao_sem_livre):
+        with pytest.raises(CargaRepassePrevistoException, match="não permite livre aplicação"):
+            verifica_tipo_aplicacao(acao_sem_livre, 0, 0, 100.0)
+
+    def test_sem_excecao_quando_valores_zero(self, acao_sem_capital):
+        verifica_tipo_aplicacao(acao_sem_capital, 0, 0, 0)
+
+    def test_sem_excecao_para_acao_completa(self, acao_completa):
+        verifica_tipo_aplicacao(acao_completa, 100.0, 100.0, 100.0)
+
+
+class TestGetTipoConta:
+    def test_retorna_tipo_conta_existente(self, tipo_conta):
+        resultado = get_tipo_conta(tipo_conta.uuid)
+        assert resultado == tipo_conta
+
+    def test_levanta_excecao_para_uuid_inexistente(self):
+        with pytest.raises(CargaRepassePrevistoException, match="não encontrado"):
+            get_tipo_conta(uuid4())
+
+
+class TestGetPeriodo:
+    def test_retorna_periodo_existente(self, periodo):
+        resultado = get_periodo(periodo.uuid)
+        assert resultado == periodo
+
+    def test_levanta_excecao_para_uuid_inexistente(self):
+        with pytest.raises(CargaRepassePrevistoException, match="não encontrado"):
+            get_periodo(uuid4())
+
+
+class TestGetAcaoAssociacao:
+    def test_retorna_acao_associacao_existente(self, acao_associacao, acao, associacao):
+        resultado = get_acao_associacao(acao, associacao)
+        assert resultado == acao_associacao
+
+    def test_cria_acao_associacao_quando_nao_existe(self, acao_factory, associacao):
+        from sme_ptrf_apps.core.models import AcaoAssociacao
+        nova_acao = acao_factory(nome='Nova Acao Teste')
+        assert not AcaoAssociacao.objects.filter(acao=nova_acao, associacao=associacao).exists()
+
+        resultado = get_acao_associacao(nova_acao, associacao)
+
+        assert resultado is not None
+        assert AcaoAssociacao.objects.filter(acao=nova_acao, associacao=associacao).exists()
+
+
+class TestGetContaAssociacao:
+    def test_retorna_conta_associacao_existente(self, conta_associacao, tipo_conta, associacao):
+        resultado = get_conta_associacao(tipo_conta, associacao, None)
+        assert resultado == conta_associacao
+
+    def test_cria_conta_associacao_com_data_inicio_quando_tem_periodo(self, tipo_conta, associacao, periodo):
+        from sme_ptrf_apps.core.models import ContaAssociacao
+        ContaAssociacao.objects.filter(tipo_conta=tipo_conta, associacao=associacao).delete()
+
+        resultado = get_conta_associacao(tipo_conta, associacao, periodo)
+
+        assert resultado is not None
+        assert resultado.data_inicio == periodo.data_inicio_realizacao_despesas
+
+    def test_cria_conta_associacao_sem_data_inicio_quando_sem_periodo(self, tipo_conta, associacao):
+        from sme_ptrf_apps.core.models import ContaAssociacao
+        ContaAssociacao.objects.filter(tipo_conta=tipo_conta, associacao=associacao).delete()
+
+        resultado = get_conta_associacao(tipo_conta, associacao, None)
+
+        assert resultado is not None
+        assert resultado.data_inicio is None
+
+    def test_retorna_none_para_tipo_conta_uuid_inexistente(self, associacao):
+        resultado = get_conta_associacao(uuid4(), associacao, None)
+        assert resultado is None
+
+
+class TestGetDatasPeriodo:
+    def test_retorna_datas_inicio_e_fim(self, periodo):
+        start, end = get_datas_periodo(periodo)
+        assert start == periodo.data_inicio_realizacao_despesas
+        assert end == periodo.data_fim_realizacao_despesas
+
+
+class TestAssociacaoPeriodoTemPc:
+    def test_retorna_false_quando_nao_tem_pc(self, associacao, periodo):
+        resultado = associacao_periodo_tem_pc(associacao, periodo)
+        assert resultado is False
+
+    def test_retorna_true_quando_tem_pc(self, associacao, periodo, prestacao_conta_factory):
+        prestacao_conta_factory(associacao=associacao, periodo=periodo, status='APROVADA')
+        resultado = associacao_periodo_tem_pc(associacao, periodo)
+        assert resultado is True
+
+
+# ---------------------------------------------------------------------------
+# processa_repasse
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def arquivo_mock(arquivo_factory):
+    return arquivo_factory(
+        tipo_carga=CARGA_REPASSE_PREVISTO,
+        tipo_delimitador=DELIMITADOR_VIRGULA,
+    )
+
+
+@pytest.fixture
+def periodo_processa(periodo_factory):
+    return periodo_factory(
+        referencia='2023.1',
+        data_inicio_realizacao_despesas=datetime.date(2023, 1, 1),
+        data_fim_realizacao_despesas=datetime.date(2023, 6, 30),
+    )
+
+
+@pytest.fixture
+def tipo_conta_processa(tipo_conta_factory):
+    return tipo_conta_factory(nome='Cheque Processa')
+
+
+@pytest.fixture
+def acao_processa(acao_factory):
+    return acao_factory(nome='Acao Processa', aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+
+
+@pytest.fixture
+def unidade_processa(dre, unidade_factory):
+    return unidade_factory(codigo_eol='654321', dre=dre)
+
+
+@pytest.fixture
+def associacao_processa(unidade_processa, periodo_factory, associacao_factory):
+    periodo_ini = periodo_factory(
+        referencia='2022.2',
+        data_inicio_realizacao_despesas=datetime.date(2022, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2022, 12, 31),
+    )
+    return associacao_factory(
+        nome='Associacao Processa',
+        cnpj='11.222.333/0001-44',
+        unidade=unidade_processa,
+        periodo_inicial=periodo_ini,
+    )
+
+
+@pytest.fixture
+def acao_associacao_processa(associacao_processa, acao_processa, acao_associacao_factory):
+    return acao_associacao_factory(associacao=associacao_processa, acao=acao_processa)
+
+
+@pytest.fixture
+def conta_associacao_processa(associacao_processa, tipo_conta_processa, conta_associacao_factory):
+    return conta_associacao_factory(
+        associacao=associacao_processa,
+        tipo_conta=tipo_conta_processa,
+        data_inicio=datetime.datetime(2000, 1, 1))
+
+
+class TestProcessaRepasse:
+    def _make_reader(self, rows):
+        return [['Id_Linha', 'Código eol', 'Valor capital', 'Valor custeio', 'Valor livre aplicacao', 'Acao']] + rows
+
+    def test_cria_repasse_com_sucesso(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+    ):
+        reader = self._make_reader([
+            ['1', '654321', '100', '200', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert Repasse.objects.filter(associacao=associacao_processa, periodo=periodo_processa).exists()
+        assert arquivo_mock.status == SUCESSO
+
+    def test_status_erro_quando_nenhum_repasse_criado(self, arquivo_mock, periodo_processa, tipo_conta_processa):
+        reader = self._make_reader([
+            ['1', '000000', '100', '200', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert arquivo_mock.status == ERRO
+
+    def test_status_processado_com_erro_quando_parcialmente_importado(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+    ):
+        reader = self._make_reader([
+            ['1', '654321', '100', '200', '0', 'Acao Processa'],
+            ['2', '000000', '100', '200', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert arquivo_mock.status == PROCESSADO_COM_ERRO
+
+    def test_erro_linha_com_menos_de_seis_colunas(self, arquivo_mock, periodo_processa, tipo_conta_processa):
+        reader = [['Id', 'EOL', 'Capital']]
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert 'seis colunas' in arquivo_mock.log
+
+    def test_erro_quando_associacao_nao_encontrada(self, arquivo_mock, periodo_processa, tipo_conta_processa):
+        reader = self._make_reader([
+            ['1', '000000', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert 'não encontrado' in arquivo_mock.log
+
+    def test_erro_quando_conta_associacao_nao_disponivel(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        acao_processa,
+        associacao_processa,
+        acao_associacao_processa,
+        tipo_conta_factory
+    ):
+        tipo_conta_sem_conta = tipo_conta_factory(nome='TipoConta Sem Conta')
+        reader = self._make_reader([
+            ['1', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        with patch('sme_ptrf_apps.receitas.services.carga_repasses_previstos.get_conta_associacao', return_value=None):
+            processa_repasse(
+                reader, tipo_conta_sem_conta.uuid, tipo_conta_sem_conta, arquivo_mock, periodo_processa
+            )
+
+        assert 'não possui a conta' in arquivo_mock.log
+
+    def test_ignora_linha_com_todos_valores_zero(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+    ):
+        reader = self._make_reader([
+            ['1', '654321', '0', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert not Repasse.objects.filter(associacao=associacao_processa, periodo=periodo_processa).exists()
+        assert arquivo_mock.status == ERRO
+
+    def test_apaga_repasse_anterior_sem_realizacao_e_recria(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+        repasse_factory
+    ):
+        repasse_existente = repasse_factory(
+            associacao=associacao_processa,
+            periodo=periodo_processa,
+            carga_origem=arquivo_mock,
+            carga_origem_linha_id=1,
+            realizado_capital=False,
+            realizado_custeio=False,
+            realizado_livre=False,
+        )
+        repasse_existente_id = repasse_existente.pk
+
+        reader = self._make_reader([
+            ['1', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert not Repasse.objects.filter(pk=repasse_existente_id).exists()
+        assert Repasse.objects.filter(associacao=associacao_processa, periodo=periodo_processa).count() == 1
+
+    def test_ignora_repasse_anterior_com_realizacao(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+        repasse_factory
+    ):
+        repasse_existente = repasse_factory(
+            associacao=associacao_processa,
+            periodo=periodo_processa,
+            carga_origem=arquivo_mock,
+            carga_origem_linha_id=2,
+            realizado_capital=True,
+            realizado_custeio=False,
+            realizado_livre=False,
+        )
+        reader = self._make_reader([
+            ['2', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert 'já teve realização' in arquivo_mock.log
+        assert Repasse.objects.filter(pk=repasse_existente.pk).exists()
+
+    def test_erro_quando_associacao_encerrada(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        acao_processa,
+        dre,
+        unidade_factory,
+        associacao_factory,
+        acao_associacao_factory,
+        conta_associacao_factory,
+    ):
+        unidade_enc = unidade_factory(codigo_eol='741852', dre=dre)
+        assoc_enc = associacao_factory(
+            unidade=unidade_enc,
+            data_de_encerramento=datetime.date(2020, 1, 1),
+        )
+        acao_associacao_factory(associacao=assoc_enc, acao=acao_processa)
+        conta_associacao_factory(associacao=assoc_enc, tipo_conta=tipo_conta_processa)
+
+        reader = self._make_reader([
+            ['1', '741852', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert 'foi encerrada' in arquivo_mock.log
+
+    def test_erro_quando_periodo_anterior_a_data_inicio_da_conta(
+        self,
+        arquivo_mock,
+        tipo_conta_processa,
+        acao_processa,
+        associacao_processa,
+        acao_associacao_processa,
+        periodo_factory,
+        conta_associacao_factory
+    ):
+        periodo_antigo = periodo_factory(
+            referencia='2021.1',
+            data_inicio_realizacao_despesas=datetime.date(2021, 1, 1),
+            data_fim_realizacao_despesas=datetime.date(2021, 6, 30),
+        )
+        conta_associacao_factory(
+            associacao=associacao_processa,
+            tipo_conta=tipo_conta_processa,
+            data_inicio=datetime.date(2023, 1, 1),
+        )
+
+        reader = self._make_reader([
+            ['1', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_antigo)
+
+        assert 'anterior ao período de criação da conta' in arquivo_mock.log
+
+    def test_erro_quando_associacao_tem_pc_no_periodo(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+        prestacao_conta_factory,
+    ):
+        prestacao_conta_factory(associacao=associacao_processa, periodo=periodo_processa, status='APROVADA')
+
+        reader = self._make_reader([
+            ['1', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert 'já possui PC gerada' in arquivo_mock.log
+
+    def test_linha_cabecalho_ignorada(
+        self,
+        arquivo_mock,
+        periodo_processa,
+        tipo_conta_processa,
+        associacao_processa,
+        acao_processa,
+        acao_associacao_processa,
+        conta_associacao_processa,
+    ):
+        reader = self._make_reader([
+            ['1', '654321', '100', '0', '0', 'Acao Processa'],
+        ])
+        processa_repasse(reader, tipo_conta_processa.uuid, tipo_conta_processa, arquivo_mock, periodo_processa)
+
+        assert Repasse.objects.filter(associacao=associacao_processa).count() == 1
+
+
+@pytest.fixture
+def periodo_carga(periodo_factory):
+    return periodo_factory(
+        referencia='2023.2',
+        data_inicio_realizacao_despesas=datetime.date(2023, 7, 1),
+        data_fim_realizacao_despesas=datetime.date(2023, 12, 31),
+    )
+
+
+@pytest.fixture
+def tipo_conta_carga(tipo_conta_factory):
+    return tipo_conta_factory(nome='Cheque Carga')
+
+
+@pytest.fixture
+def conteudo_csv_virgula():
+    return SimpleUploadedFile(
+        'repasses_virgula.csv',
+        bytes(
+            (
+                "Id_Linha,Código eol,Valor capital,Valor custeio,Valor livre aplicacao,Acao\n"
+                "1,123456,100,200,0,PTRF Básico"
+            ),
+            encoding='utf-8',
+        ),
+    )
+
+
+@pytest.fixture
+def conteudo_csv_ponto_virgula():
+    return SimpleUploadedFile(
+        'repasses_pv.csv',
+        bytes(
+            (
+                "Id_Linha;Código eol;Valor capital;Valor custeio;Valor livre aplicacao;Acao\n"
+                "1;123456;100;200;0;PTRF Básico"
+            ),
+            encoding='utf-8',
+        ),
+    )
+
+
+class TestCarregaRepassesPrevistos:
+    def test_erro_quando_sem_tipo_de_conta(self, periodo_carga, conteudo_csv_virgula, arquivo_factory):
+        arquivo = arquivo_factory(
+            identificador='carga-sem-tipo-conta',
+            conteudo=conteudo_csv_virgula,
+            tipo_carga=CARGA_REPASSE_PREVISTO,
+            tipo_delimitador=DELIMITADOR_VIRGULA,
+            tipo_de_conta=None,
+            periodo=periodo_carga,
+        )
+        carrega_repasses_previstos(arquivo)
+
+        assert arquivo.status == ERRO
+        assert 'tipo de conta' in arquivo.log.lower()
+
+    def test_erro_quando_sem_periodo(self, tipo_conta_carga, conteudo_csv_virgula, arquivo_factory):
+        arquivo = arquivo_factory(
+            identificador='carga-sem-periodo',
+            conteudo=conteudo_csv_virgula,
+            tipo_carga=CARGA_REPASSE_PREVISTO,
+            tipo_delimitador=DELIMITADOR_VIRGULA,
+            tipo_de_conta=tipo_conta_carga,
+            periodo=None,
+        )
+        carrega_repasses_previstos(arquivo)
+
+        assert arquivo.status == ERRO
+        assert 'periodo' in arquivo.log.lower()
+
+    def test_erro_quando_delimitador_incorreto(
+            self, tipo_conta_carga, periodo_carga, conteudo_csv_virgula, arquivo_factory):
+        arquivo = arquivo_factory(
+            identificador='carga-delimitador-errado',
+            conteudo=conteudo_csv_virgula,
+            tipo_carga=CARGA_REPASSE_PREVISTO,
+            tipo_delimitador=DELIMITADOR_PONTO_VIRGULA,
+            tipo_de_conta=tipo_conta_carga,
+            periodo=periodo_carga,
+        )
+        carrega_repasses_previstos(arquivo)
+
+        assert arquivo.status == ERRO
+        assert 'diferente do formato' in arquivo.log
+
+    def test_sucesso_com_arquivo_valido(
+        self,
+        tipo_conta_carga,
+        periodo_carga,
+        conteudo_csv_virgula,
+        associacao,
+        unidade,
+        acao_factory,
+        conta_associacao_factory,
+        acao_associacao_factory,
+        arquivo_factory,
+    ):
+        acao = acao_factory(
+            nome='PTRF Básico', aceita_capital=True, aceita_custeio=True, aceita_livre=True)
+        conta_associacao_factory.create(
+            associacao=associacao, tipo_conta=tipo_conta_carga, data_inicio=datetime.datetime(2000, 1, 1))
+        acao_associacao_factory.create(
+            associacao=associacao, acao=acao)
+
+        arquivo = arquivo_factory(
+            identificador='carga-valida',
+            conteudo=conteudo_csv_virgula,
+            tipo_carga=CARGA_REPASSE_PREVISTO,
+            tipo_delimitador=DELIMITADOR_VIRGULA,
+            tipo_de_conta=tipo_conta_carga,
+            periodo=periodo_carga,
+        )
+        carrega_repasses_previstos(arquivo)
+
+        assert arquivo.status == SUCESSO
+        assert Repasse.objects.filter(associacao=associacao, periodo=periodo_carga).exists()
+
+    def test_atualiza_ultima_execucao(self, tipo_conta_carga, periodo_carga, conteudo_csv_virgula, arquivo_factory):
+        arquivo = arquivo_factory(
+            identificador='carga-ultima-exec',
+            conteudo=conteudo_csv_virgula,
+            tipo_carga=CARGA_REPASSE_PREVISTO,
+            tipo_delimitador=DELIMITADOR_PONTO_VIRGULA,
+            tipo_de_conta=tipo_conta_carga,
+            periodo=periodo_carga,
+            ultima_execucao=None,
+        )
+        carrega_repasses_previstos(arquivo)
+
+        assert arquivo.ultima_execucao is not None

--- a/tests/api/cypress/support/commands_ui/commands_creditos_da_escola.js
+++ b/tests/api/cypress/support/commands_ui/commands_creditos_da_escola.js
@@ -565,11 +565,11 @@ Cypress.Commands.add('validar_soma_valores_reprogramados_ue', () => {
 })
 
 Cypress.Commands.add('validar_campos_cadastrar_creditos_da_escola_ue', () => {
-    cy.get(creditos.btn_cadastrar_credito(), { timeout: 15000 })
+    cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
-    cy.get(creditos.btn_salvar_credito(), { timeout: 3000 })
+    cy.get(creditos.btn_salvar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
@@ -677,13 +677,13 @@ Cypress.Commands.add('cadastrar_creditos_da_escola_ue', (campo) => {
     })
   }
 
-  cy.get(creditos.btn_cadastrar_credito(), { timeout: 15000 })
+  cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click({ force: true })
 
   cy.url().should('include', '/cadastro-de-credito')
 
-  cy.get(creditos.selecionar_tipo_receita(), { timeout: 10000 })
+  cy.get(creditos.selecionar_tipo_receita(), { timeout: 30000 })
     .should('be.visible')
     .select(campo, { force: true })
 
@@ -793,7 +793,7 @@ Cypress.Commands.add('cadastrar_devolucao_creditos_da_escola_ue', () => {
       })
   }
 
-  cy.get(creditos.btn_cadastrar_credito(), { timeout: 20000 })
+  cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
@@ -913,11 +913,11 @@ Cypress.Commands.add('cadastrar_credito_ue', () => {
     cy.url({ timeout: 10000 }).should('include', '/lista-de-receitas')
   }
 
-  cy.get(creditos.btn_cadastrar_credito(), { timeout: 10000 })
+  cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
-  cy.get(creditos.selecionar_tipo_receita(), { timeout: 10000 })
+  cy.get(creditos.selecionar_tipo_receita(), { timeout: 30000 })
     .should('be.visible')
     .select('Recurso Externo', { force: true })
 
@@ -1007,32 +1007,32 @@ Cypress.Commands.add('excluir_credito_ue', () => {
     selecionarPrimeiraOpcaoValida(creditos.selecionar_conta_associacao())
     selecionarPrimeiraOpcaoValida(creditos.selecionar_acao_associacao())
 
-    cy.get(creditos.inserir_valor_credito(), { timeout: 5000 })
+    cy.get(creditos.inserir_valor_credito(), { timeout: 30000 })
       .should('be.visible')
       .clear()
       .type('1', { force: true })
       .blur()
 
-    cy.get(creditos.btn_salvar_credito(), { timeout: 10000 })
+    cy.get(creditos.btn_salvar_credito(), { timeout: 30000 })
       .should('be.visible')
       .should('not.be.disabled')
       .click({ force: true })
 
     tratarPeriodoFechado()
 
-    cy.url({ timeout: 10000 }).should('include', '/lista-de-receitas')
+    cy.url({ timeout: 30000 }).should('include', '/lista-de-receitas')
   }
 
   function aguardarToast() {
     cy.get('body').then(($body) => {
       if ($body.find('.Toastify__toast').length > 0) {
-        cy.get('.Toastify__toast', { timeout: 10000 }).should('not.exist')
+        cy.get('.Toastify__toast', { timeout: 30000 }).should('not.exist')
       }
     })
   }
 
   function selecionarRegistroParaExcluir() {
-    cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 10000 })
+    cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 30000 })
       .should('exist')
       .should('be.visible')
       .click({ force: true })
@@ -1041,22 +1041,22 @@ Cypress.Commands.add('excluir_credito_ue', () => {
       const botaoExiste = $body.find(creditos.btn_deletar_credito_ue()).length > 0
 
       if (!botaoExiste) {
-        cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 10000 })
+        cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 30000 })
           .dblclick({ force: true })
       }
     })
 
-    cy.get(creditos.btn_deletar_credito_ue(), { timeout: 15000 })
+    cy.get(creditos.btn_deletar_credito_ue(), { timeout: 30000 })
       .should('exist')
       .should('be.visible')
       .should('not.be.disabled')
   }
 
-  cy.get(creditos.btn_cadastrar_credito(), { timeout: 10000 })
+  cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
-  cy.get(creditos.selecionar_tipo_receita(), { timeout: 10000 })
+  cy.get(creditos.selecionar_tipo_receita(), { timeout: 30000 })
     .should('be.visible')
     .select('Recurso Externo', { force: true })
 
@@ -1065,7 +1065,7 @@ Cypress.Commands.add('excluir_credito_ue', () => {
 
   preencherDataCredito(dataFormatada)
 
-  cy.get(creditos.selecionar_detalhamento_credito_re(), { timeout: 10000 })
+  cy.get(creditos.selecionar_detalhamento_credito_re(), { timeout: 30000 })
     .should('be.visible')
     .clear()
     .type(nomeTeste, { force: true })
@@ -1074,20 +1074,20 @@ Cypress.Commands.add('excluir_credito_ue', () => {
   aguardarToast()
   selecionarRegistroParaExcluir()
 
-  cy.get(creditos.btn_deletar_credito_ue(), { timeout: 15000 })
+  cy.get(creditos.btn_deletar_credito_ue(), { timeout: 30000 })
     .should('be.visible')
     .click({ force: true })
 
-  cy.get(creditos.btn_excluir_credito_ue(), { timeout: 15000 })
+  cy.get(creditos.btn_excluir_credito_ue(), { timeout: 30000 })
     .should('be.visible')
     .click({ force: true })
 
-  cy.get(creditos.btn_excluir_credito_ue(), { timeout: 15000 })
+  cy.get(creditos.btn_excluir_credito_ue(), { timeout: 30000 })
     .should('not.exist')
 })
 
 Cypress.Commands.add('validar_credito_ue', () => {
-  cy.get(creditos.titulo_valores_reprogramados(), { timeout: 15000 })
+  cy.get(creditos.titulo_valores_reprogramados(), { timeout: 30000 })
     .should('be.visible')
 })
 
@@ -1096,7 +1096,7 @@ Cypress.Commands.add('editar_credito_ue', () => {
   const nomeTeste = `Teste automatizado ${timestamp}`
 
   function preencherDataCredito(dataFormatada) {
-    cy.get(creditos.inserir_data_credito(), { timeout: 5000 })
+    cy.get(creditos.inserir_data_credito(), { timeout: 30000 })
       .should('be.visible')
       .then(($input) => {
         cy.wrap($input)
@@ -1167,40 +1167,40 @@ Cypress.Commands.add('editar_credito_ue', () => {
       .type('1', { force: true })
       .blur()
 
-    cy.get(creditos.btn_salvar_credito(), { timeout: 10000 })
+    cy.get(creditos.btn_salvar_credito(), { timeout: 30000 })
       .should('be.visible')
       .should('not.be.disabled')
       .click({ force: true })
 
     tratarPeriodoFechado()
-    cy.url({ timeout: 10000 }).should('include', '/lista-de-receitas')
+    cy.url({ timeout: 30000 }).should('include', '/lista-de-receitas')
   }
 
   function aguardarToast() {
     cy.get('body').then(($body) => {
       if ($body.find('.Toastify__toast').length > 0) {
-        cy.get('.Toastify__toast', { timeout: 10000 }).should('not.exist')
+        cy.get('.Toastify__toast', { timeout: 30000 }).should('not.exist')
       }
     })
   }
 
   function selecionarPrimeiroRegistroDaListagem() {
-    cy.url({ timeout: 10000 }).should('include', '/lista-de-receitas')
+    cy.url({ timeout: 30000 }).should('include', '/lista-de-receitas')
 
-    cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 15000 })
+    cy.get(creditos.selecionar_recurso_credito_ue(), { timeout: 30000 })
       .should('exist')
       .should('be.visible')
       .first()
       .click({ force: true })
 
-    cy.url({ timeout: 15000 }).should('include', '/edicao-de-receita/')
-    cy.get(creditos.btn_salvar_credito(), { timeout: 15000 })
+    cy.url({ timeout: 30000 }).should('include', '/edicao-de-receita/')
+    cy.get(creditos.btn_salvar_credito(), { timeout: 30000 })
       .should('exist')
       .should('be.visible')
   }
 
   function voltarParaListagemSeEstiverEmEdicao() {
-    cy.url({ timeout: 15000 }).then((urlAtual) => {
+    cy.url({ timeout: 30000 }).then((urlAtual) => {
       if (urlAtual.includes('/edicao-de-receita/')) {
         cy.go('back')
       }
@@ -1242,11 +1242,11 @@ Cypress.Commands.add('editar_credito_ue', () => {
       .should('not.exist')
   }
 
-  cy.get(creditos.btn_cadastrar_credito(), { timeout: 10000 })
+  cy.get(creditos.btn_cadastrar_credito(), { timeout: 30000 })
     .should('be.visible')
     .click()
 
-  cy.get(creditos.selecionar_tipo_receita(), { timeout: 10000 })
+  cy.get(creditos.selecionar_tipo_receita(), { timeout: 30000 })
     .should('be.visible')
     .select('Recurso Externo', { force: true })
 
@@ -1255,7 +1255,7 @@ Cypress.Commands.add('editar_credito_ue', () => {
 
   preencherDataCredito(dataFormatada)
 
-  cy.get(creditos.selecionar_detalhamento_credito_re(), { timeout: 10000 })
+  cy.get(creditos.selecionar_detalhamento_credito_re(), { timeout: 30000 })
     .should('be.visible')
     .clear()
     .type(nomeTeste, { force: true })


### PR DESCRIPTION

Esse PR:

- permite processar repasses previstos quando houver PC diferente de não apresentada, apresenta apenas o erro no log de processamento
- refatora funções para reduzir requisições(repetidas) ao banco de dados
- Adiciona e altera testes unitários para a feature

História [AB#143915](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/143915)
