### PR TITLE
feat(147098): retorna devolução de pc por unidade e recurso no login

### DIFF
--- a/sme_ptrf_apps/users/services/get_unidades_usuario_service.py
+++ b/sme_ptrf_apps/users/services/get_unidades_usuario_service.py
@@ -6,9 +6,9 @@ from waffle import get_waffle_flag_model
 
 def get_unidades_do_usuario(user, suporte=False):
     flags = get_waffle_flag_model()
-    
+
     novo_suporte_unidade = flags.objects.filter(name='novo-suporte-unidades', everyone=True).exists()
-    
+
     # Constante que representa o UUID da unidade Secretaria Municipal de Educação
     UUID_SME = "8919f454-bee5-419c-ad54-b2df27bf8007"
     UNIDADE_SME = {
@@ -19,34 +19,35 @@ def get_unidades_do_usuario(user, suporte=False):
             'uuid': '',
             'nome': ''
         },
-        'notificacao_uuid': None,
-        'notificar_devolucao_pc_uuid': None,
-        'notificar_devolucao_referencia': None,
+        'notificar_devolucao_por_recurso': {},
         'acesso_de_suporte': False
     }
 
     unidades = []
     for unidade in user.unidades.all().order_by("nome"):
         acesso_de_suporte = UnidadeEmSuporte.objects.filter(unidade=unidade, user=user).exists()
-        
+
         associacao = Associacao.objects.filter(unidade__uuid=unidade.uuid).first()
 
-        notificao_devolucao_pc = Notificacao.objects.filter(
+        notificacao_usuario_unidade = Notificacao.objects.filter(
             usuario=user,
             categoria=Notificacao.CATEGORIA_NOTIFICACAO_DEVOLUCAO_PC,
             unidade=unidade,
             lido=False
-        ).first()
+        ).select_related('prestacao_conta', 'prestacao_conta__periodo', 'prestacao_conta__periodo__recurso').distinct('prestacao_conta__periodo__recurso__uuid')
 
-        if notificao_devolucao_pc and notificao_devolucao_pc.prestacao_conta:
-            notificar_devolucao_referencia = notificao_devolucao_pc.prestacao_conta.periodo.referencia
-            notificar_devolucao_pc_uuid = notificao_devolucao_pc.prestacao_conta.uuid
-            notificacao_uuid = notificao_devolucao_pc.uuid
-        else:
-            notificar_devolucao_referencia = None
-            notificacao_uuid = None
-            notificar_devolucao_pc_uuid = None
-        
+        notificar_devolucao_por_recurso = {}
+
+        for notificacao in notificacao_usuario_unidade:
+            if notificacao and notificacao.prestacao_conta:
+                key = f'recurso_{notificacao.prestacao_conta.periodo.recurso.uuid}'
+
+                notificar_devolucao_por_recurso[key] = {
+                    'notificar_devolucao_referencia': notificacao.prestacao_conta.periodo.referencia,
+                    'notificar_devolucao_pc_uuid': notificacao.prestacao_conta.uuid,
+                    'notificacao_uuid': notificacao.uuid,
+                }
+
         if novo_suporte_unidade:
             if suporte and acesso_de_suporte or not suporte and not acesso_de_suporte:
                 unidades.append({
@@ -57,10 +58,8 @@ def get_unidades_do_usuario(user, suporte=False):
                         'uuid': associacao.uuid if associacao else '',
                         'nome': associacao.nome if associacao else ''
                     },
-                    'notificar_devolucao_referencia': notificar_devolucao_referencia,
-                    'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
-                    'notificacao_uuid': notificacao_uuid,
-                    'acesso_de_suporte': acesso_de_suporte
+                    'acesso_de_suporte': acesso_de_suporte,
+                    'notificar_devolucao_por_recurso': notificar_devolucao_por_recurso
                 })
         else:
             unidades.append({
@@ -71,12 +70,10 @@ def get_unidades_do_usuario(user, suporte=False):
                         'uuid': associacao.uuid if associacao else '',
                         'nome': associacao.nome if associacao else ''
                     },
-                    'notificar_devolucao_referencia': notificar_devolucao_referencia,
-                    'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
-                    'notificacao_uuid': notificacao_uuid,
-                    'acesso_de_suporte': acesso_de_suporte
+                    'acesso_de_suporte': acesso_de_suporte,
+                    'notificar_devolucao_por_recurso': notificar_devolucao_por_recurso
                 })
-    
+
     # Como a visão SME não tem uma Unidade real, cria a unidade caso o usuário tenha essa visão
     if novo_suporte_unidade:
         if user.visoes.filter(nome='SME').exists() and not suporte:

--- a/sme_ptrf_apps/users/services/login_usuario_service.py
+++ b/sme_ptrf_apps/users/services/login_usuario_service.py
@@ -40,9 +40,7 @@ class LoginUsuarioService:
                 'uuid': '',
                 'nome': ''
             },
-            'notificar_devolucao_referencia': None,
-            'notificar_devolucao_pc_uuid': None,
-            'notificacao_uuid': None,
+            'notificar_devolucao_por_recurso': {},
             'acesso_de_suporte': False
         }
 
@@ -57,21 +55,24 @@ class LoginUsuarioService:
 
                 acesso_de_suporte = UnidadeEmSuporte.objects.filter(unidade=unidade, user=self.usuario).exists()
 
-                notificao_devolucao_pc = Notificacao.objects.filter(
+                notificacao_usuario_unidade = Notificacao.objects.filter(
                     usuario=self.usuario,
                     categoria=Notificacao.CATEGORIA_NOTIFICACAO_DEVOLUCAO_PC,
                     unidade=unidade,
                     lido=False
-                ).first()
+                ).select_related('prestacao_conta', 'prestacao_conta__periodo', 'prestacao_conta__periodo__recurso').distinct('prestacao_conta__periodo__recurso__uuid')
 
-                if notificao_devolucao_pc and notificao_devolucao_pc.prestacao_conta:
-                    notificar_devolucao_referencia = notificao_devolucao_pc.prestacao_conta.periodo.referencia
-                    notificar_devolucao_pc_uuid = notificao_devolucao_pc.prestacao_conta.uuid
-                    notificacao_uuid = notificao_devolucao_pc.uuid
-                else:
-                    notificar_devolucao_referencia = None
-                    notificacao_uuid = None
-                    notificar_devolucao_pc_uuid = None
+                notificar_devolucao_por_recurso = {}
+
+                for notificacao in notificacao_usuario_unidade:
+                    if notificacao and notificacao.prestacao_conta:
+                        key = f'recurso_{notificacao.prestacao_conta.periodo.recurso.uuid}'
+
+                        notificar_devolucao_por_recurso[key] = {
+                            'notificar_devolucao_referencia': notificacao.prestacao_conta.periodo.referencia,
+                            'notificar_devolucao_pc_uuid': notificacao.prestacao_conta.uuid,
+                            'notificacao_uuid': notificacao.uuid,
+                        }
 
                 if novo_suporte_unidade:
                     if suporte and acesso_de_suporte or not suporte and not acesso_de_suporte:
@@ -83,10 +84,8 @@ class LoginUsuarioService:
                                 'uuid': associacao.uuid if associacao else '',
                                 'nome': associacao.nome if associacao else ''
                             },
-                            'notificar_devolucao_referencia': notificar_devolucao_referencia,
-                            'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
-                            'notificacao_uuid': notificacao_uuid,
-                            'acesso_de_suporte': acesso_de_suporte
+                            'acesso_de_suporte': acesso_de_suporte,
+                            'notificar_devolucao_por_recurso': notificar_devolucao_por_recurso
                         })
                 else:
                     info_unidades.append({
@@ -97,10 +96,8 @@ class LoginUsuarioService:
                             'uuid': associacao.uuid if associacao else '',
                             'nome': associacao.nome if associacao else ''
                         },
-                        'notificar_devolucao_referencia': notificar_devolucao_referencia,
-                        'notificar_devolucao_pc_uuid': notificar_devolucao_pc_uuid,
-                        'notificacao_uuid': notificacao_uuid,
-                        'acesso_de_suporte': acesso_de_suporte
+                        'acesso_de_suporte': acesso_de_suporte,
+                        'notificar_devolucao_por_recurso': notificar_devolucao_por_recurso
                     })
 
         if novo_suporte_unidade:

--- a/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/test_get_unidades_do_usuario_service.py
+++ b/sme_ptrf_apps/users/tests/tests_unidades_em_suporte/test_get_unidades_do_usuario_service.py
@@ -18,9 +18,7 @@ def test_obtem_lista_de_unidades_do_usuario_sem_acesso_suporte(
                 'uuid': ''
             },
             'nome': 'Secretaria Municipal de Educação',
-            'notificacao_uuid': None,
-            'notificar_devolucao_pc_uuid': None,
-            'notificar_devolucao_referencia': None,
+            'notificar_devolucao_por_recurso': {},
             'tipo_unidade': 'SME',
             'uuid': '8919f454-bee5-419c-ad54-b2df27bf8007',
             'acesso_de_suporte': False
@@ -46,9 +44,7 @@ def test_obtem_lista_de_unidades_do_usuario_com_acesso_suporte(
                 'uuid': associacao_em_suporte.uuid
             },
             'nome': 'Escola Unidade Diferente',
-            'notificacao_uuid': None,
-            'notificar_devolucao_pc_uuid': None,
-            'notificar_devolucao_referencia': None,
+            'notificar_devolucao_por_recurso': {},
             'tipo_unidade': 'EMEI',
             'uuid': unidade_do_suporte.uuid,
             'acesso_de_suporte': True
@@ -59,9 +55,7 @@ def test_obtem_lista_de_unidades_do_usuario_com_acesso_suporte(
                 'uuid': ''
             },
             'nome': 'Secretaria Municipal de Educação',
-            'notificacao_uuid': None,
-            'notificar_devolucao_pc_uuid': None,
-            'notificar_devolucao_referencia': None,
+            'notificar_devolucao_por_recurso': {},
             'tipo_unidade': 'SME',
             'uuid': '8919f454-bee5-419c-ad54-b2df27bf8007',
             'acesso_de_suporte': False


### PR DESCRIPTION
Este PR inclui:

- Retorna notificar devolução de pc considerando unidade e recurso ao realizar o login;
- Realiza ajustes em testes;

História: [AB#146625](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146625)
Tarefa: [AB#147098](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/147098)
