### PR TITLE
hotfix(147521): adiciona validação para impedir duplicidade ao criar/editar ReceitaPrevistaPdde

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.37.3"
+__version__ = "9.37.4"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/api/serializers/receita_prevista_pdde_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/receita_prevista_pdde_serializer.py
@@ -53,6 +53,21 @@ class ReceitaPrevistaPddeSerializer(serializers.ModelSerializer):
             except Paa.DoesNotExist:
                 raise serializers.ValidationError({'mensagem': 'PAA não encontrado!'})
 
+        acao_pdde = attrs.get('acao_pdde') or (self.instance.acao_pdde if self.instance else None)
+
+        receita_pdde = ReceitaPrevistaPdde.objects.filter(
+            paa=paa,
+            acao_pdde=acao_pdde
+        )
+
+        if self.instance:
+            receita_pdde = receita_pdde.exclude(pk=self.instance.pk)
+
+        if receita_pdde.exists():
+            raise serializers.ValidationError({
+                'acao_pdde': 'Já existe uma receita prevista para este PAA e Ação PDDE.'
+            })
+
         # Bloqueia edição quando o documento final foi gerado
         if paa.get_tem_documento_final_concluido():
             raise serializers.ValidationError({

--- a/sme_ptrf_apps/paa/tests/receitas_previstas_pdde/test_receitas_previstas_pdde_serializer.py
+++ b/sme_ptrf_apps/paa/tests/receitas_previstas_pdde/test_receitas_previstas_pdde_serializer.py
@@ -51,7 +51,10 @@ def test_receita_prevista_serializer_list_serializer_sem_erro_validate(paa, acao
         'paa': str(paa.uuid),
         'acao_pdde': str(acao_pdde.uuid),
     }
-    assert ReceitaPrevistaPddeSerializer().validate(data) == data
+
+    serializer = ReceitaPrevistaPddeSerializer(data=data)
+
+    assert serializer.is_valid(), serializer.errors
 
 
 def test_receita_prevista_pdde_serializer_bloqueia_edicao_com_documento_final_concluido(
@@ -77,3 +80,32 @@ def test_receita_prevista_pdde_serializer_bloqueia_edicao_com_documento_final_co
     assert (
         'Não é possível editar receitas previstas PDDE após a geração do '
         'documento final do PAA.') in serializer.errors['mensagem']
+
+
+def test_receita_prevista_pdde_serializer_bloqueia_create_duplicado(
+    receita_prevista_pdde
+):
+    """
+    Testa que não é possível criar uma nova receita prevista PDDE
+    com o mesmo PAA e Ação PDDE já existente.
+    """
+
+    payload = {
+        "paa": str(receita_prevista_pdde.paa.uuid),
+        "acao_pdde": str(receita_prevista_pdde.acao_pdde.uuid),
+        "previsao_valor_custeio": "500.00",
+        "previsao_valor_capital": "0.00",
+        "previsao_valor_livre": "0.00",
+        "saldo_custeio": "0.00",
+        "saldo_capital": "0.00",
+        "saldo_livre": "0.00",
+    }
+
+    serializer = ReceitaPrevistaPddeSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert 'acao_pdde' in serializer.errors
+    assert (
+        'Já existe uma receita prevista para este PAA e Ação PDDE.'
+        in serializer.errors['acao_pdde']
+    )


### PR DESCRIPTION
# O que este PR faz
-  impede duplicidade de (PAA, Ação PDDE) no create de ReceitaPrevistaPdde
- cria e atualiza teste para o cenário em questão

Referência Azure: [AB#147521](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/147521)