### PR TITLE
feat(145740): Adiciona histórico de retificação em Plano Orçamentário

### DIFF
--- a/sme_ptrf_apps/paa/admin.py
+++ b/sme_ptrf_apps/paa/admin.py
@@ -91,8 +91,10 @@ class ParametroPaaAdmin(admin.ModelAdmin):
 class PaaAdmin(admin.ModelAdmin):
     list_select_related = ('periodo_paa', 'associacao')
     list_display = ('periodo_paa', 'associacao', 'status', 'status_andamento')
-    readonly_fields = ('uuid', 'id', 'status_andamento', 'criado_em', 'alterado_em', 'replica',
-                       'acoes_conclusao', 'acoes_pdde_conclusao', 'outros_recursos_periodo_conclusao')
+    readonly_fields = (
+        'uuid', 'id', 'status_andamento', 'condicao_andamento', 'criado_em', 'alterado_em', 'replica',
+        'acoes_conclusao', 'acoes_pdde_conclusao', 'outros_recursos_periodo_conclusao'
+    )
     list_display_links = ['periodo_paa']
     search_fields = ('periodo_paa__referencia', 'associacao__nome', 'associacao__unidade__codigo_eol')
     list_filter = ('periodo_paa', 'associacao', 'status', StatusAndamentoFilter)
@@ -114,6 +116,10 @@ class PaaAdmin(admin.ModelAdmin):
         from sme_ptrf_apps.paa.enums import PaaStatusAndamentoEnum
         return PaaStatusAndamentoEnum[obj.get_status_andamento()].value
     status_andamento.short_description = 'Status Andamento'
+
+    def condicao_andamento(self, obj):
+        return obj.get_condicao_status_andamento()
+    condicao_andamento.short_description = 'Condição de Andamento'
 
 
 @admin.register(ProgramaPdde)

--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -108,7 +108,14 @@ class PaaViewSet(WaffleFlagMixin, ModelViewSet):
         associacao = instance.associacao
 
         saldos_por_acao_paa_service = SaldosPorAcaoPaaService(paa=instance, associacao=associacao)
-        receitas_previstas = saldos_por_acao_paa_service.congelar_saldos()
+        try:
+            receitas_previstas = saldos_por_acao_paa_service.congelar_saldos()
+        except Exception as e:
+            logger.error(f'Erro ao congelar saldos do PAA {instance.uuid}: {e}')
+            return Response(
+                {'mensagem': f'{e}'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         serializer = ReceitaPrevistaPaaSerializer(receitas_previstas, many=True)
 

--- a/sme_ptrf_apps/paa/models/paa.py
+++ b/sme_ptrf_apps/paa/models/paa.py
@@ -94,6 +94,28 @@ class Paa(ModeloBase):
             self.atas_da_paa.exists()
         )
 
+    def get_condicao_status_andamento(self) -> str:
+        """
+        Retorna o status da condição do andamento do PAA.
+
+        Se o objeto já possui o campo anotado 'status_andamento'(PaaManager -> Queryset),
+        retorna-o diretamente. Caso contrário, recarrega o objeto do banco com as anotações.
+
+        Returns:
+            str: Nome do status da condição (CASE 1, CASE 2,...)
+        """
+        # Se já tem o campo anotado, retorne-o
+        if hasattr(self, '_debug_case'):
+            return self._debug_case
+
+        # Caso contrário, busque a versão anotada do banco
+        if self.pk:
+            paa_anotado = Paa.objects.get(pk=self.pk)
+            return paa_anotado._debug_case
+
+        # Se é um objeto novo (ainda não salvo), retorna padrão
+        return 'Condição #'
+
     def get_status_andamento(self) -> str:
         """
         Retorna o status de andamento do PAA.

--- a/sme_ptrf_apps/paa/paa_querysets/paa_queryset.py
+++ b/sme_ptrf_apps/paa/paa_querysets/paa_queryset.py
@@ -59,55 +59,109 @@ class PaaQuerySet(models.QuerySet):
             output_field=models.BooleanField(),
         )
 
+        # Cada entrada: (condição, valor_status_andamento, label_debug)
+        # Condição pode ser dict (kwargs) ou Q expression
+        # Facilitar a identificação das condições que possam ocorrer fora de fluxo
+        case_definitions = [
+            # Fora do Fluxo - Réplica existente no PAA em Elaboração
+            (
+                {'status': PaaStatusEnum.EM_ELABORACAO.name, 'replica__isnull': False},
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'Em elaboração + com Réplica',
+            ),
+            # Fora do Fluxo - Em Elaboração com ata gerada
+            (
+                {'status': PaaStatusEnum.EM_ELABORACAO.name, 'tem_ata_concluida': True},
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'Em elaboração + com Ata gerada',
+            ),
+            # Fora de Fluxo - Réplica existente quando gerado
+            (
+                {
+                    'status': PaaStatusEnum.GERADO.name,
+                    'tem_documento_final_concluido': True,
+                    'tem_ata_concluida': True,
+                    'replica__isnull': False
+                },
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'Gerado + Doc Final + Ata + Réplica',
+            ),
+            # Fora de Fluxo: é gerado, não tem ata
+            (
+                {'status': PaaStatusEnum.GERADO.name, 'tem_ata_concluida': False},
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'Gerado + sem Ata',
+            ),
+            # Fora de Fluxo - Retificação sem Réplica
+            (
+                {'status': PaaStatusEnum.EM_RETIFICACAO.name, 'replica__isnull': True},
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'Em retificação + sem Réplica',
+            ),
+            # Gerado completo - é gerado, tem documento e tem ata
+            (
+                {
+                    'status': PaaStatusEnum.GERADO.name,
+                    'tem_documento_final_concluido': True,
+                    'tem_ata_concluida': True
+                },
+                PaaStatusAndamentoEnum.GERADO.name,
+                'Gerado + Doc Final + Ata',
+            ),
+            # Retificação correta quando há uma Réplica
+            (
+                {'status': PaaStatusEnum.EM_RETIFICACAO.name, 'replica__isnull': False},
+                PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name,
+                'Em retificação + com Réplica',
+            ),
+            # Em Elaboração quando tem apenas documento final concluído
+            (
+                Q(status=PaaStatusEnum.EM_ELABORACAO.name) & tem_documento_final_concluido,
+                PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name,
+                'Em elaboração + Doc Final',
+            ),
+            # Em elaboração
+            (
+                {
+                    'status': PaaStatusEnum.EM_ELABORACAO.name,
+                    'tem_documento_final_concluido': False,
+                    'tem_ata_concluida': False
+                },
+                PaaStatusAndamentoEnum.EM_ELABORACAO.name,
+                'Em elaboração',
+            ),
+            # Fluxo não iniciado
+            (
+                {'status': PaaStatusEnum.NAO_INICIADO.name},
+                PaaStatusAndamentoEnum.FORA_FLUXO.name,
+                'PAA existente não pode ser \"Não iniciado\"',
+            ),
+        ]
+
+        def make_when(condition, value):
+            """
+                Método utilizado para reaproveitar os Cases de status_andamento para _debug_case
+            """
+            if isinstance(condition, dict):
+                return When(**condition, then=Value(value))
+            return When(condition, then=Value(value))
+
         return self.annotate(
             tem_documento_final_concluido=tem_documento_final_concluido,
             tem_ata_concluida=tem_ata_concluida,
             status_andamento=Case(
-
-                # GERADO: status GERADO + documento final concluído + ata concluída
-                When(
-                    status=PaaStatusEnum.GERADO.name,
-                    tem_documento_final_concluido=True,
-                    tem_ata_concluida=True,
-                    then=Value(PaaStatusAndamentoEnum.GERADO.name),
-                ),
-
-                # RETIFICACAO: status EM_RETIFICACAO + com replica
-                # Enquanto Status está em retificação, deve haver uma réplica
-                When(
-                    status=PaaStatusEnum.EM_RETIFICACAO.name,
-                    replica__isnull=False,
-                    then=Value(PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name),
-                ),
-
-                # GERADO: status GERADO e sem ata gerada
-                # Cenário fora de fluxo, mas possível(em manipulação admin)
-                When(
-                    status=PaaStatusEnum.GERADO.name,
-                    tem_ata_concluida=False,
-                    then=Value(PaaStatusAndamentoEnum.FORA_FLUXO.name),
-                ),
-
-                # GERADO_PARCIALMENTE: status EM_RETIFICACAO
-                When(
-                    status=PaaStatusEnum.EM_RETIFICACAO.name,
-                    then=Value(PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name),
-                ),
-
-                # GERADO_PARCIALMENTE: status EM_ELABORACAO + documento final concluído
-                When(
-                    Q(status=PaaStatusEnum.EM_ELABORACAO.name) & tem_documento_final_concluido,
-                    then=Value(PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name),
-                ),
-
-                # NAO_INICIADO: status padrão NAO_INICIADO
-                When(
-                    status=PaaStatusEnum.NAO_INICIADO.name,
-                    then=Value(PaaStatusAndamentoEnum.NAO_INICIADO.name)
-                ),
+                *[make_when(cond, status) for cond, status, _ in case_definitions],
                 default=Value(PaaStatusAndamentoEnum.EM_ELABORACAO.name),
                 output_field=CharField(),
-            )
+            ),
+            _debug_case=Case(
+                *[make_when(
+                    cond,
+                    f'Condição {index + 1} - {label}'
+                ) for index, (cond, _, label) in enumerate(case_definitions)],
+                default=Value('Condição padrão: Não mapeada'),
+                output_field=CharField(),
+            ),
         )
 
     def get_queryset(self):

--- a/sme_ptrf_apps/paa/querysets.py
+++ b/sme_ptrf_apps/paa/querysets.py
@@ -43,11 +43,12 @@ def queryset_prioridades_paa(qs):
     )
 
     qs = qs.select_related(
-        'paa',
+        'paa', 'paa__periodo_paa', 'paa__associacao', 'paa__associacao__unidade',
         'acao_associacao',
         'acao_associacao__acao',
         'acao_associacao__associacao',
         'programa_pdde',
+        'acao_pdde',
         'acao_pdde__programa',
         'especificacao_material',
         'especificacao_material__tipo_custeio',

--- a/sme_ptrf_apps/paa/services/acoes_paa_service.py
+++ b/sme_ptrf_apps/paa/services/acoes_paa_service.py
@@ -46,11 +46,11 @@ class AcoesPaaService:
         # Ações Registradas no PAA
         acoes_conclusao = self.paa.acoes_conclusao.all()
 
-        logger.info('Flag \'paa-retificacao\' encontrada. Carregando Ações PTRF + Ações salvas no PAA.')
         return self.associacao.acoes.filter(
             Q(acao__recurso__legado=True, acao__exibir_paa=True) |
             Q(acao__in=acoes_conclusao)
-        ).distinct()
+        ).select_related(
+            'acao', 'acao__recurso', 'associacao', 'associacao__unidade').distinct()
 
     def obter_pdde(self) -> QuerySet:
         """
@@ -74,7 +74,6 @@ class AcoesPaaService:
         # Açoes registradas no PAA
         acoes_pdde_conclusao = self.paa.acoes_pdde_conclusao.all()
 
-        logger.info('Flag \'paa-retificacao\' encontrada. Carregando Ações PDDE + Ações salvas no PAA.')
         return AcaoPdde.objects.filter(
             Q(pk__in=qs_disponiveis) |
             Q(pk__in=acoes_pdde_conclusao)
@@ -126,6 +125,9 @@ class AcoesReceitasPrevistasPaaService(AcoesPaaService):
             acao_assoc['receitas_previstas_paa'] = ReceitaPrevistaPaaSerializer(
                 self.paa.receitaprevistapaa_set.filter(
                     acao_associacao__acao__uuid=str(acao_assoc['acao']['uuid'])
+                ).select_related(
+                    'acao_associacao',
+                    'acao_associacao__acao',
                 ),
                 many=True).data
         return serialized_acoes

--- a/sme_ptrf_apps/paa/services/plano_orcamentario_service.py
+++ b/sme_ptrf_apps/paa/services/plano_orcamentario_service.py
@@ -43,6 +43,38 @@ class PlanoOrcamentarioService:
     def __init__(self, paa: Paa):
         self.paa = paa
 
+    def _obter_alteracoes(self) -> dict:
+        """Retorna alterações do PAA em relação ao snapshot da retificação (com cache por instância)."""
+        if not hasattr(self, '_alteracoes_cache'):
+            from sme_ptrf_apps.paa.services.retificacao_paa_service import RetificacaoPaaService
+            try:
+                self._alteracoes_cache = RetificacaoPaaService(self.paa, None).identificar_alteracoes()
+            except Exception as e:
+                logger.warning(f"Erro ao obter alterações do PAA {self.paa.uuid}: {str(e)}")
+                self._alteracoes_cache = {}
+        return self._alteracoes_cache
+
+    def _status_alteracao(self, alteracoes_secao, chave):
+        """Retorna 'adicionado', 'modificado', 'removido' ou None para uma chave na seção de alterações."""
+        item = alteracoes_secao.get(str(chave))
+        if item is None:
+            return None
+        return item.get('acao')
+
+    def _status_alteracao_agregado(self, alteracoes_secao):
+        """
+        Agrega status de múltiplos registros em uma seção.
+        Retorna 'adicionado' se só há adições, 'removido' se só há remoções, 'modificado' se há mix, None se vazio.
+        """
+        if not alteracoes_secao:
+            return None
+        acoes = {v.get('acao') for v in alteracoes_secao.values()}
+        if acoes == {'adicionado'}:
+            return 'adicionado'
+        if acoes == {'removido'}:
+            return 'removido'
+        return 'modificado'
+
     def _calcular_saldo(self, receitas, despesas):
         """
         Calcula saldo considerando regras de negativos.
@@ -120,6 +152,8 @@ class PlanoOrcamentarioService:
             acao__exibir_paa=True
         ).all()
 
+        alteracoes_receitas_ptrf = self._obter_alteracoes().get('receitas_ptrf', {})
+
         receitas = []
         for acao_assoc in acoes_associacoes:
             try:
@@ -169,7 +203,8 @@ class PlanoOrcamentarioService:
                 'uuid': acao_uuid,
                 'acao': acao_data,
                 'receitas_previstas_paa': receitas_previstas_data,
-                'saldos': saldos_finais
+                'saldos': saldos_finais,
+                'alteracao': self._status_alteracao(alteracoes_receitas_ptrf, acao_assoc.uuid),
             })
         return receitas
 
@@ -244,6 +279,9 @@ class PlanoOrcamentarioService:
             prioridadepaa__paa=self.paa
         ).distinct()
         acoes_pdde = (acoes_com_receitas | acoes_com_prioridades).distinct()
+
+        alteracoes_receitas_pdde = self._obter_alteracoes().get('receitas_pdde', {})
+
         acoes_com_totais = []
 
         for acao_pdde in acoes_pdde:
@@ -289,7 +327,8 @@ class PlanoOrcamentarioService:
                 'total_valor_custeio': float(valores_custeio),
                 'total_valor_capital': float(valores_capital),
                 'total_valor_livre_aplicacao': float(valores_livre),
-                'total': float(valores_custeio + valores_capital + valores_livre)
+                'total': float(valores_custeio + valores_capital + valores_livre),
+                'alteracao': self._status_alteracao(alteracoes_receitas_pdde, acao_pdde.uuid),
             })
 
         return acoes_com_totais
@@ -314,6 +353,10 @@ class PlanoOrcamentarioService:
         from sme_ptrf_apps.paa.models import OutroRecursoPeriodoPaa, ReceitaPrevistaOutroRecursoPeriodo
         from sme_ptrf_apps.paa.enums import RecursoOpcoesEnum
 
+        alteracoes = self._obter_alteracoes()
+        alteracoes_recurso_proprio = alteracoes.get('receitas_recurso_proprio', {})
+        alteracoes_outros_recursos = alteracoes.get('receitas_outros_recursos', {})
+
         receitas = []
 
         total_recursos_proprios = self._obter_total_recursos_proprios()
@@ -329,7 +372,8 @@ class PlanoOrcamentarioService:
                 'capital': Decimal('0'),
                 'livre': total_recursos_proprios,
                 'total': total_recursos_proprios
-            }
+            },
+            'alteracao': self._status_alteracao_agregado(alteracoes_recurso_proprio),
         })
 
         outros_recursos_periodo = OutroRecursoPeriodoPaa.objects.disponiveis_para_paa(self.paa)
@@ -377,7 +421,8 @@ class PlanoOrcamentarioService:
                     'capital': valores_capital,
                     'livre': valores_livre,
                     'total': valores_custeio + valores_capital + valores_livre
-                }
+                },
+                'alteracao': self._status_alteracao(alteracoes_outros_recursos, outro_recurso_periodo.uuid),
             })
 
         return receitas
@@ -490,7 +535,8 @@ class PlanoOrcamentarioService:
                 'receitas': _converter_valores_para_float(receita_valores),
                 'despesas': _converter_valores_para_float(despesa_valores),
                 'saldos': _converter_valores_para_float(saldo_valores),
-                'ocultarCusteioCapital': ocultar_custeio_capital
+                'ocultarCusteioCapital': ocultar_custeio_capital,
+                'historicos': receita_item.get('alteracao')
             })
 
             total_receitas['custeio'] += receita_valores['custeio']
@@ -628,7 +674,8 @@ class PlanoOrcamentarioService:
                 'exibirLivre': exibe_livre,
                 'receitas': _converter_valores_para_float(receita_valores),
                 'despesas': _converter_valores_para_float(despesa_valores),
-                'saldos': _converter_valores_para_float(saldo_valores)
+                'saldos': _converter_valores_para_float(saldo_valores),
+                'historicos': receita.get('alteracao')
             })
 
             total_receitas['custeio'] += receita_valores['custeio']
@@ -734,7 +781,8 @@ class PlanoOrcamentarioService:
                 'exibirLivre': exibe_livre,
                 'receitas': _converter_valores_para_float(receita_valores),
                 'despesas': _converter_valores_para_float(despesa_valores),
-                'saldos': _converter_valores_para_float(saldo_valores)
+                'saldos': _converter_valores_para_float(saldo_valores),
+                'historicos': acao.get('alteracao')
             })
 
             total_receitas['custeio'] += receita_valores['custeio']

--- a/sme_ptrf_apps/paa/services/receitas_previstas_paa_service.py
+++ b/sme_ptrf_apps/paa/services/receitas_previstas_paa_service.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from sme_ptrf_apps.core.models import Associacao
+from sme_ptrf_apps.core.models import Associacao, Recurso
 from sme_ptrf_apps.core.models.periodo import Periodo
 from sme_ptrf_apps.paa.models import ReceitaPrevistaPaa
 from sme_ptrf_apps.core.services.resumo_rescursos_service import ResumoRecursosService
@@ -48,8 +48,10 @@ class SaldosPorAcaoPaaService:
             return []
 
         self.paa.set_congelar_saldo()
-        self.periodo = Periodo.da_data(self.paa.saldo_congelado_em)
-
+        recurso = Recurso.objects.filter(legado=True).first()
+        self.periodo = Periodo.da_data_por_recurso(self.paa.saldo_congelado_em, recurso=recurso)
+        if not self.periodo:
+            raise Exception('Não foi possivel encontrar o período relacionado à data de congelamento do saldo.')
         receitas_previstas = []
         acoes_associacao = Associacao.acoes_da_associacao(associacao_uuid=self.associacao.uuid)
 

--- a/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
+++ b/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
@@ -74,7 +74,11 @@ class ResumoPrioridadesService:
 
         # Queryset Somente de Prioridades do PAA do recurso PTRF
         prioridades_ptrf_qs = self.paa.prioridadepaa_set.filter(
-            recurso=RecursoOpcoesEnum.PTRF.name)
+            recurso=RecursoOpcoesEnum.PTRF.name
+        ).select_related(
+            'acao_associacao',
+            'acao_associacao__acao'
+        )
 
         acoes_associacoes_qs = AcoesPaaService(self.paa).obter_ptrf().order_by('acao__nome')
 

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
@@ -13,7 +13,7 @@ def _qs():
 
 
 class TestAnnotateStatusGeracao:
-    def test_status_nao_iniciado_andamento_tambem_nao_iniciado(
+    def test_status_nao_iniciado_retorna_fora_fluxo(
         self, paa_factory, periodo_paa_factory, associacao
     ):
         periodo = periodo_paa_factory.create()
@@ -23,8 +23,8 @@ class TestAnnotateStatusGeracao:
             status=PaaStatusEnum.NAO_INICIADO.name,
         )
 
-        qs = _qs().filter(pk=paa.pk).filter_por_status_geracao(PaaStatusAndamentoEnum.NAO_INICIADO.name)
-        assert qs.first().status_andamento == PaaStatusAndamentoEnum.NAO_INICIADO.name
+        qs = _qs().filter(pk=paa.pk)
+        assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
 
     def test_status_gerado_com_documento_final_concluido_e_ata_concluida(
         self, paa_factory, documento_paa_factory, ata_paa_factory, periodo_paa_factory, associacao
@@ -84,7 +84,7 @@ class TestAnnotateStatusGeracao:
         assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
 
     def test_status_em_retificacao_retorna_gerado_parcialmente(
-        self, paa_factory, periodo_paa_factory, associacao, documento_paa_factory, ata_paa_factory
+        self, paa_factory, periodo_paa_factory, associacao, documento_paa_factory, ata_paa_factory, replica_paa_factory
     ):
         periodo = periodo_paa_factory.create()
         paa = paa_factory.create(
@@ -101,6 +101,7 @@ class TestAnnotateStatusGeracao:
             paa=paa,
             status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
         )
+        replica_paa_factory.create(paa=paa)
 
         qs = _qs().filter(pk=paa.pk).paas_gerados_parcialmente()
         assert qs.first().status_andamento == PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name
@@ -172,6 +173,73 @@ class TestAnnotateStatusGeracao:
         qs = _qs().filter(pk=paa.pk).paas_em_elaboracao()
         assert qs.first().status_andamento == PaaStatusAndamentoEnum.EM_ELABORACAO.name
 
+    def test_status_em_elaboracao_com_replica_retorna_fora_fluxo(
+        self, paa_factory, periodo_paa_factory, associacao, replica_paa_factory
+    ):
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(
+            periodo_paa=periodo,
+            associacao=associacao,
+            status=PaaStatusEnum.EM_ELABORACAO.name,
+        )
+        replica_paa_factory.create(paa=paa)
+
+        qs = _qs().filter(pk=paa.pk)
+        assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
+
+    def test_status_em_elaboracao_com_ata_concluida_retorna_fora_fluxo(
+        self, paa_factory, ata_paa_factory, periodo_paa_factory, associacao
+    ):
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(
+            periodo_paa=periodo,
+            associacao=associacao,
+            status=PaaStatusEnum.EM_ELABORACAO.name,
+        )
+        ata_paa_factory.create(
+            paa=paa,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+
+        qs = _qs().filter(pk=paa.pk)
+        assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
+
+    def test_status_gerado_com_documento_ata_e_replica_retorna_fora_fluxo(
+        self, paa_factory, documento_paa_factory, ata_paa_factory, periodo_paa_factory, associacao, replica_paa_factory
+    ):
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(
+            periodo_paa=periodo,
+            associacao=associacao,
+            status=PaaStatusEnum.GERADO.name,
+        )
+        documento_paa_factory.create(
+            paa=paa,
+            versao=DocumentoPaa.VersaoChoices.FINAL,
+            status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
+        )
+        ata_paa_factory.create(
+            paa=paa,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        replica_paa_factory.create(paa=paa)
+
+        qs = _qs().filter(pk=paa.pk)
+        assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
+
+    def test_status_em_retificacao_sem_replica_retorna_fora_fluxo(
+        self, paa_factory, periodo_paa_factory, associacao
+    ):
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(
+            periodo_paa=periodo,
+            associacao=associacao,
+            status=PaaStatusEnum.EM_RETIFICACAO.name,
+        )
+
+        qs = _qs().filter(pk=paa.pk)
+        assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
+
 
 class TestFilterPorStatusGeracao:
     def test_filtra_somente_gerados(
@@ -205,7 +273,8 @@ class TestFilterPorStatusGeracao:
         assert resultado_qs.first().pk == paa_gerado.pk
 
     def test_filtra_somente_gerados_parcialmente(
-        self, paa_factory, documento_paa_factory, periodo_paa_factory, associacao_factory, ata_paa_factory
+        self, paa_factory, documento_paa_factory, periodo_paa_factory,
+        associacao_factory, ata_paa_factory, replica_paa_factory
     ):
         periodo = periodo_paa_factory.create()
 
@@ -220,6 +289,7 @@ class TestFilterPorStatusGeracao:
             status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
         )
         ata_paa_factory.create(paa=paa_retificacao, status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO)
+        replica_paa_factory.create(paa=paa_retificacao)
 
         # PAA em elaboracao com doc final
         assoc2 = associacao_factory.create()

--- a/sme_ptrf_apps/paa/tests/services/test_outros_recursos_periodo_service_base.py
+++ b/sme_ptrf_apps/paa/tests/services/test_outros_recursos_periodo_service_base.py
@@ -174,7 +174,8 @@ def test_paas_afetados_em_elaboracao(base_service, periodo_paa_1, ata_paa_factor
 
 
 @pytest.mark.django_db
-def test_paas_afetados_gerado_retificado(base_service, periodo_paa_1, ata_paa_factory, documento_paa_factory):
+def test_paas_afetados_gerado_retificado(base_service, periodo_paa_1, ata_paa_factory, documento_paa_factory,
+                                         replica_paa_factory):
     """Testa filtro de PAAs gerados ou em retificação"""
     paa_gerado_sem_documento_e_ata = PaaFactory.create(
         periodo_paa=periodo_paa_1,
@@ -193,6 +194,7 @@ def test_paas_afetados_gerado_retificado(base_service, periodo_paa_1, ata_paa_fa
         versao=DocumentoPaa.VersaoChoices.FINAL,
         status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
     )
+    replica_paa_factory.create(paa=paa_retificacao)
 
     paas_gerados_retificados = base_service._paas_afetados_gerado_retificado()
 
@@ -213,7 +215,8 @@ def test_paa_em_elaboracao_true(base_service, periodo_paa):
 
 
 @pytest.mark.django_db
-def test_paa_em_elaboracao_false(base_service, periodo_paa, ata_paa_factory, documento_paa_factory):
+def test_paa_em_elaboracao_false(
+        base_service, periodo_paa, ata_paa_factory, documento_paa_factory, replica_paa_factory):
     """Testa verificação quando PAA não está em elaboração"""
     paa = PaaFactory.create(
         periodo_paa=periodo_paa,
@@ -229,6 +232,7 @@ def test_paa_em_elaboracao_false(base_service, periodo_paa, ata_paa_factory, doc
         versao=DocumentoPaa.VersaoChoices.FINAL,
         status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
     )
+    replica_paa_factory.create(paa=paa)
 
     assert base_service._paa_gerado_retificado(paa) is True
 
@@ -276,7 +280,8 @@ def test_paa_gerado_retificado_gerado(base_service, periodo_paa, ata_paa_factory
 
 
 @pytest.mark.django_db
-def test_paa_gerado_retificacao_true(base_service, periodo_paa, ata_paa_factory, documento_paa_factory):
+def test_paa_gerado_retificacao_true(
+        base_service, periodo_paa, ata_paa_factory, documento_paa_factory, replica_paa_factory):
     """Testa verificação para PAA em retificação"""
     paa = PaaFactory.create(
         periodo_paa=periodo_paa,
@@ -291,6 +296,7 @@ def test_paa_gerado_retificacao_true(base_service, periodo_paa, ata_paa_factory,
         paa=paa,
         status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
     )
+    replica_paa_factory.create(paa=paa)
     assert base_service._paa_gerado_retificado(paa) is True
 
 

--- a/sme_ptrf_apps/paa/tests/services/test_plano_orcamentario_integracao.py
+++ b/sme_ptrf_apps/paa/tests/services/test_plano_orcamentario_integracao.py
@@ -1,0 +1,777 @@
+"""
+Suite de integração — PlanoOrcamentarioService + fluxo PAA → GERADO → RETIFICAÇÃO
+
+Valida o ciclo completo:
+  1. Criação de um PAA com receitas PTRF, PDDE, Recursos Próprios e Outros Recursos
+  2. Vinculação de prioridades que consomem o saldo de cada fonte
+  3. Informação de introdução, conclusão e objetivos
+  4. Transição para status GERADO
+  5. Início da retificação (criação da réplica-snapshot)
+  6. Modificação de receitas e prioridades
+  7. Verificação de que _calcular_secao_ptrf(), _calcular_secao_pdde() e
+     _calcular_secao_outros_recursos() retornam dicts com a prop 'historicos'
+     indicando corretamente: None (sem alteração), 'adicionado', 'modificado', 'removido'.
+"""
+
+import pytest
+from decimal import Decimal
+from datetime import date
+from unittest.mock import patch
+
+from sme_ptrf_apps.paa.services.plano_orcamentario_service import PlanoOrcamentarioService
+from sme_ptrf_apps.paa.services.retificacao_paa_service import RetificacaoPaaService
+from sme_ptrf_apps.paa.models import AtaPaa, DocumentoPaa
+from sme_ptrf_apps.paa.enums import PaaStatusEnum, RecursoOpcoesEnum
+from sme_ptrf_apps.core.fixtures.factories import AcaoAssociacaoFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# helpers
+
+def _saldo_zero():
+    """Retorna saldo zerado para mock de AcaoAssociacao.saldo_atual()."""
+    return {'saldo_atual_custeio': 0.0, 'saldo_atual_capital': 0.0, 'saldo_atual_livre': 0.0}
+
+
+def _service(paa):
+    return PlanoOrcamentarioService(paa)
+
+
+# fixtures locais
+
+@pytest.fixture
+def periodo_paa_integ(periodo_paa_factory):
+    return periodo_paa_factory.create(
+        referencia='Integ 2025',
+        data_inicial=date(2025, 1, 1),
+        data_final=date(2025, 12, 31),
+    )
+
+
+@pytest.fixture
+def paa_integ(paa_factory, periodo_paa_integ, associacao):
+    return paa_factory.create(
+        periodo_paa=periodo_paa_integ,
+        associacao=associacao,
+        texto_introducao='Introdução original do PAA.',
+        texto_conclusao='Conclusão original do PAA.',
+    )
+
+
+@pytest.fixture
+def acao_ptrf(acao_factory):
+    """Ação PTRF que aceita custeio e capital (exibir_paa=True por padrão)."""
+    return acao_factory(
+        nome='Ação PTRF Integração',
+        aceita_custeio=True,
+        aceita_capital=True,
+        aceita_livre=False,
+    )
+
+
+@pytest.fixture
+def acao_assoc_ptrf(paa_integ, acao_ptrf):
+    return AcaoAssociacaoFactory.create(
+        associacao=paa_integ.associacao,
+        acao=acao_ptrf,
+        status='ATIVA',
+    )
+
+
+@pytest.fixture
+def receita_ptrf(paa_integ, acao_assoc_ptrf, receita_prevista_paa_factory):
+    """Receita PTRF com saldo suficiente para prioridades."""
+    return receita_prevista_paa_factory.create(
+        paa=paa_integ,
+        acao_associacao=acao_assoc_ptrf,
+        previsao_valor_custeio='500.00',
+        previsao_valor_capital='300.00',
+        previsao_valor_livre='0.00',
+    )
+
+
+@pytest.fixture
+def prioridade_ptrf(paa_integ, acao_assoc_ptrf, receita_ptrf, prioridade_paa_factory):
+    """Prioridade PTRF que consome o saldo de custeio integralmente."""
+    return prioridade_paa_factory.create(
+        paa=paa_integ,
+        recurso=RecursoOpcoesEnum.PTRF.name,
+        acao_associacao=acao_assoc_ptrf,
+        acao_pdde=None,
+        programa_pdde=None,
+        tipo_aplicacao='CUSTEIO',
+        valor_total='500.00',
+    )
+
+
+@pytest.fixture
+def acao_pdde_integ(acao_pdde_factory):
+    return acao_pdde_factory.create(
+        aceita_custeio=True,
+        aceita_capital=True,
+        aceita_livre_aplicacao=False,
+    )
+
+
+@pytest.fixture
+def receita_pdde_integ(paa_integ, acao_pdde_integ, receita_prevista_pdde_factory):
+    """Receita PDDE com saldo suficiente para prioridades."""
+    return receita_prevista_pdde_factory.create(
+        paa=paa_integ,
+        acao_pdde=acao_pdde_integ,
+        previsao_valor_custeio='800.00',
+        previsao_valor_capital='400.00',
+        previsao_valor_livre='0.00',
+        saldo_custeio='0.00',
+        saldo_capital='0.00',
+        saldo_livre='0.00',
+    )
+
+
+@pytest.fixture
+def prioridade_pdde(paa_integ, acao_pdde_integ, receita_pdde_integ, prioridade_paa_factory):
+    """Prioridade PDDE que consome o saldo de custeio integralmente."""
+    return prioridade_paa_factory.create(
+        paa=paa_integ,
+        recurso=RecursoOpcoesEnum.PDDE.name,
+        acao_pdde=acao_pdde_integ,
+        programa_pdde=acao_pdde_integ.programa,
+        acao_associacao=None,
+        tipo_aplicacao='CUSTEIO',
+        valor_total='800.00',
+    )
+
+
+@pytest.fixture
+def recurso_proprio_integ(paa_integ, recurso_proprio_paa_factory, fonte_recurso_paa_factory):
+    fonte = fonte_recurso_paa_factory.create()
+    return recurso_proprio_paa_factory.create(
+        paa=paa_integ,
+        associacao=paa_integ.associacao,
+        fonte_recurso=fonte,
+        valor='1000.00',
+        descricao='Recurso próprio de integração',
+    )
+
+
+@pytest.fixture
+def outro_recurso_integ(outro_recurso_factory):
+    return outro_recurso_factory.create(
+        nome='Outro Recurso Integração',
+        aceita_custeio=True,
+        aceita_capital=False,
+        aceita_livre_aplicacao=False,
+    )
+
+
+@pytest.fixture
+def outro_recurso_periodo_integ(periodo_paa_integ, outro_recurso_integ, outro_recurso_periodo_factory):
+    # sem unidades → disponível para todas as associações
+    return outro_recurso_periodo_factory.create(
+        periodo_paa=periodo_paa_integ,
+        outro_recurso=outro_recurso_integ,
+        ativo=True,
+    )
+
+
+@pytest.fixture
+def receita_outro_recurso(paa_integ, outro_recurso_periodo_integ,
+                          receita_prevista_outro_recurso_periodo_factory):
+    return receita_prevista_outro_recurso_periodo_factory.create(
+        paa=paa_integ,
+        outro_recurso_periodo=outro_recurso_periodo_integ,
+        previsao_valor_custeio='600.00',
+        previsao_valor_capital='0.00',
+        previsao_valor_livre='0.00',
+        saldo_custeio='0.00',
+        saldo_capital='0.00',
+        saldo_livre='0.00',
+    )
+
+
+@pytest.fixture
+def prioridade_outro_recurso(paa_integ, outro_recurso_integ, receita_outro_recurso,
+                             prioridade_paa_factory):
+    """Prioridade Outro Recurso que consome o saldo de custeio integralmente."""
+    return prioridade_paa_factory.create(
+        paa=paa_integ,
+        recurso=RecursoOpcoesEnum.OUTRO_RECURSO.name,
+        outro_recurso=outro_recurso_integ,
+        acao_associacao=None,
+        acao_pdde=None,
+        programa_pdde=None,
+        tipo_aplicacao='CUSTEIO',
+        valor_total='600.00',
+    )
+
+
+@pytest.fixture
+def objetivo_integ(paa_integ, objetivo_paa_factory):
+    objetivo = objetivo_paa_factory.create(paa=paa_integ)
+    paa_integ.objetivos.add(objetivo)
+    return objetivo
+
+
+@pytest.fixture
+def paa_completo_gerado(
+    paa_integ,
+    receita_ptrf, prioridade_ptrf,
+    receita_pdde_integ, prioridade_pdde,
+    recurso_proprio_integ,
+    receita_outro_recurso, prioridade_outro_recurso,
+    objetivo_integ,
+    ata_paa_factory, documento_paa_factory,
+):
+    """
+    PAA com todos os dados (PTRF, PDDE, RecursoPróprio, OutrosRecursos,
+    prioridades, objetivos) em estado GERADO.
+    """
+    ata_paa_factory.create(
+        paa=paa_integ,
+        status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+    )
+    documento_paa_factory.create(
+        paa=paa_integ,
+        versao=DocumentoPaa.VersaoChoices.FINAL,
+        status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
+    )
+    paa_integ.status = PaaStatusEnum.GERADO.name
+    paa_integ.save()
+    return paa_integ
+
+
+@pytest.fixture
+def paa_em_retificacao(paa_completo_gerado, replica_paa_factory):
+    """
+    PAA em EM_RETIFICACAO com réplica (snapshot do estado GERADO).
+    O snapshot é gerado via RetificacaoPaaService para garantir fidelidade
+    ao que a aplicação produziria.
+    """
+    snapshot = RetificacaoPaaService(paa_completo_gerado, None).gerar_snapshot()
+    replica_paa_factory.create(
+        paa=paa_completo_gerado,
+        historico=snapshot,
+    )
+    paa_completo_gerado.status = PaaStatusEnum.EM_RETIFICACAO.name
+    paa_completo_gerado.save()
+    return paa_completo_gerado
+
+
+# Testes: PAA sem retificação (EM_ELABORACAO)
+
+class TestPlanoOrcamentarioPaaEmElaboracao:
+    """
+    PAA sem réplica: a prop 'historicos' deve ser None em todas as linhas,
+    pois não há snapshot para comparar.
+    """
+
+    def test_secao_ptrf_historicos_none_sem_retificacao(
+        self, paa_integ, acao_assoc_ptrf, receita_ptrf
+    ):
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_integ)
+            receitas = svc._obter_receitas_ptrf()
+            prioridades = svc._obter_prioridades_agrupadas()
+            secao = svc._calcular_secao_ptrf(receitas, prioridades['PTRF'])
+
+        assert secao is not None, "Seção PTRF deve ser criada quando há receitas"
+        linhas_acao = [linha for linha in secao['linhas'] if not linha.get('isTotal')]
+        assert linhas_acao, "Deve haver ao menos uma linha de ação"
+        assert all(linha['historicos'] is None for linha in linhas_acao), (
+            "historicos deve ser None quando não há retificação em curso"
+        )
+
+    def test_secao_pdde_historicos_none_sem_retificacao(
+        self, paa_integ, receita_pdde_integ, prioridade_pdde
+    ):
+        svc = _service(paa_integ)
+        acoes_pdde = svc._obter_acoes_pdde_totais()
+        prioridades = svc._obter_prioridades_agrupadas()
+        secao = svc._calcular_secao_pdde(acoes_pdde, prioridades['PDDE'])
+
+        assert secao is not None, "Seção PDDE deve ser criada quando há receitas"
+        linhas_acao = [linha for linha in secao['linhas'] if not linha.get('isTotal')]
+        assert linhas_acao, "Deve haver ao menos uma linha de ação"
+        assert all(linha['historicos'] is None for linha in linhas_acao), (
+            "historicos deve ser None quando não há retificação em curso"
+        )
+
+    def test_secao_outros_recursos_historicos_none_sem_retificacao(
+        self, paa_integ, recurso_proprio_integ, receita_outro_recurso
+    ):
+        svc = _service(paa_integ)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None, "Seção Outros Recursos deve ser criada"
+        linhas_recurso = [linha for linha in secao['linhas'] if not linha.get('isTotal')]
+        assert linhas_recurso, "Deve haver ao menos uma linha de recurso"
+        assert all(linha['historicos'] is None for linha in linhas_recurso), (
+            "historicos deve ser None quando não há retificação em curso"
+        )
+
+    def test_construir_plano_completo_sem_retificacao_inclui_tres_secoes(
+        self, paa_integ, acao_assoc_ptrf, receita_ptrf, prioridade_ptrf,
+        receita_pdde_integ, prioridade_pdde,
+        recurso_proprio_integ, receita_outro_recurso, prioridade_outro_recurso,
+    ):
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_integ)
+            plano = svc.construir_plano_orcamentario()
+
+        chaves = [s['key'] for s in plano['secoes']]
+        assert 'ptrf' in chaves
+        assert 'pdde' in chaves
+        assert 'outros_recursos' in chaves
+
+
+# Testes: PAA em retificação — historicos reflete alterações
+class TestPlanoOrcamentarioPaaRetificacaoHistoricos:
+    """
+    Após criar réplica-snapshot e modificar dados do PAA,
+    a prop 'historicos' nas linhas de cada seção deve refletir a ação:
+      - None: item não foi alterado em relação ao snapshot
+      - 'adicionado': item inexistia no snapshot e foi inserido
+      - 'modificado': item existia no snapshot mas teve valores alterados
+      - 'removido': item existia no snapshot mas foi removido
+    """
+
+    # Seção PTRF
+    def test_secao_ptrf_historicos_none_para_receita_inalterada(
+        self, paa_em_retificacao, acao_assoc_ptrf, receita_ptrf
+    ):
+        """Receita PTRF não modificada após o snapshot → historicos = None."""
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_em_retificacao)
+            receitas = svc._obter_receitas_ptrf()
+            prioridades = svc._obter_prioridades_agrupadas()
+            secao = svc._calcular_secao_ptrf(receitas, prioridades['PTRF'])
+
+        assert secao is not None
+        # a key na linha é str(acao.uuid), não str(acao_associacao.uuid)
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(acao_assoc_ptrf.acao.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] is None
+
+    def test_secao_ptrf_historicos_modificado_apos_alterar_previsao_custeio(
+        self, paa_em_retificacao, acao_assoc_ptrf, receita_ptrf
+    ):
+        """Alterar previsão de custeio de uma receita PTRF → historicos = 'modificado'."""
+        receita_ptrf.previsao_valor_custeio = Decimal('999.00')
+        receita_ptrf.save()
+
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_em_retificacao)
+            receitas = svc._obter_receitas_ptrf()
+            prioridades = svc._obter_prioridades_agrupadas()
+            secao = svc._calcular_secao_ptrf(receitas, prioridades['PTRF'])
+
+        assert secao is not None
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(acao_assoc_ptrf.acao.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] == 'modificado'
+
+    def test_secao_ptrf_historicos_adicionado_ao_inserir_nova_acao(
+        self, paa_em_retificacao, acao_factory, receita_prevista_paa_factory
+    ):
+        """
+        Adicionar nova AcaoAssociacao + ReceitaPrevistaPaa após o snapshot
+        → historicos = 'adicionado' para a nova ação.
+        """
+        nova_acao = acao_factory(
+            nome='Nova Ação PTRF Pós-Snapshot',
+            aceita_custeio=True,
+            aceita_capital=False,
+            aceita_livre=False,
+        )
+        nova_acao_assoc = AcaoAssociacaoFactory.create(
+            associacao=paa_em_retificacao.associacao,
+            acao=nova_acao,
+            status='ATIVA',
+        )
+        receita_prevista_paa_factory.create(
+            paa=paa_em_retificacao,
+            acao_associacao=nova_acao_assoc,
+            previsao_valor_custeio='250.00',
+            previsao_valor_capital='0.00',
+            previsao_valor_livre='0.00',
+        )
+
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_em_retificacao)
+            receitas = svc._obter_receitas_ptrf()
+            prioridades = svc._obter_prioridades_agrupadas()
+            secao = svc._calcular_secao_ptrf(receitas, prioridades['PTRF'])
+
+        assert secao is not None
+        linha_nova = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(nova_acao.uuid)),
+            None,
+        )
+        assert linha_nova is not None, "Nova ação deve aparecer na seção PTRF"
+        assert linha_nova['historicos'] == 'adicionado'
+
+    def test_secao_ptrf_historicos_removido_ao_excluir_receita(
+        self, paa_em_retificacao, acao_assoc_ptrf, receita_ptrf
+    ):
+        """
+        Remover a ReceitaPrevistaPaa após o snapshot mantém a linha fora da seção,
+        mas o snapshot a registra como 'removido' nas alterações.
+        O snapshot marcará a ação como removida; a seção não terá linha para ela
+        (pois não há receita para exibir), mas a propriedade alteracao estará disponível.
+        """
+        uuid_acao_assoc = str(acao_assoc_ptrf.uuid)
+        receita_ptrf.delete()
+
+        svc = _service(paa_em_retificacao)
+        alteracoes = svc._obter_alteracoes()
+
+        # A ação deve aparecer como 'removida' nas alterações de receitas_ptrf
+        assert 'receitas_ptrf' in alteracoes
+        assert uuid_acao_assoc in alteracoes['receitas_ptrf']
+        assert alteracoes['receitas_ptrf'][uuid_acao_assoc]['acao'] == 'removido'
+
+    # Seção PDDE
+    def test_secao_pdde_historicos_none_para_acao_inalterada(
+        self, paa_em_retificacao, acao_pdde_integ, receita_pdde_integ
+    ):
+        """Ação PDDE não modificada após o snapshot → historicos = None."""
+        svc = _service(paa_em_retificacao)
+        acoes_pdde = svc._obter_acoes_pdde_totais()
+        prioridades = svc._obter_prioridades_agrupadas()
+        secao = svc._calcular_secao_pdde(acoes_pdde, prioridades['PDDE'])
+
+        assert secao is not None
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(acao_pdde_integ.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] is None
+
+    def test_secao_pdde_historicos_modificado_apos_alterar_receita(
+        self, paa_em_retificacao, acao_pdde_integ, receita_pdde_integ
+    ):
+        """Alterar previsão de custeio de uma receita PDDE → historicos = 'modificado'."""
+        receita_pdde_integ.previsao_valor_custeio = Decimal('1500.00')
+        receita_pdde_integ.save()
+
+        svc = _service(paa_em_retificacao)
+        acoes_pdde = svc._obter_acoes_pdde_totais()
+        prioridades = svc._obter_prioridades_agrupadas()
+        secao = svc._calcular_secao_pdde(acoes_pdde, prioridades['PDDE'])
+
+        assert secao is not None
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(acao_pdde_integ.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] == 'modificado'
+
+    def test_secao_pdde_historicos_adicionado_ao_inserir_nova_acao(
+        self, paa_em_retificacao, acao_pdde_factory, receita_prevista_pdde_factory
+    ):
+        """
+        Inserir nova AcaoPdde + ReceitaPrevistaPdde após o snapshot
+        → historicos = 'adicionado' para a nova ação.
+        """
+        nova_acao_pdde = acao_pdde_factory.create(
+            aceita_custeio=True,
+            aceita_capital=False,
+            aceita_livre_aplicacao=False,
+        )
+        receita_prevista_pdde_factory.create(
+            paa=paa_em_retificacao,
+            acao_pdde=nova_acao_pdde,
+            previsao_valor_custeio='400.00',
+            previsao_valor_capital='0.00',
+            previsao_valor_livre='0.00',
+            saldo_custeio='0.00',
+            saldo_capital='0.00',
+            saldo_livre='0.00',
+        )
+
+        svc = _service(paa_em_retificacao)
+        acoes_pdde = svc._obter_acoes_pdde_totais()
+        prioridades = svc._obter_prioridades_agrupadas()
+        secao = svc._calcular_secao_pdde(acoes_pdde, prioridades['PDDE'])
+
+        assert secao is not None
+        linha_nova = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(nova_acao_pdde.uuid)),
+            None,
+        )
+        assert linha_nova is not None, "Nova ação PDDE deve aparecer na seção"
+        assert linha_nova['historicos'] == 'adicionado'
+
+    def test_secao_pdde_historicos_removido_ao_excluir_receita(
+        self, paa_em_retificacao, acao_pdde_integ, receita_pdde_integ
+    ):
+        """
+        Remover ReceitaPrevistaPdde após o snapshot → ação aparece como 'removida'
+        nas alterações (verificação via _obter_alteracoes).
+        """
+        uuid_acao_pdde = str(acao_pdde_integ.uuid)
+        receita_pdde_integ.delete()
+
+        svc = _service(paa_em_retificacao)
+        alteracoes = svc._obter_alteracoes()
+
+        assert 'receitas_pdde' in alteracoes
+        assert uuid_acao_pdde in alteracoes['receitas_pdde']
+        assert alteracoes['receitas_pdde'][uuid_acao_pdde]['acao'] == 'removido'
+
+    # Seção Outros Recursos
+    def test_secao_outros_recursos_historicos_none_para_recurso_inalterado(
+        self, paa_em_retificacao, outro_recurso_integ, receita_outro_recurso
+    ):
+        """Outro Recurso não modificado após snapshot → historicos = None."""
+        svc = _service(paa_em_retificacao)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None
+        # key na linha é str(outro_recurso.uuid), não str(outro_recurso_periodo.uuid)
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(outro_recurso_integ.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] is None
+
+    def test_secao_outros_recursos_historicos_modificado_apos_alterar_receita(
+        self, paa_em_retificacao, outro_recurso_integ, receita_outro_recurso
+    ):
+        """Alterar previsão de custeio de receita Outro Recurso → historicos = 'modificado'."""
+        receita_outro_recurso.previsao_valor_custeio = Decimal('900.00')
+        receita_outro_recurso.save()
+
+        svc = _service(paa_em_retificacao)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None
+        linha = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(outro_recurso_integ.uuid)),
+            None,
+        )
+        assert linha is not None
+        assert linha['historicos'] == 'modificado'
+
+    def test_secao_outros_recursos_historicos_adicionado_para_novo_outro_recurso(
+        self, paa_em_retificacao, periodo_paa_integ,
+        outro_recurso_factory, outro_recurso_periodo_factory,
+        receita_prevista_outro_recurso_periodo_factory,
+    ):
+        """
+        Inserir novo OutroRecurso + ReceitaPrevistaOutroRecursoPeriodo após snapshot
+        → historicos = 'adicionado' para o novo recurso.
+        """
+        novo_outro_recurso = outro_recurso_factory.create(
+            nome='Outro Recurso Novo Pós-Snapshot',
+            aceita_custeio=True,
+            aceita_capital=False,
+            aceita_livre_aplicacao=False,
+        )
+        novo_periodo_recurso = outro_recurso_periodo_factory.create(
+            periodo_paa=periodo_paa_integ,
+            outro_recurso=novo_outro_recurso,
+            ativo=True,
+        )
+        receita_prevista_outro_recurso_periodo_factory.create(
+            paa=paa_em_retificacao,
+            outro_recurso_periodo=novo_periodo_recurso,
+            previsao_valor_custeio='300.00',
+            previsao_valor_capital='0.00',
+            previsao_valor_livre='0.00',
+            saldo_custeio='0.00',
+            saldo_capital='0.00',
+            saldo_livre='0.00',
+        )
+
+        svc = _service(paa_em_retificacao)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None
+        linha_nova = next(
+            (linha for linha in secao['linhas'] if linha['key'] == str(novo_outro_recurso.uuid)),
+            None,
+        )
+        assert linha_nova is not None, "Novo Outro Recurso deve aparecer na seção"
+        assert linha_nova['historicos'] == 'adicionado'
+
+    def test_secao_outros_recursos_recurso_proprio_historicos_adicionado(
+        self, paa_em_retificacao, recurso_proprio_integ,
+        recurso_proprio_paa_factory, fonte_recurso_paa_factory,
+    ):
+        """
+        Adicionar novo RecursoProprioPaa após snapshot
+        → historicos agregado = 'adicionado' na linha RECURSO_PROPRIO.
+        """
+        fonte = fonte_recurso_paa_factory.create()
+        recurso_proprio_paa_factory.create(
+            paa=paa_em_retificacao,
+            associacao=paa_em_retificacao.associacao,
+            fonte_recurso=fonte,
+            valor='500.00',
+            descricao='Novo recurso próprio pós-snapshot',
+        )
+
+        svc = _service(paa_em_retificacao)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None
+        linha_rp = next(
+            (linha for linha in secao['linhas'] if linha['key'] == 'RECURSO_PROPRIO'),
+            None,
+        )
+        assert linha_rp is not None
+        assert linha_rp['historicos'] == 'adicionado'
+
+    def test_secao_outros_recursos_recurso_proprio_historicos_modificado(
+        self, paa_em_retificacao, recurso_proprio_integ
+    ):
+        """
+        Alterar o valor de um RecursoProprioPaa existente após snapshot
+        → historicos agregado = 'modificado' na linha RECURSO_PROPRIO.
+        """
+        recurso_proprio_integ.valor = Decimal('9999.00')
+        recurso_proprio_integ.save()
+
+        svc = _service(paa_em_retificacao)
+        receitas = svc._obter_receitas_outros_recursos()
+        prioridades = svc._obter_prioridades_outros_recursos()
+        secao = svc._calcular_secao_outros_recursos(receitas, prioridades)
+
+        assert secao is not None
+        linha_rp = next(
+            (linha for linha in secao['linhas'] if linha['key'] == 'RECURSO_PROPRIO'),
+            None,
+        )
+        assert linha_rp is not None
+        assert linha_rp['historicos'] == 'modificado'
+
+    #  Plano completo
+
+    def test_construir_plano_completo_em_retificacao_inclui_tres_secoes(
+        self, paa_em_retificacao, receita_ptrf, receita_pdde_integ,
+        recurso_proprio_integ, receita_outro_recurso,
+    ):
+        """
+        Valida que construir_plano_orcamentario() retorna as três seções
+        (ptrf, pdde, outros_recursos) no PAA em retificação.
+        """
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_em_retificacao)
+            plano = svc.construir_plano_orcamentario()
+
+        chaves = [s['key'] for s in plano['secoes']]
+        assert 'ptrf' in chaves
+        assert 'pdde' in chaves
+        assert 'outros_recursos' in chaves
+
+    def test_construir_plano_historicos_aparecem_em_secoes_com_alteracao(
+        self, paa_em_retificacao, receita_ptrf, acao_assoc_ptrf,
+        receita_pdde_integ, acao_pdde_integ,
+        recurso_proprio_integ, receita_outro_recurso, outro_recurso_integ,
+    ):
+        """
+        Após modificar receitas em todas as seções, confirma que 'historicos'
+        aparece em cada seção do plano orçamentário completo.
+        """
+        # Modifica receita PTRF
+        receita_ptrf.previsao_valor_custeio = Decimal('111.00')
+        receita_ptrf.save()
+
+        # Modifica receita PDDE
+        receita_pdde_integ.previsao_valor_custeio = Decimal('222.00')
+        receita_pdde_integ.save()
+
+        # Modifica receita Outro Recurso
+        receita_outro_recurso.previsao_valor_custeio = Decimal('333.00')
+        receita_outro_recurso.save()
+
+        with patch(
+            'sme_ptrf_apps.core.models.acao_associacao.AcaoAssociacao.saldo_atual',
+            return_value=_saldo_zero(),
+        ):
+            svc = _service(paa_em_retificacao)
+            plano = svc.construir_plano_orcamentario()
+
+        secoes = {s['key']: s for s in plano['secoes']}
+
+        # Seção PTRF: linha da ação modificada deve ter historicos = 'modificado'
+        secao_ptrf = secoes['ptrf']
+        linha_ptrf = next(
+            (linha for linha in secao_ptrf['linhas'] if linha['key'] == str(acao_assoc_ptrf.acao.uuid)),
+            None,
+        )
+        assert linha_ptrf is not None
+        assert linha_ptrf['historicos'] == 'modificado'
+
+        # Seção PDDE: linha da ação modificada deve ter historicos = 'modificado'
+        secao_pdde = secoes['pdde']
+        linha_pdde = next(
+            (linha for linha in secao_pdde['linhas'] if linha['key'] == str(acao_pdde_integ.uuid)),
+            None,
+        )
+        assert linha_pdde is not None
+        assert linha_pdde['historicos'] == 'modificado'
+
+        # Seção Outros Recursos: linha do outro recurso modificado deve ter historicos = 'modificado'
+        secao_outros = secoes['outros_recursos']
+        linha_outro = next(
+            (linha for linha in secao_outros['linhas'] if linha['key'] == str(outro_recurso_integ.uuid)),
+            None,
+        )
+        assert linha_outro is not None
+        assert linha_outro['historicos'] == 'modificado'
+
+    def test_cache_alteracoes_reutilizado_entre_chamadas(
+        self, paa_em_retificacao, receita_ptrf
+    ):
+        """
+        _obter_alteracoes() deve cachear o resultado na instância do service
+        para evitar consultas desnecessárias ao banco em chamadas subsequentes.
+        """
+        svc = _service(paa_em_retificacao)
+
+        resultado1 = svc._obter_alteracoes()
+        resultado2 = svc._obter_alteracoes()
+
+        assert resultado1 is resultado2, (
+            "O resultado de _obter_alteracoes() deve ser o mesmo objeto (cache)"
+        )


### PR DESCRIPTION

Esse PR:

- Adiciona Obtenção de alterações de PAA em retificação (RetificacaoPaaService)
- Inclusão de Condição de status de Andamento no PAA(Admin/Model)
- Adiciona Tratamento de Exceção no congelamento de Saldo quando não hover período PTRF relacionado à data de congelamento.
- Corrige a obtenção de período pelo método Periodo.da_data_por_recurso em congelamento de saldo (Após implementação de Prêmio)
- Adiciona cenários de Status de PAA Fora de Fluxo, considerando Elaboração e Retificação
- Adiciona select_related em querysets para melhoria de performance
- Ajustes e inclusões de testes


História [AB#145740](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145740)
