### PR TITLE
feat(148189): remove os períodos iniciais para perfil SME

### DIFF
--- a/sme_ptrf_apps/core/api/views/periodos_viewset.py
+++ b/sme_ptrf_apps/core/api/views/periodos_viewset.py
@@ -10,7 +10,7 @@ from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
 from ..serializers.periodo_serializer import (PeriodoSerializer, PeriodoLookUpSerializer, PeriodoRetrieveSerializer,
                                               PeriodoCreateSerializer)
 from ...models import Periodo, PeriodoInicialAssociacao, Associacao, Recurso
-from ...services import valida_datas_periodo
+from ...services import valida_datas_periodo, get_periodo_corte_por_dre, get_periodo_corte
 
 
 class PeriodosViewSet(mixins.ListModelMixin,
@@ -58,7 +58,7 @@ class PeriodosViewSet(mixins.ListModelMixin,
 
         dre_uuid = self.request.query_params.get('dre_uuid')
         if dre_uuid:
-            periodo_corte = self.get_periodo_corte_por_dre(dre_uuid)
+            periodo_corte = get_periodo_corte_por_dre(dre_uuid=dre_uuid, recurso=self.request.recurso)
 
             if not periodo_corte:
                 qs = qs.none()
@@ -67,43 +67,18 @@ class PeriodosViewSet(mixins.ListModelMixin,
                     data_inicio_realizacao_despesas__gte=periodo_corte.data_inicio_realizacao_despesas
                 )
 
-        return qs.order_by('-referencia')
+        solicitacao_sme = self.request.query_params.get('solicitacao_sme', 'false').lower() == 'true'
+        if solicitacao_sme:
+            periodo_corte_sme = get_periodo_corte(recurso=self.request.recurso)
 
-    def get_periodo_corte_por_dre(self, dre_uuid):
-        recurso = getattr(self.request, 'recurso', None)
-        if not recurso:
-            return None
-
-        periodo_inicial_assoc = (
-            PeriodoInicialAssociacao.objects
-            .filter(
-                associacao__unidade__dre__uuid=dre_uuid,
-                recurso=recurso,
-            )
-            .select_related('periodo_inicial')
-            .order_by('periodo_inicial__data_inicio_realizacao_despesas')
-            .first()
-        )
-
-        if periodo_inicial_assoc and periodo_inicial_assoc.periodo_inicial:
-            return periodo_inicial_assoc.periodo_inicial.proximo_periodo
-
-        if recurso.legado:
-            associacao_legado = (
-                Associacao.objects
-                .filter(
-                    unidade__dre__uuid=dre_uuid,
-                    periodo_inicial__isnull=False,
+            if not periodo_corte_sme:
+                qs = qs.none()
+            else:
+                qs = qs.filter(
+                    data_inicio_realizacao_despesas__gte=periodo_corte_sme.data_inicio_realizacao_despesas
                 )
-                .select_related('periodo_inicial')
-                .order_by('periodo_inicial__data_inicio_realizacao_despesas')
-                .first()
-            )
 
-            if associacao_legado and associacao_legado.periodo_inicial:
-                return associacao_legado.periodo_inicial.proximo_periodo
-
-        return None
+        return qs.order_by('-referencia')
 
     def get_serializer_class(self):
         if self.action == 'retrieve':

--- a/sme_ptrf_apps/core/services/__init__.py
+++ b/sme_ptrf_apps/core/services/__init__.py
@@ -23,7 +23,7 @@ from .info_por_acao_services import (
 )
 from .membro_associacao_service import TerceirizadasException, TerceirizadasService, SmeIntegracaoApiException, SmeIntegracaoApiService, retorna_membros_do_conselho_fiscal_por_associacao
 from sme_ptrf_apps.core.services.notificacao_services.notificacao_inicio_periodo_prestacao_de_contas import notificar_inicio_periodo_prestacao_de_contas
-from .periodo_services import status_prestacao_conta_associacao, valida_datas_periodo
+from .periodo_services import status_prestacao_conta_associacao, valida_datas_periodo, get_periodo_corte_por_dre, get_periodo_corte
 from .prestacao_contas_services import (
     concluir_prestacao_de_contas,
     informacoes_financeiras_para_atas,

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -3,7 +3,7 @@ from django.apps import apps
 from functools import lru_cache
 from django.db import models
 from datetime import timedelta
-from ..models import Associacao, Periodo, PrestacaoConta
+from ..models import Associacao, Periodo, PrestacaoConta, PeriodoInicialAssociacao
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
@@ -237,3 +237,54 @@ def validar_troca_recurso(periodo, recurso_novo):
         raise ValidationError(
             "Não é possível alterar o recurso de um período já utilizado."
         )
+
+
+def _primeiro_periodo_inicial_associado(recurso, dre_uuid=None):
+    queryset = (
+        PeriodoInicialAssociacao.objects
+        .filter(recurso=recurso)
+        .select_related('periodo_inicial')
+    )
+
+    if dre_uuid is not None:
+        queryset = queryset.filter(associacao__unidade__dre__uuid=dre_uuid)
+
+    return queryset.order_by('periodo_inicial__data_inicio_realizacao_despesas').first()
+
+
+def _primeira_associacao_com_periodo_inicial_legado(dre_uuid=None):
+    queryset = (
+        Associacao.objects
+        .filter(periodo_inicial__isnull=False)
+        .select_related('periodo_inicial')
+    )
+
+    if dre_uuid is not None:
+        queryset = queryset.filter(unidade__dre__uuid=dre_uuid)
+
+    return queryset.order_by('periodo_inicial__data_inicio_realizacao_despesas').first()
+
+
+def get_periodo_corte(recurso, dre_uuid=None):
+    if not recurso:
+        return None
+
+    periodo_inicial_assoc = _primeiro_periodo_inicial_associado(recurso=recurso, dre_uuid=dre_uuid)
+
+    if periodo_inicial_assoc and periodo_inicial_assoc.periodo_inicial:
+        return periodo_inicial_assoc.periodo_inicial.proximo_periodo
+
+    if recurso.legado:
+        associacao_legado = _primeira_associacao_com_periodo_inicial_legado(dre_uuid=dre_uuid)
+
+        if associacao_legado and associacao_legado.periodo_inicial:
+            return associacao_legado.periodo_inicial.proximo_periodo
+
+    return None
+
+
+def get_periodo_corte_por_dre(dre_uuid, recurso):
+    if not dre_uuid or not recurso:
+        return None
+
+    return get_periodo_corte(recurso=recurso, dre_uuid=dre_uuid)


### PR DESCRIPTION
Este PR inclui:

- Lista períodos sem períodos iniciais para perfil SME, enviando o parâmetro `solicitacao_sme`;
- Move função de captura do período inicial para dentro do periodo_services;

História: [AB#140952](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/140952)
Tarefa: [AB#148189](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148189)