### PR TITLE
fix(147699): corrige inconsistência na devolução de PC

### DIFF
--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -608,21 +608,31 @@ class PrestacaoConta(ModeloBase):
     @transaction.atomic
     def devolver(self, data_limite_ue):
         from ..services.notificacao_services import notificar_prestacao_de_contas_devolvida_para_acertos
-        from ..models import DevolucaoPrestacaoConta
+        from ..models import DevolucaoPrestacaoConta, AnalisePrestacaoConta
+        
         devolucao = DevolucaoPrestacaoConta.objects.create(
             prestacao_conta=self,
             data=date.today(),
             data_limite_ue=data_limite_ue
         )
 
-        if self.analise_atual:
-            self.analise_atual.devolucao_prestacao_conta = devolucao
-            self.analise_atual.status = self.STATUS_DEVOLVIDA
-            self.analise_atual.save()
+        analise_id = self.analise_atual_id
 
-        self.analise_atual = None
+        if analise_id:
+            AnalisePrestacaoConta.objects.filter(
+                id=analise_id
+            ).update(
+                devolucao_prestacao_conta=devolucao,
+                status=self.STATUS_DEVOLVIDA
+            )
+
+        self.analise_atual_id = None
         self.justificativa_pendencia_realizacao = ""
-        self.save()
+
+        self.save(update_fields=[
+            "analise_atual",
+            "justificativa_pendencia_realizacao"
+        ])
 
         notificar_prestacao_de_contas_devolvida_para_acertos(self, data_limite_ue)
         return self


### PR DESCRIPTION
# O que este PR faz
- Corrige um cenário de inconsistência no fluxo de devolução da prestação de contas, onde em casos específicos a devolução era criada e a prestação tinha a análise atual removida, porém a análise vinculada não persistia corretamente o status e o vínculo da devolução

Referência Azure: [AB#147699](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/147699)