### PR TITLE
 hotfix(148542): ajusta geração documento PAA para  obter_receitas_previstas filtro recurso legado

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.38.3"
+__version__ = "9.38.4"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/services/plano_orcamentario_service.py
+++ b/sme_ptrf_apps/paa/services/plano_orcamentario_service.py
@@ -6,6 +6,7 @@ from django.db.models import Sum
 from sme_ptrf_apps.paa.models import Paa, RecursoProprioPaa
 from sme_ptrf_apps.paa.querysets import queryset_prioridades_paa
 from sme_ptrf_apps.paa.enums import RecursoOpcoesEnum
+from sme_ptrf_apps.paa.services.acoes_paa_service import AcoesPaaService
 
 logger = logging.getLogger(__name__)
 
@@ -116,9 +117,7 @@ class PlanoOrcamentarioService:
         Obtém receitas PTRF formatadas com saldos atuais e congelados.
         Retorna lista de receitas com informações completas para cada ação.
         """
-        acoes_associacoes = self.paa.associacao.acoes.select_related('acao').filter(
-            acao__exibir_paa=True
-        ).all()
+        acoes_associacoes = AcoesPaaService(self.paa).obter_ptrf()
 
         receitas = []
         for acao_assoc in acoes_associacoes:


### PR DESCRIPTION
# O que este PR faz

- ajusta geração documento PAA, utilizando método obter_receitas_ptrf em PlanoOrcamentarioService para obter as acoes conforme AcoesPaaService que considera apenas o recurso legado.

Referência Azure: [AB#148542](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148542)