### PR TITLE
feat(147067): Remove cor título

### DIFF
--- a/sme_ptrf_apps/static/css/lauda-pdf.css
+++ b/sme_ptrf_apps/static/css/lauda-pdf.css
@@ -237,10 +237,6 @@ header.lauda-doc-header {
   margin-top: 0.15cm;
 }
 
-.lauda-titulo-reprovadas {
-  color: #b40c02;
-}
-
 .lauda-texto-intro {
   line-height: 1.4;
   margin-bottom: 0.35cm;

--- a/sme_ptrf_apps/templates/pdf/lauda/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/lauda/pdf.html
@@ -73,7 +73,7 @@
 
   {% if dados.tabelas.reprovadas %}
   <article class="col-12 px-0 mt-3">
-    <p class="titulo-tabelas lauda-secao-cabecalho lauda-titulo-reprovadas"><strong>Prestações de contas reprovadas</strong></p>
+    <p class="titulo-tabelas lauda-secao-cabecalho"><strong>Prestações de contas reprovadas</strong></p>
     {% include "pdf/lauda/partials/tabela-lauda.html" with linhas=dados.tabelas.reprovadas %}
   </article>
   {% endif %}


### PR DESCRIPTION
Esse PR:

- Remove cor título de PCS reprovadas na lauda.

História: [AB#147067](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/147067)