### PR TITLE
fix(149139): Adiciona validacao status update ata paa

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.1"
+__version__ = "9.39.2"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/api/serializers/ata_paa_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/ata_paa_serializer.py
@@ -8,6 +8,7 @@ from sme_ptrf_apps.core.api.serializers import AssociacaoInfoAtaSerializer
 from sme_ptrf_apps.paa.api.serializers.presentes_ata_paa_serializer import (PresentesAtaPaaSerializer,
                                                                             PresentesAtaPaaCreateSerializer)
 from sme_ptrf_apps.paa.models import AtaPaa, Paa
+from sme_ptrf_apps.paa.services.validacao_edicao_ata_paa_service import validar_edicao_ata_paa
 from sme_ptrf_apps.utils.update_instance_from_dict import update_instance_from_dict
 
 from waffle import get_waffle_flag_model
@@ -112,6 +113,11 @@ class AtaPaaCreateSerializer(serializers.ModelSerializer):
     def get_nome_ata(self, obj):
         return obj.nome
 
+    def _checar_permite_edicao_ata(self, ata_paa: AtaPaa):
+        validacao = validar_edicao_ata_paa(ata_paa)
+        if not validacao.get('is_valid'):
+            raise serializers.ValidationError({'mensagem': validacao.get('mensagem')})
+
     def create(self, validated_data):
         with transaction.atomic():
             presentes_na_ata_paa = validated_data.pop('presentes_na_ata_paa', [])
@@ -189,6 +195,8 @@ class AtaPaaCreateSerializer(serializers.ModelSerializer):
             return ata_paa
 
     def update(self, instance, validated_data):
+        self._checar_permite_edicao_ata(instance)
+
         with transaction.atomic():
             presentes_json = validated_data.pop('presentes_na_ata_paa', [])
 

--- a/sme_ptrf_apps/paa/services/validacao_edicao_ata_paa_service.py
+++ b/sme_ptrf_apps/paa/services/validacao_edicao_ata_paa_service.py
@@ -1,0 +1,48 @@
+from sme_ptrf_apps.paa.enums import PaaStatusEnum
+from sme_ptrf_apps.paa.models import AtaPaa
+
+
+def validar_edicao_ata_paa(ata_paa: AtaPaa) -> dict:
+    """
+    Valida se a ata pode ser editada (participantes, dados da reunião, etc.).
+
+    Regras:
+    - PAA em retificação: só permite editar a ata de RETIFICACAO; a de apresentação fica congelada.
+    - PAA GERADO: não permite editar ata com PDF já gerado (CONCLUIDO ou EM_PROCESSAMENTO);
+      evita PAA GERADO + ata NAO_GERADO (FORA_FLUXO na listagem).
+    - Demais casos (elaboração, retificação em andamento): permite;
+      o serializer continua invalidando o PDF para obrigar regeração quando aplicável.
+    """
+    paa = ata_paa.paa
+
+    if paa.status == PaaStatusEnum.EM_RETIFICACAO.name:
+        if ata_paa.tipo_ata != AtaPaa.ATA_RETIFICACAO:
+            return {
+                'is_valid': False,
+                'mensagem': (
+                    'Durante a retificação, apenas a ata de retificação pode ser editada. '
+                    'A ata de apresentação original permanece congelada.'
+                ),
+            }
+        return {'is_valid': True}
+
+    if paa.status == PaaStatusEnum.GERADO.name and ata_paa.documento_gerado:
+        if ata_paa.tipo_ata == AtaPaa.ATA_APRESENTACAO:
+            mensagem = (
+                'O Plano Anual já foi concluído e a ata de apresentação já foi gerada. '
+                'Para alterar participantes ou dados da ata, utilize o fluxo de retificação do PAA.'
+            )
+        else:
+            mensagem = (
+                'A ata de retificação já foi gerada. '
+                'Não é possível alterar participantes ou dados da ata neste estado.'
+            )
+        return {'is_valid': False, 'mensagem': mensagem}
+
+    if ata_paa.status_geracao_pdf == AtaPaa.STATUS_EM_PROCESSAMENTO:
+        return {
+            'is_valid': False,
+            'mensagem': 'A ata está sendo gerada. Aguarde a conclusão do processamento.',
+        }
+
+    return {'is_valid': True}

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_service.py
@@ -7,12 +7,14 @@ from model_bakery import baker
 from sme_ptrf_apps.paa.models import AtaPaa
 
 
+from sme_ptrf_apps.paa.enums import PaaStatusEnum
 from sme_ptrf_apps.paa.services.ata_paa_service import (
     gerar_arquivo_ata_paa,
     unidade_precisa_professor_gremio,
     verifica_precisa_professor_gremio,
     validar_geracao_ata_paa,
 )
+from sme_ptrf_apps.paa.services.validacao_edicao_ata_paa_service import validar_edicao_ata_paa
 from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO
 
 pytestmark = pytest.mark.django_db
@@ -255,14 +257,9 @@ class TestGerarArquivoAtaPaa:
 
 
 @pytest.fixture
-def paa_com_documento_concluido(paa):
+def paa_com_documento_concluido(paa, documento_paa_factory):
     """Fixture para PAA com documento final concluído"""
-    baker.make(
-        'DocumentoPaa',
-        paa=paa,
-        status_geracao='CONCLUIDO',
-        versao='FINAL'
-    )
+    documento_paa_factory.create(paa=paa)
     return paa
 
 
@@ -391,3 +388,85 @@ class TestValidarGeracaoAtaPaa:
         assert 'mensagem' in resultado, resultado
         assert 'A ata já está sendo gerada' in resultado['mensagem']
         assert resultado['is_valid'] is False
+
+
+@pytest.mark.django_db
+class TestValidarEdicaoAtaPaa:
+    """Testes para validar_edicao_ata_paa"""
+
+    def test_bloqueia_edicao_ata_apresentacao_quando_paa_gerado_e_pdf_concluido(
+        self, paa_com_documento_concluido, ata_paa_factory,
+    ):
+        paa_com_documento_concluido.status = PaaStatusEnum.GERADO.name
+        paa_com_documento_concluido.save()
+        ata = ata_paa_factory.create(
+            paa=paa_com_documento_concluido,
+            tipo_ata=AtaPaa.ATA_APRESENTACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+
+        resultado = validar_edicao_ata_paa(ata)
+
+        assert resultado['is_valid'] is False
+        assert 'retificação' in resultado['mensagem'].lower()
+
+    def test_permite_edicao_ata_apresentacao_quando_paa_gerado_sem_pdf(
+        self, paa_com_documento_concluido, ata_paa_factory,
+    ):
+        paa_com_documento_concluido.status = PaaStatusEnum.GERADO.name
+        paa_com_documento_concluido.save()
+        ata = ata_paa_factory.create(
+            paa=paa_com_documento_concluido,
+            tipo_ata=AtaPaa.ATA_APRESENTACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        resultado = validar_edicao_ata_paa(ata)
+
+        assert resultado['is_valid'] is True
+
+    def test_permite_edicao_ata_retificacao_durante_retificacao(
+        self, paa_com_documento_concluido, ata_paa_factory,
+    ):
+        paa_com_documento_concluido.status = PaaStatusEnum.EM_RETIFICACAO.name
+        paa_com_documento_concluido.save()
+        ata_ret = ata_paa_factory.create(
+            paa=paa_com_documento_concluido,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        resultado = validar_edicao_ata_paa(ata_ret)
+
+        assert resultado['is_valid'] is True
+
+    def test_permite_reeditar_ata_retificacao_mesmo_com_pdf_para_regerar(
+        self, paa_com_documento_concluido, ata_paa_factory,
+    ):
+        paa_com_documento_concluido.status = PaaStatusEnum.EM_RETIFICACAO.name
+        paa_com_documento_concluido.save()
+        ata_ret = ata_paa_factory.create(
+            paa=paa_com_documento_concluido,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+
+        resultado = validar_edicao_ata_paa(ata_ret)
+
+        assert resultado['is_valid'] is True
+
+    def test_bloqueia_edicao_ata_apresentacao_durante_retificacao(
+        self, paa_com_documento_concluido, ata_paa_factory,
+    ):
+        paa_com_documento_concluido.status = PaaStatusEnum.EM_RETIFICACAO.name
+        paa_com_documento_concluido.save()
+        ata_apresentacao = ata_paa_factory.create(
+            paa=paa_com_documento_concluido,
+            tipo_ata=AtaPaa.ATA_APRESENTACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+
+        resultado = validar_edicao_ata_paa(ata_apresentacao)
+
+        assert resultado['is_valid'] is False
+        assert 'apenas a ata de retificação' in resultado['mensagem'].lower()


### PR DESCRIPTION
Esse PR:

- Valida edição da ata do PAA no PATCH, bloqueando alterações quando o plano já está concluído com PDF gerado.
- Evita PAA GERADO com ata sem PDF, que tirava o plano da listagem vigente.
- Na retificação, só a ata de retificação pode ser editada; a de apresentação fica congelada.

História: [AB#149139](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149139)