### PR TITLE
fix(149227): Bloqueia alteração ata de apresentação após recebimento PC

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.2"
+__version__ = "9.39.3"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/api/serializers/ata_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/ata_serializer.py
@@ -7,11 +7,13 @@ from ...api.serializers import AssociacaoInfoAtaSerializer
 from ...api.serializers.periodo_serializer import PeriodoLookUpSerializer
 from ...api.serializers.presentes_ata_serializer import PresentesAtaSerializer, PresentesAtaCreateSerializer
 from ...models import Ata, PrestacaoConta
+from sme_ptrf_apps.core.services.validacao_edicao_ata_service import validar_edicao_ata_pc
 from sme_ptrf_apps.utils.update_instance_from_dict import update_instance_from_dict
 
 from waffle import get_waffle_flag_model
 
 logger = logging.getLogger(__name__)
+
 
 class AtaLookUpSerializer(serializers.ModelSerializer):
     nome = serializers.SerializerMethodField('get_nome_ata')
@@ -48,7 +50,7 @@ class AtaSerializer(serializers.ModelSerializer):
 
     def get_hora_reuniao(self, obj):
         return obj.hora_reuniao.strftime('%H:%M')
-    
+
     def get_completa(self, obj):
         if obj.completa:
             return True
@@ -102,44 +104,51 @@ class AtaCreateSerializer(serializers.ModelSerializer):
     def get_nome_ata(self, obj):
         return obj.nome
 
+    def _checar_permite_edicao_ata(self, ata: Ata):
+        validacao = validar_edicao_ata_pc(ata)
+        if not validacao.get('is_valid'):
+            raise serializers.ValidationError({'mensagem': validacao.get('mensagem')})
+
     def create(self, validated_data):
         presentes_na_ata = validated_data.pop('presentes_na_ata')
         ata = Ata.objects.create(**validated_data)
 
         presentes_lista = []
-        
+
         flags = get_waffle_flag_model()
         if flags.objects.filter(name='historico-de-membros', everyone=True).exists():
             if validated_data and validated_data["data_reuniao"]:
                 servico_composicao = ServicoRecuperaComposicaoPorData()
-                composicao = servico_composicao.get_composicao_por_data_e_associacao(validated_data["data_reuniao"], ata.associacao)
+                composicao = servico_composicao.get_composicao_por_data_e_associacao(
+                    validated_data["data_reuniao"], ata.associacao
+                )
                 ata.composicao = composicao
             else:
                 ata.composicao = None
-            
+
             for presente in presentes_na_ata:
                 presidente = presente.pop('presidente_da_reuniao', False)
                 secretario = presente.pop('secretario_da_reuniao', False)
-                
+
                 presente_object = PresentesAtaCreateSerializer().create(presente)
                 presente_object.save()
-                
-                if presidente:
-                    ata.presidente_da_reuniao = presentes_object
-                    
-                elif secretario:
-                    ata.secretario_da_reuniao = presentes_object
 
-                presentes_object.eh_conselho_fiscal()
-                presentes_lista.append(presentes_object)
+                if presidente:
+                    ata.presidente_da_reuniao = presente_object
+
+                elif secretario:
+                    ata.secretario_da_reuniao = presente_object
+
+                presente_object.eh_conselho_fiscal()
+                presentes_lista.append(presente_object)
         else:
             for presente in presentes_na_ata:
                 presente.pop('presidente_da_reuniao', None)
                 presente.pop('secretario_da_reuniao', None)
-                
-                presentes_object = PresentesAtaCreateSerializer().create(presente)
-                presentes_object.eh_conselho_fiscal()
-                presentes_lista.append(presentes_object)
+
+                presente_object = PresentesAtaCreateSerializer().create(presente)
+                presente_object.eh_conselho_fiscal()
+                presentes_lista.append(presente_object)
 
         ata.presentes_na_ata.set(presentes_lista)
         ata.arquivo_pdf = None
@@ -149,8 +158,10 @@ class AtaCreateSerializer(serializers.ModelSerializer):
         return ata
 
     def update(self, instance, validated_data):
+        self._checar_permite_edicao_ata(instance)
+
         presentes_json = validated_data.pop('presentes_na_ata')
-        
+
         if instance.presidente_da_reuniao:
             instance.presidente_da_reuniao = None
         if instance.secretario_da_reuniao:
@@ -159,12 +170,14 @@ class AtaCreateSerializer(serializers.ModelSerializer):
 
         instance.presentes_na_ata.all().delete()
         presentes_lista = []
-        
+
         flags = get_waffle_flag_model()
         if flags.objects.filter(name='historico-de-membros', everyone=True).exists():
             if validated_data and validated_data["data_reuniao"]:
                 servico_composicao = ServicoRecuperaComposicaoPorData()
-                composicao = servico_composicao.get_composicao_por_data_e_associacao(validated_data["data_reuniao"], instance.associacao)
+                composicao = servico_composicao.get_composicao_por_data_e_associacao(
+                    validated_data["data_reuniao"], instance.associacao
+                )
                 instance.composicao = composicao
             else:
                 instance.composicao = None
@@ -172,24 +185,24 @@ class AtaCreateSerializer(serializers.ModelSerializer):
             for presente in presentes_json:
                 presidente = presente.pop('presidente_da_reuniao', False)
                 secretario = presente.pop('secretario_da_reuniao', False)
-                
+
                 presente_object = PresentesAtaCreateSerializer().create(presente)
                 presente_object.save()
-                
+
                 if presidente:
                     instance.presidente_da_reuniao = presente_object
-                    
+
                 elif secretario:
                     instance.secretario_da_reuniao = presente_object
-                    
+
                 presente_object.eh_conselho_fiscal()
                 presentes_lista.append(presente_object)
-            
+
         else:
             for presente in presentes_json:
                 presente.pop('presidente_da_reuniao', None)
                 presente.pop('secretario_da_reuniao', None)
-                
+
                 presente_object = PresentesAtaCreateSerializer().create(presente)
                 presente_object.eh_conselho_fiscal()
                 presentes_lista.append(presente_object)

--- a/sme_ptrf_apps/core/services/validacao_edicao_ata_service.py
+++ b/sme_ptrf_apps/core/services/validacao_edicao_ata_service.py
@@ -1,0 +1,60 @@
+from sme_ptrf_apps.core.models import Ata, PrestacaoConta
+
+STATUS_PC_PERMITE_EDITAR_ATA_APRESENTACAO = {
+    PrestacaoConta.STATUS_NAO_APRESENTADA,
+    PrestacaoConta.STATUS_NAO_RECEBIDA,
+}
+
+
+def _pc_permite_editar_ata_apresentacao(ata: Ata) -> bool:
+    if not ata.prestacao_conta_id:
+        return False
+    return ata.prestacao_conta.status in STATUS_PC_PERMITE_EDITAR_ATA_APRESENTACAO
+
+
+def validar_edicao_ata_pc(ata: Ata) -> dict:
+    """
+    Valida se a ata de PC pode ser editada (participantes, dados da reunião, etc.).
+
+    Regras:
+    - Apresentação enquanto a PC não foi recebida (NAO_APRESENTADA / NAO_RECEBIDA):
+      edição permitida mesmo com PDF gerado, para permitir regeração.
+    - Apresentação após recebimento da PC com PDF gerado: bloqueada;
+      alterações devem ser feitas na ata de retificação.
+    - Apresentação enquanto existe ata de retificação na PC: bloqueada.
+    - Qualquer ata com PDF em processamento: bloqueada até concluir.
+    """
+    if ata.status_geracao_pdf == Ata.STATUS_EM_PROCESSAMENTO:
+        return {
+            'is_valid': False,
+            'mensagem': 'A ata está sendo gerada. Aguarde a conclusão do processamento.',
+        }
+
+    if ata.tipo_ata == Ata.ATA_APRESENTACAO:
+        if (
+            ata.prestacao_conta_id and
+            ata.prestacao_conta.atas_da_prestacao.filter(
+                tipo_ata=Ata.ATA_RETIFICACAO,
+                previa=False,
+            ).exists()
+        ):
+            return {
+                'is_valid': False,
+                'mensagem': (
+                    'Durante a retificação, apenas a ata de retificação pode ser editada. '
+                    'A ata de apresentação original permanece congelada.'
+                ),
+            }
+
+        if not _pc_permite_editar_ata_apresentacao(ata):
+            if ata.documento_gerado or ata.pdf_gerado_previamente:
+                return {
+                    'is_valid': False,
+                    'mensagem': (
+                        'A ata de apresentação já foi gerada. '
+                        'Para alterar participantes ou dados da reunião, utilize a ata de retificação '
+                        'da prestação de contas.'
+                    ),
+                }
+
+    return {'is_valid': True}

--- a/sme_ptrf_apps/core/tests/tests_api_atas_associacao/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_atas_associacao/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from sme_ptrf_apps.core.models import Ata
+
+
+@pytest.fixture
+def ata_apresentacao(ata_factory, prestacao_conta_factory, associacao):
+    prestacao_conta = prestacao_conta_factory(associacao=associacao)
+    return ata_factory(
+        prestacao_conta=prestacao_conta,
+        associacao=associacao,
+        periodo=prestacao_conta.periodo,
+        tipo_ata=Ata.ATA_APRESENTACAO,
+        status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+        pdf_gerado_previamente=False,
+        presidente_reuniao='José',
+        secretario_reuniao='Ana',
+    )

--- a/sme_ptrf_apps/core/tests/tests_api_atas_associacao/test_update_ata_associacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_atas_associacao/test_update_ata_associacao.py
@@ -4,14 +4,13 @@ import json
 import pytest
 from rest_framework import status
 
-from ...models import Ata
+from ...models import Ata, PrestacaoConta
 
 pytestmark = pytest.mark.django_db
 
 
-def test_api_update_ata_associacao(jwt_authenticated_client_a, ata_2020_1_cheque_aprovada):
-
-    payload = {
+def _payload_edicao_ata():
+    return {
         "tipo_reuniao": "EXTRAORDINARIA",
         "convocacao": "SEGUNDA",
         "data_reuniao": "2020-06-20",
@@ -25,10 +24,18 @@ def test_api_update_ata_associacao(jwt_authenticated_client_a, ata_2020_1_cheque
         'presentes_na_ata': [],
     }
 
-    response = jwt_authenticated_client_a.patch(f'/api/atas-associacao/{ata_2020_1_cheque_aprovada.uuid}/', data=json.dumps(payload),
-                            content_type='application/json')
 
-    registro_alterado = Ata.by_uuid(uuid=ata_2020_1_cheque_aprovada.uuid)
+def test_api_update_ata_associacao(jwt_authenticated_client_a, ata_apresentacao):
+
+    payload = _payload_edicao_ata()
+
+    response = jwt_authenticated_client_a.patch(
+        f'/api/atas-associacao/{ata_apresentacao.uuid}/',
+        data=json.dumps(payload),
+        content_type='application/json',
+    )
+
+    registro_alterado = Ata.by_uuid(uuid=ata_apresentacao.uuid)
 
     assert response.status_code == status.HTTP_200_OK
     assert registro_alterado.tipo_reuniao == 'EXTRAORDINARIA'
@@ -41,3 +48,61 @@ def test_api_update_ata_associacao(jwt_authenticated_client_a, ata_2020_1_cheque
     assert registro_alterado.cargo_secretaria_reuniao == "SecretáriaXXX"
     assert registro_alterado.parecer_conselho == "REJEITADA"
     assert registro_alterado.comentarios == "TesteXXX"
+
+
+def test_api_update_ata_apresentacao_bloqueada_quando_pdf_gerado_e_pc_recebida(
+    jwt_authenticated_client_a, ata_apresentacao,
+):
+    ata_apresentacao.prestacao_conta.status = PrestacaoConta.STATUS_RECEBIDA
+    ata_apresentacao.prestacao_conta.save()
+    ata_apresentacao.status_geracao_pdf = Ata.STATUS_CONCLUIDO
+    ata_apresentacao.save()
+
+    response = jwt_authenticated_client_a.patch(
+        f'/api/atas-associacao/{ata_apresentacao.uuid}/',
+        data=json.dumps(_payload_edicao_ata()),
+        content_type='application/json',
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'retificação' in response.json()['mensagem'].lower()
+
+    registro = Ata.by_uuid(uuid=ata_apresentacao.uuid)
+    assert registro.presidente_reuniao == 'José'
+
+
+def test_api_update_ata_apresentacao_bloqueada_quando_pdf_gerado_previamente_e_pc_em_analise(
+    jwt_authenticated_client_a, ata_apresentacao,
+):
+    ata_apresentacao.prestacao_conta.status = PrestacaoConta.STATUS_EM_ANALISE
+    ata_apresentacao.prestacao_conta.save()
+    ata_apresentacao.status_geracao_pdf = Ata.STATUS_NAO_GERADO
+    ata_apresentacao.pdf_gerado_previamente = True
+    ata_apresentacao.save()
+
+    response = jwt_authenticated_client_a.patch(
+        f'/api/atas-associacao/{ata_apresentacao.uuid}/',
+        data=json.dumps(_payload_edicao_ata()),
+        content_type='application/json',
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert 'retificação' in response.json()['mensagem'].lower()
+
+
+def test_api_update_ata_apresentacao_permitida_quando_pdf_gerado_e_pc_nao_recebida(
+    jwt_authenticated_client_a, ata_apresentacao,
+):
+    ata_apresentacao.prestacao_conta.status = PrestacaoConta.STATUS_NAO_RECEBIDA
+    ata_apresentacao.prestacao_conta.save()
+    ata_apresentacao.status_geracao_pdf = Ata.STATUS_CONCLUIDO
+    ata_apresentacao.save()
+
+    response = jwt_authenticated_client_a.patch(
+        f'/api/atas-associacao/{ata_apresentacao.uuid}/',
+        data=json.dumps(_payload_edicao_ata()),
+        content_type='application/json',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert Ata.by_uuid(uuid=ata_apresentacao.uuid).presidente_reuniao == 'PedroXXX'

--- a/sme_ptrf_apps/core/tests/tests_services/tests_validacao_edicao_ata_service/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_validacao_edicao_ata_service/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from datetime import date
+
+from sme_ptrf_apps.core.models import PrestacaoConta
+
+
+@pytest.fixture
+def prestacao_conta_devolvida(prestacao_conta_factory):
+    return prestacao_conta_factory(
+        status=PrestacaoConta.STATUS_DEVOLVIDA,
+        data_recebimento=date(2020, 10, 1),
+    )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_validacao_edicao_ata_service/test_validacao_edicao_ata_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_validacao_edicao_ata_service/test_validacao_edicao_ata_service.py
@@ -1,0 +1,132 @@
+import pytest
+
+from sme_ptrf_apps.core.models import Ata, PrestacaoConta
+from sme_ptrf_apps.core.services.validacao_edicao_ata_service import validar_edicao_ata_pc
+
+pytestmark = pytest.mark.django_db
+
+
+class TestValidarEdicaoAtaPc:
+    def test_bloqueia_edicao_ata_apresentacao_com_pdf_concluido_quando_pc_recebida(
+        self, ata_factory, prestacao_conta_factory,
+    ):
+        prestacao_conta = prestacao_conta_factory(status=PrestacaoConta.STATUS_RECEBIDA)
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            prestacao_conta=prestacao_conta,
+            associacao=prestacao_conta.associacao,
+            periodo=prestacao_conta.periodo,
+            status_geracao_pdf=Ata.STATUS_CONCLUIDO,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is False
+        assert 'retificação' in resultado['mensagem'].lower()
+
+    def test_bloqueia_edicao_ata_apresentacao_com_pdf_gerado_previamente_quando_pc_em_analise(
+        self, ata_factory, prestacao_conta_factory,
+    ):
+        prestacao_conta = prestacao_conta_factory(status=PrestacaoConta.STATUS_EM_ANALISE)
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            prestacao_conta=prestacao_conta,
+            associacao=prestacao_conta.associacao,
+            periodo=prestacao_conta.periodo,
+            status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+            pdf_gerado_previamente=True,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is False
+        assert 'retificação' in resultado['mensagem'].lower()
+
+    def test_permite_edicao_ata_apresentacao_com_pdf_concluido_quando_pc_nao_recebida(
+        self, ata_factory, prestacao_conta_factory,
+    ):
+        prestacao_conta = prestacao_conta_factory(status=PrestacaoConta.STATUS_NAO_RECEBIDA)
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            prestacao_conta=prestacao_conta,
+            associacao=prestacao_conta.associacao,
+            periodo=prestacao_conta.periodo,
+            status_geracao_pdf=Ata.STATUS_CONCLUIDO,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is True
+
+    def test_permite_edicao_ata_apresentacao_com_pdf_gerado_previamente_quando_pc_nao_apresentada(
+        self, ata_factory, prestacao_conta_factory,
+    ):
+        prestacao_conta = prestacao_conta_factory(status=PrestacaoConta.STATUS_NAO_APRESENTADA)
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            prestacao_conta=prestacao_conta,
+            associacao=prestacao_conta.associacao,
+            periodo=prestacao_conta.periodo,
+            status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+            pdf_gerado_previamente=True,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is True
+
+    def test_permite_edicao_ata_apresentacao_sem_pdf(self, ata_factory):
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+            pdf_gerado_previamente=False,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is True
+
+    def test_bloqueia_edicao_ata_apresentacao_durante_retificacao(
+        self, ata_factory, prestacao_conta_devolvida,
+    ):
+        ata_apresentacao = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            prestacao_conta=prestacao_conta_devolvida,
+            associacao=prestacao_conta_devolvida.associacao,
+            periodo=prestacao_conta_devolvida.periodo,
+            status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+            pdf_gerado_previamente=False,
+        )
+        ata_factory(
+            tipo_ata=Ata.ATA_RETIFICACAO,
+            prestacao_conta=prestacao_conta_devolvida,
+            associacao=prestacao_conta_devolvida.associacao,
+            periodo=prestacao_conta_devolvida.periodo,
+            previa=False,
+        )
+
+        resultado = validar_edicao_ata_pc(ata_apresentacao)
+
+        assert resultado['is_valid'] is False
+        assert 'apenas a ata de retificação' in resultado['mensagem'].lower()
+
+    def test_permite_edicao_ata_retificacao(self, ata_factory):
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_RETIFICACAO,
+            status_geracao_pdf=Ata.STATUS_NAO_GERADO,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is True
+
+    def test_bloqueia_edicao_ata_em_processamento(self, ata_factory):
+        ata = ata_factory(
+            tipo_ata=Ata.ATA_APRESENTACAO,
+            status_geracao_pdf=Ata.STATUS_EM_PROCESSAMENTO,
+        )
+
+        resultado = validar_edicao_ata_pc(ata)
+
+        assert resultado['is_valid'] is False
+        assert 'sendo gerada' in resultado['mensagem'].lower()

--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -27,8 +27,10 @@ from sme_ptrf_apps.paa.api.serializers.paa_serializer import (
 )
 from sme_ptrf_apps.paa.api.serializers.renderizador_paa_serializer import RenderizadorPaaBuilder
 from sme_ptrf_apps.paa.api.serializers.receita_prevista_paa_serializer import ReceitaPrevistaPaaSerializer
+from sme_ptrf_apps.logging.loggers import ContextualLogger
 from sme_ptrf_apps.paa.models import Paa, PeriodoPaa
-from sme_ptrf_apps.paa.models.documento_paa import obter_documento_final_por_retificacao
+from sme_ptrf_apps.paa.models.documento_paa import DocumentoPaa, obter_documento_final_por_retificacao
+from sme_ptrf_apps.paa.services.documento_paa_service import DocumentoPaaService
 from sme_ptrf_apps.core.models import Associacao
 from sme_ptrf_apps.paa.services.paa_service import PaaService, ImportacaoConfirmacaoNecessaria
 from sme_ptrf_apps.paa.services.receitas_previstas_paa_service import SaldosPorAcaoPaaService
@@ -407,6 +409,25 @@ class PaaViewSet(WaffleFlagMixin, ModelViewSet):
             return Response(
                 {"mensagem": "O documento final já foi gerado e não é mais possível gerar prévias."},
                 status=400)
+
+        documento_previa = paa.documento_previa
+        if documento_previa and documento_previa.status_geracao == DocumentoPaa.StatusChoices.EM_PROCESSAMENTO:
+            return Response(
+                {
+                    "mensagem": (
+                        "A prévia do documento já está sendo gerada. "
+                        "Aguarde a conclusão para solicitar uma nova prévia."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        logger = ContextualLogger.get_logger(
+            __name__,
+            operacao='Plano Anual de Atividades',
+            username=usuario.username,
+        )
+        DocumentoPaaService(paa=paa, usuario=usuario, previa=True, logger=logger).iniciar()
 
         gerar_previa_documento_paa_async.apply_async(
             args=[str(paa.uuid), usuario.username]

--- a/sme_ptrf_apps/paa/services/documento_paa_service.py
+++ b/sme_ptrf_apps/paa/services/documento_paa_service.py
@@ -29,6 +29,19 @@ class DocumentoPaaService:
         self.criar_novo_documento()
         self.marcar_em_processamento()
 
+    def preparar_documento_para_task(self):
+        """
+        Na prévia, o registro EM_PROCESSAMENTO é criado na API antes do Celery.
+        """
+        if self.previa:
+            documento_previa = self.paa.documento_previa
+            if documento_previa and documento_previa.status_geracao == DocumentoPaa.StatusChoices.EM_PROCESSAMENTO:
+                self.documento_paa = documento_previa
+                self.logger.info('Documento PAA prévia em processamento reutilizado pela task.')
+                return
+
+        self.iniciar()
+
     def marcar_em_processamento(self):
         self.documento_paa.arquivo_em_processamento()
         self.logger.info('Documento PAA em processamento')

--- a/sme_ptrf_apps/paa/services/paa_service.py
+++ b/sme_ptrf_apps/paa/services/paa_service.py
@@ -277,6 +277,13 @@ class PaaService:
             if paa.documento_final.status_geracao == DocumentoPaa.StatusChoices.EM_PROCESSAMENTO:
                 return ["O documento já está sendo gerado."]
 
+        documento_previa = paa.documento_previa
+        if documento_previa and documento_previa.status_geracao == DocumentoPaa.StatusChoices.EM_PROCESSAMENTO:
+            return [
+                "A prévia do documento ainda está sendo gerada. "
+                "Aguarde a conclusão para gerar o documento final."
+            ]
+
         errors = []
         # Valida se todas as receitas previstas foram totalmente utilizadas nas prioridades
         resumo_service = ResumoPrioridadesService(paa)

--- a/sme_ptrf_apps/paa/tasks/gerar_previa_documento_paa.py
+++ b/sme_ptrf_apps/paa/tasks/gerar_previa_documento_paa.py
@@ -32,7 +32,7 @@ def gerar_previa_documento_paa_async(self, paa_uuid, username=""):
     usuario = get_user_model().objects.get(username=username)
 
     service = DocumentoPaaService(paa=paa, usuario=username, previa=True, logger=logger)
-    service.iniciar()
+    service.preparar_documento_para_task()
 
     try:
         documento_paa = service.documento_paa

--- a/sme_ptrf_apps/paa/tests/documento_paa/test_gerar_previa_documento_paa_tasks.py
+++ b/sme_ptrf_apps/paa/tests/documento_paa/test_gerar_previa_documento_paa_tasks.py
@@ -18,7 +18,8 @@ def test_gerar_previa_documento_paa_async_sucesso(paa, usuario_task):
         result = gerar_previa_documento_paa_async.apply(args=[str(paa.uuid), usuario_task.username])
 
     assert result.successful()
-    mock_service_class.return_value.iniciar.assert_called_once()
+    mock_service_class.return_value.preparar_documento_para_task.assert_called_once()
+    mock_service_class.return_value.iniciar.assert_not_called()
     mock_service_class.return_value.marcar_concluido.assert_called_once()
     mock_service_class.return_value.marcar_erro.assert_not_called()
 

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_viewset_gerar_documento.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_viewset_gerar_documento.py
@@ -1,8 +1,23 @@
 import json
 import pytest
+from unittest.mock import patch
 from rest_framework import status
 
 pytestmark = pytest.mark.django_db
+
+
+def test_nao_pode_gerar_final_quando_previa_em_processamento(
+        jwt_authenticated_client_sme, flag_paa, documento_paa_factory, paa_factory):
+    paa = paa_factory()
+    documento_paa_factory(paa=paa, versao="PREVIA", status_geracao="EM_PROCESSAMENTO")
+
+    response = jwt_authenticated_client_sme.post(f'/api/paa/{paa.uuid}/gerar-documento/',
+                                                 content_type='application/json',
+                                                 data=json.dumps({"confirmar": 1}))
+    result = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "A prévia do documento ainda está sendo gerada" in result["mensagem"]
 
 
 def test_nao_pode_gerar_final_quando_documento_final_existe(jwt_authenticated_client_sme, flag_paa,
@@ -62,15 +77,61 @@ def test_nao_pode_gerar_previa_quando_documento_final_existe(jwt_authenticated_c
 
 
 def test_iniciar_geracao_previa_com_sucesso(jwt_authenticated_client_sme, flag_paa, paa_factory):
+    from sme_ptrf_apps.paa.models import DocumentoPaa
+
     paa = paa_factory()
 
-    response = jwt_authenticated_client_sme.post(f'/api/paa/{paa.uuid}/gerar-previa-documento/',
-                                                 content_type='application/json')
+    with patch('sme_ptrf_apps.paa.api.views.paa_viewset.gerar_previa_documento_paa_async.apply_async'):
+        response = jwt_authenticated_client_sme.post(
+            f'/api/paa/{paa.uuid}/gerar-previa-documento/',
+            content_type='application/json',
+        )
 
     result = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert result["mensagem"] == 'Geração de documento prévia iniciada'
+
+    documento_previa = paa.documentopaa_set.filter(versao=DocumentoPaa.VersaoChoices.PREVIA).first()
+    assert documento_previa is not None
+    assert documento_previa.status_geracao == DocumentoPaa.StatusChoices.EM_PROCESSAMENTO
+
+
+def test_nao_pode_gerar_previa_quando_previa_em_processamento(jwt_authenticated_client_sme, flag_paa,
+                                                              documento_paa_factory, paa_factory):
+    paa = paa_factory()
+    documento_paa_factory(paa=paa, versao="PREVIA", status_geracao="EM_PROCESSAMENTO")
+
+    response = jwt_authenticated_client_sme.post(f'/api/paa/{paa.uuid}/gerar-previa-documento/',
+                                                 content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "A prévia do documento já está sendo gerada" in result["mensagem"]
+
+
+def test_gerar_documento_final_bloqueado_apos_iniciar_previa_na_api(
+        jwt_authenticated_client_sme, flag_paa, paa_factory, objetivo_paa_factory,
+        atividade_estatutaria_paa_factory):
+    objetivo = objetivo_paa_factory()
+    paa = paa_factory(texto_introducao="Intro", texto_conclusao="Conclusao")
+    paa.objetivos.add(objetivo)
+    atividade_estatutaria_paa_factory(paa=paa)
+
+    with patch('sme_ptrf_apps.paa.api.views.paa_viewset.gerar_previa_documento_paa_async.apply_async'):
+        jwt_authenticated_client_sme.post(
+            f'/api/paa/{paa.uuid}/gerar-previa-documento/',
+            content_type='application/json',
+        )
+
+    response = jwt_authenticated_client_sme.post(
+        f'/api/paa/{paa.uuid}/gerar-documento/',
+        content_type='application/json',
+        data=json.dumps({"confirmar": 1}),
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "A prévia do documento ainda está sendo gerada" in response.json()["mensagem"]
 
 
 def test_gerar_documento_sem_confirmacao(jwt_authenticated_client_sme, flag_paa, paa_factory,

--- a/sme_ptrf_apps/paa/tests/services/test_documento_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_documento_paa_service.py
@@ -261,6 +261,41 @@ class TestIniciar:
         service.marcar_em_processamento.assert_called_once()
 
 
+class TestPrepararDocumentoParaTask:
+    def test_reutiliza_previa_em_processamento_sem_chamar_iniciar(self, paa):
+        from model_bakery import baker
+
+        documento_previa = baker.make(
+            DocumentoPaa,
+            paa=paa,
+            versao=DocumentoPaa.VersaoChoices.PREVIA,
+            status_geracao=DocumentoPaa.StatusChoices.EM_PROCESSAMENTO,
+        )
+        service = make_service(paa=paa, previa=True)
+        service.iniciar = MagicMock()
+
+        service.preparar_documento_para_task()
+
+        service.iniciar.assert_not_called()
+        assert service.documento_paa == documento_previa
+
+    def test_chama_iniciar_quando_previa_nao_esta_em_processamento(self, paa):
+        service = make_service(paa=paa, previa=True)
+        service.iniciar = MagicMock()
+
+        service.preparar_documento_para_task()
+
+        service.iniciar.assert_called_once()
+
+    def test_chama_iniciar_para_documento_final(self, paa):
+        service = make_service(paa=paa, previa=False)
+        service.iniciar = MagicMock()
+
+        service.preparar_documento_para_task()
+
+        service.iniciar.assert_called_once()
+
+
 @pytest.mark.django_db
 class TestDocumentoPaaServiceIntegracao:
     def test_criar_novo_documento_persiste_no_banco(self, paa):

--- a/sme_ptrf_apps/paa/tests/services/test_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_paa_service.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 
 from sme_ptrf_apps.paa.services.paa_service import PaaService
 from sme_ptrf_apps.paa.enums import PaaStatusEnum
-from sme_ptrf_apps.paa.models import PrioridadePaa
+from sme_ptrf_apps.paa.models import PrioridadePaa, DocumentoPaa
 from sme_ptrf_apps.paa.services.resumo_prioridades_service import ResumoPrioridadesService
 
 
@@ -360,6 +360,19 @@ class TestPodeGerarDocumentoFinal:
 
         assert len(erros) == 1
         assert "O documento já está sendo gerado" in erros[0]
+
+    def test_nao_pode_gerar_documento_final_quando_previa_em_processamento(self, paa):
+        baker.make(
+            'DocumentoPaa',
+            paa=paa,
+            versao=DocumentoPaa.VersaoChoices.PREVIA,
+            status_geracao=DocumentoPaa.StatusChoices.EM_PROCESSAMENTO,
+        )
+
+        erros = PaaService.pode_gerar_documento_final(paa)
+
+        assert len(erros) == 1
+        assert "A prévia do documento ainda está sendo gerada" in erros[0]
 
     def test_pode_gerar_prioridades_incompletas(
         self,


### PR DESCRIPTION
Esse PR:

- Bloqueia a alteração da ATA de Apresentação após recebimento da PC;
- Bloqueia a geração final da ATA do PAA quando já existe uma prévia em andamento.

História: [AB#149227](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149227)