### PR TITLE
feat(136898): Ajustes pontuais no Enum de Atividades Estatutárias

### DIFF
--- a/sme_ptrf_apps/despesas/api/views/especificacoes_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/especificacoes_viewset.py
@@ -153,7 +153,7 @@ class ParametrizacaoEspecificacoesMaterialServicoViewSet(mixins.CreateModelMixin
         except ProtectedError:
             raise exceptions.ValidationError({
                 'erro': 'ProtectedError',
-                'mensagem': 'Essa operação não pode ser realizada. Há despesas vinculadas à esta especificação'
+                'mensagem': 'Essa operação não pode ser realizada. Há registros vinculados a esta especificação'
             })
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/sme_ptrf_apps/despesas/tests/tests_api_especificacoes/test_especificacoes_endpoint.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_especificacoes/test_especificacoes_endpoint.py
@@ -118,7 +118,7 @@ def test_exclusao_especificacao_despesas_vinculadas(
     assert 'mensagem' in response.data
     assert response.data['erro'] == 'ProtectedError', response.data['erro']
     assert response.data['mensagem'] == ('Essa operação não pode ser realizada. ' +
-                                         'Há despesas vinculadas à esta especificação')
+                                         'Há registros vinculados a esta especificação')
 
 
 def test_alteracao_especificacao_sem_alteracao_aplicacao(jwt_authenticated_client, especificacao_material_servico):

--- a/sme_ptrf_apps/paa/api/serializers/atividade_estatutaria_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/atividade_estatutaria_serializer.py
@@ -85,12 +85,16 @@ class AtividadeEstatutariaSerializer(serializers.ModelSerializer):
         return StatusChoices(int(obj.status)).label
 
     def get_ano_label(self, obj):
-        return TipoAnosAtividadeEstatutariaEnum[obj.ano].value if obj.ano else ""
+        if not obj.ano or obj.ano == 'None':
+            return ""
+        return TipoAnosAtividadeEstatutariaEnum[obj.ano].value
 
     def get_mes_label(self, obj):
         return Mes(int(obj.mes)).label if obj.mes else ""
 
     def get_tipo_label(self, obj):
+        if not obj.tipo or obj.tipo == 'None':
+            return ""
         return TipoAtividadeEstatutariaEnum[obj.tipo].value
 
     class Meta:


### PR DESCRIPTION


Esse PR:

- Ajusta o representation Enum de Atividades Estatutárias

- Ajuste extra em mensagem de ProtectedErro ao remover uma Especificação de Materiais e Serviços

História [AB#136898](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/136898)
