### PR TITLE
hotfix(148847): complementa validações no cadastro de despesas

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.3"
+__version__ = "9.39.4"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -90,6 +90,7 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
         ValidacaoDespesaService.validar_rateios_serializer(
             raw_rateios=self.initial_data.get("rateios", []),
             valor_total=self.initial_data.get("valor_total"),
+            valor_original=self.initial_data.get("valor_original"),
             retem_imposto=self.initial_data.get("retem_imposto", False),
             raw_despesas_impostos=self.initial_data.get("despesas_impostos", []),
             valor_recursos_proprios=self.initial_data.get(

--- a/sme_ptrf_apps/despesas/services/validacao_despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/validacao_despesa_service.py
@@ -9,62 +9,145 @@ class ValidacaoDespesaService:
     @staticmethod
     def validar_rateios_serializer(
         valor_total,
-        raw_rateios=[],
-        raw_despesas_impostos=[],
+        valor_original,
+        raw_rateios=None,
+        raw_despesas_impostos=None,
         retem_imposto=False,
         valor_recursos_proprios=0,
     ):
+        """
+        Regras de validação dos rateios da despesa.
+
+        valor_original:
+            Representa o valor exibido no extrato comprobatório.
+            Esse campo foi criado posteriormente ao valor_rateio para armazenar o
+            valor original informado no documento, mesmo quando
+            ele difere do valor efetivamente pago.
+
+        valor_rateio:
+            Representa o valor efetivamente realizado/pago na operação.
+
+        Regras:
+
+        - A soma dos `valor_rateio` dos rateios deve ser igual ao
+        valor real (`valor_total`) da despesa + impostos (caso haja)
+
+        - A soma dos `valor_original` dos rateios deve ser igual ao
+        `valor_original` informado na despesa + impostos (caso haja)
+
+        Referência: #20303 [Associações] Incluir campos de "valor_realizado" no cadastro de despesa
+        """
+
+        raw_rateios = raw_rateios or []
+        raw_despesas_impostos = raw_despesas_impostos or []        
+    
         if not raw_rateios:
             raise serializers.ValidationError(
                 "A despesa deve conter ao menos um rateio."
             )
 
         total_rateios = sum(
-            Decimal(str(r.get("valor_rateio", 0)))
-            for r in raw_rateios
+            Decimal(str(rateio.get("valor_rateio", 0)))
+            for rateio in raw_rateios
         )
 
-        valor_real = Decimal(str(valor_total or 0)) - Decimal(
+        total_rateios_original = sum(
+            Decimal(str(rateio.get("valor_original", 0)))
+            for rateio in raw_rateios
+        )
+
+        valor_real_despesa = Decimal(str(valor_total or 0)) - Decimal(
             str(valor_recursos_proprios or 0)
         )
 
-        total_rateios_impostos = total_rateios
+        valor_original_despesa = Decimal(str(valor_original or 0))
+
+        total_rateios_com_impostos = total_rateios
+        total_rateios_original_com_impostos = total_rateios_original
 
         if retem_imposto:
-            total_impostos = sum(
-                Decimal(str(r.get("valor_total", 0)))
-                for r in raw_despesas_impostos
+            total_impostos_valor_total = sum(
+                Decimal(str(imposto.get("valor_total", 0)))
+                for imposto in raw_despesas_impostos
             )
 
-            total_rateios_impostos += total_impostos
+            total_impostos_valor_original = sum(
+                Decimal(str(imposto.get("valor_original", 0)))
+                for imposto in raw_despesas_impostos
+            )
 
-        if total_rateios_impostos != valor_real:
+            total_rateios_com_impostos += total_impostos_valor_total
+            total_rateios_original_com_impostos += total_impostos_valor_original
+
+        if total_rateios_com_impostos != valor_real_despesa:
             raise serializers.ValidationError(
-                "A soma dos rateios deve ser igual ao valor real da despesa."
+                "A soma dos valores realizados dos rateios deve "
+                "ser igual ao valor real da despesa."
+            )
+
+        if total_rateios_original_com_impostos != valor_original_despesa:
+            raise serializers.ValidationError(
+                "A soma dos valores originais dos rateios deve "
+                "ser igual ao valor original da despesa."
             )
 
         # Valida rateios do tipo capital
         for rateio in raw_rateios:
-            if rateio.get('aplicacao_recurso') == APLICACAO_CAPITAL:
-                quantidade_itens_capital = rateio.get('quantidade_itens_capital')
-                valor_item_capital = rateio.get('valor_item_capital')
+            if rateio.get("aplicacao_recurso") != APLICACAO_CAPITAL:
+                continue
 
-                if quantidade_itens_capital <= 0:
-                    raise serializers.ValidationError({
-                        'mensagem': 'Rateio de capital não pode ter quantidade menor ou igual a zero'
-                    })
+            quantidade_itens_capital = rateio.get(
+                "quantidade_itens_capital"
+            )
 
-                if valor_item_capital:
-                    valor_total_item_capital = (
-                        Decimal(str(valor_item_capital)) *
-                        Decimal(str(quantidade_itens_capital))
+            valor_item_capital = rateio.get(
+                "valor_item_capital"
+            )
+
+            if quantidade_itens_capital <= 0:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Rateio de capital não pode ter "
+                        "quantidade menor ou igual a zero"
                     )
-                    valor_rateio = Decimal(str(rateio.get('valor_rateio', 0)))
+                })
 
-                    if valor_total_item_capital != valor_rateio:
-                        raise serializers.ValidationError({
-                            'mensagem': 'Valor do rateio capital diverge do valor calculado pela quantidade de itens'
-                        })
+            if not valor_item_capital:
+                continue
+
+            valor_total_item_capital = (
+                Decimal(str(valor_item_capital))
+                * Decimal(str(quantidade_itens_capital))
+            )
+
+            valor_rateio = Decimal(
+                str(rateio.get("valor_rateio", 0))
+            )
+
+            valor_original_rateio = Decimal(
+                str(rateio.get("valor_original", 0))
+            )
+
+            """
+            Atualmente, o campo valor total do capital (valor_original) é
+            disabled e calculado com base no quantidade de unidades x valor)
+            Portanto, não pode divergir do valor realizado, igual é quando CUSTEIO.
+            """
+            if valor_total_item_capital != valor_original_rateio:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Valor total do capital diverge do valor "
+                        "calculado pela quantidade de itens"
+                    )
+                })
+
+            if valor_total_item_capital != valor_rateio:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Valor do rateio capital diverge do valor "
+                        "calculado pela quantidade de itens"
+                    )
+                })
 
     @staticmethod
     def validar_periodo_e_contas(

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_despesa_paa_prioridades_impacto.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_despesa_paa_prioridades_impacto.py
@@ -141,6 +141,7 @@ def _payload_despesa_capital(associacao, tipo_documento, tipo_transacao, conta_a
         "nome_fornecedor": "FORNECEDOR TESTE SA",
         "data_transacao": "2020-03-10",
         "valor_total": float(valor_rateio),
+        "valor_original": float(valor_rateio),
         "valor_recursos_proprios": 0,
         "motivos_pagamento_antecipado": [],
         "outros_motivos_pagamento_antecipado": "",
@@ -153,6 +154,7 @@ def _payload_despesa_capital(associacao, tipo_documento, tipo_transacao, conta_a
                 "tipo_custeio": None,
                 "especificacao_material_servico": especificacao_capital.id,
                 "valor_rateio": float(valor_rateio),
+                "valor_original": float(valor_rateio),
                 "quantidade_itens_capital": 2,
                 "valor_item_capital": float(valor_rateio) / 2,
                 "numero_processo_incorporacao_capital": "9876543210",
@@ -525,7 +527,7 @@ class TestPostDespesaCapitalComSaldoNegativo:
             associacao, tipo_documento, tipo_transacao,
             conta_associacao, acao_associacao,
             especificacao_capital,
-            valor_rateio=100,
+            valor_rateio=100,            
         )
 
         response = jwt_authenticated_client_d.post(

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_validacao_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_validacao_despesa_service.py
@@ -33,12 +33,14 @@ def test_validar_rateios_serializer_ok():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CUSTEIO,
         }
     ]
 
     ValidacaoDespesaService.validar_rateios_serializer(
         valor_total=100,
+        valor_original=100,
         raw_rateios=rateios,
         raw_despesas_impostos=[],
         retem_imposto=False,
@@ -50,6 +52,7 @@ def test_validar_rateios_serializer_sem_rateios():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=[],
         )
 
@@ -58,22 +61,24 @@ def test_validar_rateios_serializer_sem_rateios():
 
 def test_validar_rateios_serializer_soma_invalida():
     rateios = [
-        {"valor_rateio": 80, "aplicacao_recurso": APLICACAO_CUSTEIO},
+        {"valor_rateio": 80, "valor_original": 80, "aplicacao_recurso": APLICACAO_CUSTEIO},
     ]
 
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
-    assert "soma dos rateios" in str(exc.value)
+    assert "soma dos valores" in str(exc.value)
 
 
 def test_rateio_capital_quantidade_zero():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 0,
             "valor_item_capital": 50,
@@ -83,6 +88,7 @@ def test_rateio_capital_quantidade_zero():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
@@ -93,6 +99,7 @@ def test_rateio_capital_valor_divergente():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 2,
             "valor_item_capital": 40,
@@ -102,6 +109,7 @@ def test_rateio_capital_valor_divergente():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
@@ -113,6 +121,7 @@ def test_rateio_capital_valores_float_equivalentes_decimal():
     rateios = [
         {
             "valor_rateio": 1838.7,
+            "valor_original": 1838.7,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 3,
             "valor_item_capital": 612.9,
@@ -121,6 +130,7 @@ def test_rateio_capital_valores_float_equivalentes_decimal():
 
     ValidacaoDespesaService.validar_rateios_serializer(
         valor_total=1838.7,
+        valor_original=1838.7,
         raw_rateios=rateios,
     )
 
@@ -201,3 +211,87 @@ def test_validar_conta_imposto_inicio_maior(conta_ativa, recurso_legado):
         )
 
     assert "rateios de imposto" in str(exc.value)
+
+def test_validar_rateios_serializer_soma_valor_original_invalida():
+    rateios = [
+        {
+            "valor_rateio": 100,
+            "valor_original": 80,
+            "aplicacao_recurso": APLICACAO_CUSTEIO,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=100,
+            valor_original=100,
+            raw_rateios=rateios,
+        )
+
+    assert "valores originais dos rateios" in str(exc.value)
+
+
+def test_rateio_capital_valor_original_divergente():
+    rateios = [
+        {
+            "valor_rateio": 100,
+            "valor_original": 80,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 50,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=100,
+            valor_original=80,
+            raw_rateios=rateios,
+        )
+
+    assert (
+        "Valor total do capital diverge do valor calculado"
+        in str(exc.value)
+    )
+
+
+def test_rateio_capital_valor_rateio_divergente():
+    rateios = [
+        {
+            "valor_rateio": 80,
+            "valor_original": 100,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 50,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=80,
+            valor_original=100,
+            raw_rateios=rateios,
+        )
+
+    assert (
+        "Valor do rateio capital diverge do valor calculado"
+        in str(exc.value)
+    )
+
+
+def test_rateio_capital_valores_validos():
+    rateios = [
+        {
+            "valor_rateio": 120,
+            "valor_original": 120,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 60,
+        }
+    ]
+
+    ValidacaoDespesaService.validar_rateios_serializer(
+        valor_total=120,
+        valor_original=120,
+        raw_rateios=rateios,
+    )


### PR DESCRIPTION
# O que este PR faz

- Adicionada validação do somatório dos `valor_original` dos rateios em relação ao `valor_original` da despesa.

- Ajustada validação dos rateios de capital para validar também o campo `valor_original` com base no cálculo:
  - `quantidade_itens_capital × valor_item_capital`

- Mantida validação do `valor_rateio` dos rateios de capital com base no cálculo:
  - `quantidade_itens_capital × valor_item_capital`

- Adicionados testes unitários para cenários de:
  - divergência do somatório de `valor_original`;
  - divergência de `valor_original` em rateio de capital;
  - divergência de `valor_rateio` em rateio de capital;
  - cenário válido de rateio de capital.

Referência Azure: [AB#148847](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148847)