### PR TITLE
fix(149227): Ata de retificação não aparece para unidade

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.4"
+__version__ = "9.39.5"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -7,20 +7,7 @@ from ..models import Associacao, Periodo, PrestacaoConta, PeriodoInicialAssociac
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
-    """
-    Status Período	Status Documentos PC	Status PC na DRE	Parte Período	        Parte Prestação de Contas	                    Exibe Cadeado	Cor
-    Em andamento	Não gerados	            N/A	                Período em andamento.	 		                                                        1
-    Em andamento	Gerados	                N/A	                Período em andamento.	Documentos gerados para prestação de contas.	            X	2
-    Encerrado	    Não gerados	            Não Recebida	    Período finalizado.	    Documentos Pendentes de geração.		                        3
-    Encerrado	    Gerados	                Não Recebida	    Período finalizado.	    Prestação de Contas ainda não recebida pela DRE.	        X	2
-    Encerrado	    Gerados	                Recebida	        Período finalizado.	    Prestação de Contas recebida pela DRE.	                    X	4
-    Encerrado	    Gerados	                Em Análise	        Período finalizado.	    Prestação de Contas em análise pela DRE.	                X	4
-    Encerrado	    Gerados	                Devolvida	        Período finalizado.	    Prestação de Contas devolvida para ajustes.		                3
-    Encerrado	    Gerados	                Devolvida Retornada Período finalizado.	    Prestação de Contas apresentada após acertos.		            X   2
-    Encerrado	    Gerados	                Devolvida Recebida  Período finalizado.	    Prestação de Contas recebida após acertos.		            X   4
-    Encerrado	    Gerados	                Aprovada	        Período finalizado.	    Prestação de Contas aprovada pela DRE.	                    X	5
-    Encerrado	    Gerados	                Reprovada	        Período finalizado.	    Prestação de Contas reprovada pela DRE.	                    X	3
-    """
+    """Retorna o status da prestação de contas de uma associação em um período."""
 
     def pc_requer_ata_retificacao(prestacao_conta):
         if not prestacao_conta:
@@ -28,7 +15,12 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
 
         ultima_analise = prestacao_conta.analises_da_prestacao.filter(status='DEVOLVIDA').last()
 
-        return ultima_analise is not None and (ultima_analise.requer_alteracao_em_lancamentos or ultima_analise.requer_informacao_devolucao_ao_tesouro)
+        return (
+            ultima_analise is not None and (
+                ultima_analise.requer_alteracao_em_lancamentos or
+                ultima_analise.requer_informacao_devolucao_ao_tesouro
+            )
+        )
 
     def pc_requer_geracao_documentos(prestacao_conta):
         # Necessário devido a conflitos no import direto
@@ -117,6 +109,7 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
         'legenda_cor': cor,
         'prestacao_de_contas_uuid': prestacao.uuid if prestacao and prestacao.uuid else None,
         'requer_retificacao': pc_requer_ata_retificacao(prestacao),
+        'possui_ata_retificacao': prestacao.ultima_ata_retificacao() is not None if prestacao else False,
         'tem_acertos_pendentes': pc_tem_solicitacoes_de_acerto_pendentes(prestacao),
         'requer_acertos_em_extrato': pc_requer_acertos_em_extrato(prestacao),
     }
@@ -176,7 +169,10 @@ def valida_datas_periodo(
             )
 
             if existe_periodo_para_recurso:
-                mensagem = "Período anterior não definido só é permitido para o primeiro período cadastrado para o recurso."
+                mensagem = (
+                    "Período anterior não definido só é permitido para o "
+                    "primeiro período cadastrado para o recurso."
+                )
                 valido = False
         else:
             periodos = (

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -7,7 +7,20 @@ from ..models import Associacao, Periodo, PrestacaoConta, PeriodoInicialAssociac
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
-    """Retorna o status da prestação de contas de uma associação em um período."""
+    """
+    Status Período	Status Documentos PC	Status PC na DRE	Parte Período	        Parte Prestação de Contas	                    Exibe Cadeado	Cor
+    Em andamento	Não gerados	            N/A	                Período em andamento.	 		                                                        1
+    Em andamento	Gerados	                N/A	                Período em andamento.	Documentos gerados para prestação de contas.	            X	2
+    Encerrado	    Não gerados	            Não Recebida	    Período finalizado.	    Documentos Pendentes de geração.		                        3
+    Encerrado	    Gerados	                Não Recebida	    Período finalizado.	    Prestação de Contas ainda não recebida pela DRE.	        X	2
+    Encerrado	    Gerados	                Recebida	        Período finalizado.	    Prestação de Contas recebida pela DRE.	                    X	4
+    Encerrado	    Gerados	                Em Análise	        Período finalizado.	    Prestação de Contas em análise pela DRE.	                X	4
+    Encerrado	    Gerados	                Devolvida	        Período finalizado.	    Prestação de Contas devolvida para ajustes.		                3
+    Encerrado	    Gerados	                Devolvida Retornada Período finalizado.	    Prestação de Contas apresentada após acertos.		            X   2
+    Encerrado	    Gerados	                Devolvida Recebida  Período finalizado.	    Prestação de Contas recebida após acertos.		            X   4
+    Encerrado	    Gerados	                Aprovada	        Período finalizado.	    Prestação de Contas aprovada pela DRE.	                    X	5
+    Encerrado	    Gerados	                Reprovada	        Período finalizado.	    Prestação de Contas reprovada pela DRE.	                    X	3
+    """
 
     def pc_requer_ata_retificacao(prestacao_conta):
         if not prestacao_conta:

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
@@ -24,7 +24,10 @@ def test_action_painel_acoes(
     despesa_fora_periodo,
     rateio_fora_periodo_50_custeio,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/', content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -78,6 +81,7 @@ def test_action_painel_acoes(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
 
@@ -104,8 +108,10 @@ def test_action_painel_acoes_por_periodo(
     despesa_fora_periodo,
     rateio_fora_periodo_50_custeio,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?periodo_uuid={periodo_anterior.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?periodo_uuid={periodo_anterior.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -159,6 +165,7 @@ def test_action_painel_acoes_por_periodo(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -179,7 +186,10 @@ def test_action_painel_acoes_deve_atender_a_ordem_das_acoes(
     receita_100_no_periodo,
     receita_100_no_periodo_acao_de_destaque,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/', content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -265,6 +275,7 @@ def test_action_painel_acoes_deve_atender_a_ordem_das_acoes(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
@@ -25,8 +25,10 @@ def test_action_painel_acoes_de_uma_conta(
     rateio_fora_periodo_50_custeio,
     conta_associacao
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -110,6 +112,7 @@ def test_action_painel_acoes_de_uma_conta(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -138,8 +141,10 @@ def test_action_painel_acoes_de_uma_conta_tendo_outras_contas(
     conta_associacao_cartao,
     rateio_no_periodo_1500_capital_outra_conta
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -223,6 +228,7 @@ def test_action_painel_acoes_de_uma_conta_tendo_outras_contas(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -249,8 +255,10 @@ def test_action_painel_acoes_de_uma_conta_invalida(
     rateio_fora_periodo_50_custeio,
     conta_associacao
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta=NAOEXISTE',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta=NAOEXISTE',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {'erro': 'UUID da conta inválido.'}

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -34,6 +34,7 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
             'texto_status': 'Período em andamento. ',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -77,6 +78,7 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -98,7 +100,9 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
     assert result == esperado
 
 
-def test_chamada_sem_passar_data(jwt_authenticated_client_a, associacao, periodo_2020_1, prestacao_conta_2020_1_conciliada):
+def test_chamada_sem_passar_data(
+    jwt_authenticated_client_a, associacao, periodo_2020_1, prestacao_conta_2020_1_conciliada
+):
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/',
                                               content_type='application/json')
     result = json.loads(response.content)
@@ -147,8 +151,10 @@ def test_chamada_data_sem_periodo(jwt_authenticated_client_a, associacao, period
 def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prestacao_conta_2020_1_conciliada):
     periodo = prestacao_conta_2020_1_conciliada.periodo
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
     esperado = {
         'associacao': f'{associacao.uuid}',
@@ -167,6 +173,7 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
             'texto_status': 'Período finalizado. Prestação de contas ainda não recebida pela DRE.',
             'prestacao_de_contas_uuid': f'{prestacao_conta_2020_1_conciliada.uuid}',
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -204,8 +211,10 @@ def _prestacao_conta_devolvida(periodo, associacao):
 def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, associacao, _prestacao_conta_devolvida):
     periodo = _prestacao_conta_devolvida.periodo
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -225,6 +234,7 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
             'texto_status': 'Período finalizado. Prestação de contas devolvida para ajustes.',
             'prestacao_de_contas_uuid': f'{_prestacao_conta_devolvida.uuid}',
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -253,8 +263,10 @@ def test_status_periodo_pendencias_cadastrais_com_contas_pendentes(
     observacao_conciliacao_campos_nao_preenchidos_002,
     periodo_2020_1
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -275,8 +287,10 @@ def test_status_periodo_pendencias_cadastrais_somente_uma_conta_pendente(
     periodo_2020_1
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -302,8 +316,10 @@ def test_status_periodo_pendencias_cadastrais_sem_contas_pendentes(
     periodo_2020_1,
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -327,8 +343,11 @@ def test_status_periodo_pendencias_cadastrais_somente_dados_associacao_com_pende
     periodo_2020_1,
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -351,8 +370,11 @@ def test_status_periodo_todas_as_pendencias_cadastrais(
     conta_associacao_incompleta,
     periodo_2020_1,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -392,7 +414,9 @@ def test_status_periodo_saldo_zerado_sem_justificativa(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=0,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante, texto=None)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -424,7 +448,9 @@ def test_status_periodo_saldo_diferente_de_zero_sem_justificativa(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=1000,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante, texto=None)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -457,7 +483,9 @@ def test_status_periodo_sem_pendencias(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=1000,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -477,8 +505,11 @@ def test_status_periodo_com_conta_encerrada_com_saldo(
     solicitacao_encerramento_conta_pendente,
     receita_conta_encerrada
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -495,8 +526,11 @@ def test_status_periodo_anterior_com_conta_encerrada_com_saldo(
     solicitacao_encerramento_conta_pendente,
     receita_conta_encerrada
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_aberto.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_aberto.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -511,10 +545,37 @@ def test_status_periodo_com_conta_encerrada_sem_saldo(
     conta_associacao_encerramento_conta,
     solicitacao_encerramento_conta_aprovada,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
     assert 'tem_conta_encerrada_com_saldo' in result
     assert result['tem_conta_encerrada_com_saldo'] is False
+
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_em_analise_com_ata_retificacao_existente(
+    jwt_authenticated_client_a,
+    associacao,
+    prestacao_conta_2020_1_conciliada,
+    ata_2020_1_retificacao,
+):
+    prestacao_conta_2020_1_conciliada.status = PrestacaoConta.STATUS_EM_ANALISE
+    prestacao_conta_2020_1_conciliada.save()
+
+    periodo = prestacao_conta_2020_1_conciliada.periodo
+
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['prestacao_contas_status']['status_prestacao'] == PrestacaoConta.STATUS_EM_ANALISE
+    assert result['prestacao_contas_status']['requer_retificacao'] is False
+    assert result['prestacao_contas_status']['possui_ata_retificacao'] is True

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
@@ -37,6 +37,7 @@ def test_obtem_painel_resumo_recursos_por_associacao_periodo_conta(
         'status_prestacao': 'NAO_APRESENTADA',
         'texto_status': 'Período em andamento. ',
         'requer_retificacao': False,
+        'possui_ata_retificacao': False,
         'tem_acertos_pendentes': False,
         'requer_acertos_em_extrato': False
 

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
@@ -25,6 +25,7 @@ def test_painel_resumo_recursos_retorna_info_conta(
         'status_prestacao': 'NAO_APRESENTADA',
         'texto_status': 'Período em andamento. ',
         'requer_retificacao': False,
+        'possui_ata_retificacao': False,
         'tem_acertos_pendentes': False,
         'requer_acertos_em_extrato': False
 
@@ -101,8 +102,12 @@ def test_painel_resumo_recursos_retorna_info_conta(
         'associacao': prr_associacao.uuid,
         'periodo_referencia': prr_periodo_2020_1.referencia,
         'prestacao_contas_status': status_pc_esperado,
-        'data_inicio_realizacao_despesas': f'{prr_periodo_2020_1.data_inicio_realizacao_despesas if prr_periodo_2020_1 else ""}',
-        'data_fim_realizacao_despesas': f'{prr_periodo_2020_1.data_fim_realizacao_despesas if prr_periodo_2020_1 else ""}',
+        'data_inicio_realizacao_despesas': (
+            f'{prr_periodo_2020_1.data_inicio_realizacao_despesas if prr_periodo_2020_1 else ""}'
+        ),
+        'data_fim_realizacao_despesas': (
+            f'{prr_periodo_2020_1.data_fim_realizacao_despesas if prr_periodo_2020_1 else ""}'
+        ),
         'data_prevista_repasse': f'{prr_periodo_2020_1.data_prevista_repasse if prr_periodo_2020_1 else ""}',
         'ultima_atualizacao': '2020-01-01 10:20:00',
         'info_acoes': info_acoes_esperado,


### PR DESCRIPTION
Esse PR:

- Corrige a visualização da ata de retificação para a unidade.

História: [AB#149227](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149227)