### PR TITLE
fix(149227): Ata de retificação não aparece para unidade -> testes

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.3"
+__version__ = "9.39.4"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.39.4"
+__version__ = "9.39.5"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -7,20 +7,7 @@ from ..models import Associacao, Periodo, PrestacaoConta, PeriodoInicialAssociac
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
-    """
-    Status Período	Status Documentos PC	Status PC na DRE	Parte Período	        Parte Prestação de Contas	                    Exibe Cadeado	Cor
-    Em andamento	Não gerados	            N/A	                Período em andamento.	 		                                                        1
-    Em andamento	Gerados	                N/A	                Período em andamento.	Documentos gerados para prestação de contas.	            X	2
-    Encerrado	    Não gerados	            Não Recebida	    Período finalizado.	    Documentos Pendentes de geração.		                        3
-    Encerrado	    Gerados	                Não Recebida	    Período finalizado.	    Prestação de Contas ainda não recebida pela DRE.	        X	2
-    Encerrado	    Gerados	                Recebida	        Período finalizado.	    Prestação de Contas recebida pela DRE.	                    X	4
-    Encerrado	    Gerados	                Em Análise	        Período finalizado.	    Prestação de Contas em análise pela DRE.	                X	4
-    Encerrado	    Gerados	                Devolvida	        Período finalizado.	    Prestação de Contas devolvida para ajustes.		                3
-    Encerrado	    Gerados	                Devolvida Retornada Período finalizado.	    Prestação de Contas apresentada após acertos.		            X   2
-    Encerrado	    Gerados	                Devolvida Recebida  Período finalizado.	    Prestação de Contas recebida após acertos.		            X   4
-    Encerrado	    Gerados	                Aprovada	        Período finalizado.	    Prestação de Contas aprovada pela DRE.	                    X	5
-    Encerrado	    Gerados	                Reprovada	        Período finalizado.	    Prestação de Contas reprovada pela DRE.	                    X	3
-    """
+    """Retorna o status da prestação de contas de uma associação em um período."""
 
     def pc_requer_ata_retificacao(prestacao_conta):
         if not prestacao_conta:
@@ -28,7 +15,12 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
 
         ultima_analise = prestacao_conta.analises_da_prestacao.filter(status='DEVOLVIDA').last()
 
-        return ultima_analise is not None and (ultima_analise.requer_alteracao_em_lancamentos or ultima_analise.requer_informacao_devolucao_ao_tesouro)
+        return (
+            ultima_analise is not None and (
+                ultima_analise.requer_alteracao_em_lancamentos or
+                ultima_analise.requer_informacao_devolucao_ao_tesouro
+            )
+        )
 
     def pc_requer_geracao_documentos(prestacao_conta):
         # Necessário devido a conflitos no import direto
@@ -117,6 +109,7 @@ def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
         'legenda_cor': cor,
         'prestacao_de_contas_uuid': prestacao.uuid if prestacao and prestacao.uuid else None,
         'requer_retificacao': pc_requer_ata_retificacao(prestacao),
+        'possui_ata_retificacao': prestacao.ultima_ata_retificacao() is not None if prestacao else False,
         'tem_acertos_pendentes': pc_tem_solicitacoes_de_acerto_pendentes(prestacao),
         'requer_acertos_em_extrato': pc_requer_acertos_em_extrato(prestacao),
     }
@@ -176,7 +169,10 @@ def valida_datas_periodo(
             )
 
             if existe_periodo_para_recurso:
-                mensagem = "Período anterior não definido só é permitido para o primeiro período cadastrado para o recurso."
+                mensagem = (
+                    "Período anterior não definido só é permitido para o "
+                    "primeiro período cadastrado para o recurso."
+                )
                 valido = False
         else:
             periodos = (

--- a/sme_ptrf_apps/core/services/periodo_services.py
+++ b/sme_ptrf_apps/core/services/periodo_services.py
@@ -7,7 +7,20 @@ from ..models import Associacao, Periodo, PrestacaoConta, PeriodoInicialAssociac
 
 
 def status_prestacao_conta_associacao(periodo_uuid, associacao_uuid):
-    """Retorna o status da prestação de contas de uma associação em um período."""
+    """
+    Status Período	Status Documentos PC	Status PC na DRE	Parte Período	        Parte Prestação de Contas	                    Exibe Cadeado	Cor
+    Em andamento	Não gerados	            N/A	                Período em andamento.	 		                                                        1
+    Em andamento	Gerados	                N/A	                Período em andamento.	Documentos gerados para prestação de contas.	            X	2
+    Encerrado	    Não gerados	            Não Recebida	    Período finalizado.	    Documentos Pendentes de geração.		                        3
+    Encerrado	    Gerados	                Não Recebida	    Período finalizado.	    Prestação de Contas ainda não recebida pela DRE.	        X	2
+    Encerrado	    Gerados	                Recebida	        Período finalizado.	    Prestação de Contas recebida pela DRE.	                    X	4
+    Encerrado	    Gerados	                Em Análise	        Período finalizado.	    Prestação de Contas em análise pela DRE.	                X	4
+    Encerrado	    Gerados	                Devolvida	        Período finalizado.	    Prestação de Contas devolvida para ajustes.		                3
+    Encerrado	    Gerados	                Devolvida Retornada Período finalizado.	    Prestação de Contas apresentada após acertos.		            X   2
+    Encerrado	    Gerados	                Devolvida Recebida  Período finalizado.	    Prestação de Contas recebida após acertos.		            X   4
+    Encerrado	    Gerados	                Aprovada	        Período finalizado.	    Prestação de Contas aprovada pela DRE.	                    X	5
+    Encerrado	    Gerados	                Reprovada	        Período finalizado.	    Prestação de Contas reprovada pela DRE.	                    X	3
+    """
 
     def pc_requer_ata_retificacao(prestacao_conta):
         if not prestacao_conta:

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes.py
@@ -24,7 +24,10 @@ def test_action_painel_acoes(
     despesa_fora_periodo,
     rateio_fora_periodo_50_custeio,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/', content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -78,6 +81,7 @@ def test_action_painel_acoes(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
 
@@ -104,8 +108,10 @@ def test_action_painel_acoes_por_periodo(
     despesa_fora_periodo,
     rateio_fora_periodo_50_custeio,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?periodo_uuid={periodo_anterior.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?periodo_uuid={periodo_anterior.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -159,6 +165,7 @@ def test_action_painel_acoes_por_periodo(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -179,7 +186,10 @@ def test_action_painel_acoes_deve_atender_a_ordem_das_acoes(
     receita_100_no_periodo,
     receita_100_no_periodo_acao_de_destaque,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/', content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -265,6 +275,7 @@ def test_action_painel_acoes_deve_atender_a_ordem_das_acoes(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_painel_acoes_de_uma_conta.py
@@ -25,8 +25,10 @@ def test_action_painel_acoes_de_uma_conta(
     rateio_fora_periodo_50_custeio,
     conta_associacao
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -110,6 +112,7 @@ def test_action_painel_acoes_de_uma_conta(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -138,8 +141,10 @@ def test_action_painel_acoes_de_uma_conta_tendo_outras_contas(
     conta_associacao_cartao,
     rateio_no_periodo_1500_capital_outra_conta
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta={conta_associacao.uuid}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -223,6 +228,7 @@ def test_action_painel_acoes_de_uma_conta_tendo_outras_contas(
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -249,8 +255,10 @@ def test_action_painel_acoes_de_uma_conta_invalida(
     rateio_fora_periodo_50_custeio,
     conta_associacao
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta=NAOEXISTE',
-                          content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/painel-acoes/?conta=NAOEXISTE',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {'erro': 'UUID da conta inválido.'}

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_action_status_periodo.py
@@ -34,6 +34,7 @@ def test_status_periodo_em_andamento(jwt_authenticated_client_a, associacao, per
             'texto_status': 'Período em andamento. ',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -77,6 +78,7 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
             'texto_status': 'Período finalizado. Documentos pendentes de geração.',
             'prestacao_de_contas_uuid': None,
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -98,7 +100,9 @@ def test_status_periodo_pendente(jwt_authenticated_client_a, associacao, periodo
     assert result == esperado
 
 
-def test_chamada_sem_passar_data(jwt_authenticated_client_a, associacao, periodo_2020_1, prestacao_conta_2020_1_conciliada):
+def test_chamada_sem_passar_data(
+    jwt_authenticated_client_a, associacao, periodo_2020_1, prestacao_conta_2020_1_conciliada
+):
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/',
                                               content_type='application/json')
     result = json.loads(response.content)
@@ -147,8 +151,10 @@ def test_chamada_data_sem_periodo(jwt_authenticated_client_a, associacao, period
 def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prestacao_conta_2020_1_conciliada):
     periodo = prestacao_conta_2020_1_conciliada.periodo
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
     esperado = {
         'associacao': f'{associacao.uuid}',
@@ -167,6 +173,7 @@ def test_status_periodo_finalizado(jwt_authenticated_client_a, associacao, prest
             'texto_status': 'Período finalizado. Prestação de contas ainda não recebida pela DRE.',
             'prestacao_de_contas_uuid': f'{prestacao_conta_2020_1_conciliada.uuid}',
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -204,8 +211,10 @@ def _prestacao_conta_devolvida(periodo, associacao):
 def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, associacao, _prestacao_conta_devolvida):
     periodo = _prestacao_conta_devolvida.periodo
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     esperado = {
@@ -225,6 +234,7 @@ def test_status_periodo_devolvido_para_acertos(jwt_authenticated_client_a, assoc
             'texto_status': 'Período finalizado. Prestação de contas devolvida para ajustes.',
             'prestacao_de_contas_uuid': f'{_prestacao_conta_devolvida.uuid}',
             'requer_retificacao': False,
+            'possui_ata_retificacao': False,
             'tem_acertos_pendentes': False,
             'requer_acertos_em_extrato': False
         },
@@ -253,8 +263,10 @@ def test_status_periodo_pendencias_cadastrais_com_contas_pendentes(
     observacao_conciliacao_campos_nao_preenchidos_002,
     periodo_2020_1
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -275,8 +287,10 @@ def test_status_periodo_pendencias_cadastrais_somente_uma_conta_pendente(
     periodo_2020_1
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -302,8 +316,10 @@ def test_status_periodo_pendencias_cadastrais_sem_contas_pendentes(
     periodo_2020_1,
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -327,8 +343,11 @@ def test_status_periodo_pendencias_cadastrais_somente_dados_associacao_com_pende
     periodo_2020_1,
 ):
 
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao_cadastro_incompleto.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -351,8 +370,11 @@ def test_status_periodo_todas_as_pendencias_cadastrais(
     conta_associacao_incompleta,
     periodo_2020_1,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_incompleta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     pendencias_cadastrais_esperado = {
@@ -392,7 +414,9 @@ def test_status_periodo_saldo_zerado_sem_justificativa(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=0,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante, texto=None)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -424,7 +448,9 @@ def test_status_periodo_saldo_diferente_de_zero_sem_justificativa(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=1000,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante, texto=None)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -457,7 +483,9 @@ def test_status_periodo_sem_pendencias(
     periodo_2020_1 = periodo_factory.create(data_inicio_realizacao_despesas=datetime(2020, 1, 1),
                                             data_fim_realizacao_despesas=datetime(2020, 5, 30))
     observacao_conciliacao_factory.create(data_extrato=periodo_2020_1.data_fim_realizacao_despesas, saldo_extrato=1000,
-                                          periodo=periodo_2020_1, associacao=associacao, conta_associacao=conta_associacao,
+                                          periodo=periodo_2020_1,
+                                          associacao=associacao,
+                                          conta_associacao=conta_associacao,
                                           comprovante_extrato=comprovante)
 
     response = jwt_authenticated_client_a.get(f'/api/associacoes/{associacao.uuid}/status-periodo/?data=2020-01-01',
@@ -477,8 +505,11 @@ def test_status_periodo_com_conta_encerrada_com_saldo(
     solicitacao_encerramento_conta_pendente,
     receita_conta_encerrada
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -495,8 +526,11 @@ def test_status_periodo_anterior_com_conta_encerrada_com_saldo(
     solicitacao_encerramento_conta_pendente,
     receita_conta_encerrada
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_aberto.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_aberto.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
@@ -511,10 +545,37 @@ def test_status_periodo_com_conta_encerrada_sem_saldo(
     conta_associacao_encerramento_conta,
     solicitacao_encerramento_conta_aprovada,
 ):
-    response = jwt_authenticated_client_a.get(f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/?data={periodo_2020_1.data_inicio_realizacao_despesas}',
-                                              content_type='application/json')
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{conta_associacao_encerramento_conta.associacao.uuid}/status-periodo/'
+        f'?data={periodo_2020_1.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
     result = json.loads(response.content)
 
     assert response.status_code == status.HTTP_200_OK
     assert 'tem_conta_encerrada_com_saldo' in result
     assert result['tem_conta_encerrada_com_saldo'] is False
+
+
+@freeze_time('2020-07-10 10:20:00')
+def test_status_periodo_em_analise_com_ata_retificacao_existente(
+    jwt_authenticated_client_a,
+    associacao,
+    prestacao_conta_2020_1_conciliada,
+    ata_2020_1_retificacao,
+):
+    prestacao_conta_2020_1_conciliada.status = PrestacaoConta.STATUS_EM_ANALISE
+    prestacao_conta_2020_1_conciliada.save()
+
+    periodo = prestacao_conta_2020_1_conciliada.periodo
+
+    response = jwt_authenticated_client_a.get(
+        f'/api/associacoes/{associacao.uuid}/status-periodo/?data={periodo.data_inicio_realizacao_despesas}',
+        content_type='application/json',
+    )
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result['prestacao_contas_status']['status_prestacao'] == PrestacaoConta.STATUS_EM_ANALISE
+    assert result['prestacao_contas_status']['requer_retificacao'] is False
+    assert result['prestacao_contas_status']['possui_ata_retificacao'] is True

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_cria_objeto.py
@@ -37,6 +37,7 @@ def test_obtem_painel_resumo_recursos_por_associacao_periodo_conta(
         'status_prestacao': 'NAO_APRESENTADA',
         'texto_status': 'Período em andamento. ',
         'requer_retificacao': False,
+        'possui_ata_retificacao': False,
         'tem_acertos_pendentes': False,
         'requer_acertos_em_extrato': False
 

--- a/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_painel_resumo_recursos_service/test_painel_resumo_recursos_servico_retorna_json.py
@@ -25,6 +25,7 @@ def test_painel_resumo_recursos_retorna_info_conta(
         'status_prestacao': 'NAO_APRESENTADA',
         'texto_status': 'Período em andamento. ',
         'requer_retificacao': False,
+        'possui_ata_retificacao': False,
         'tem_acertos_pendentes': False,
         'requer_acertos_em_extrato': False
 
@@ -101,8 +102,12 @@ def test_painel_resumo_recursos_retorna_info_conta(
         'associacao': prr_associacao.uuid,
         'periodo_referencia': prr_periodo_2020_1.referencia,
         'prestacao_contas_status': status_pc_esperado,
-        'data_inicio_realizacao_despesas': f'{prr_periodo_2020_1.data_inicio_realizacao_despesas if prr_periodo_2020_1 else ""}',
-        'data_fim_realizacao_despesas': f'{prr_periodo_2020_1.data_fim_realizacao_despesas if prr_periodo_2020_1 else ""}',
+        'data_inicio_realizacao_despesas': (
+            f'{prr_periodo_2020_1.data_inicio_realizacao_despesas if prr_periodo_2020_1 else ""}'
+        ),
+        'data_fim_realizacao_despesas': (
+            f'{prr_periodo_2020_1.data_fim_realizacao_despesas if prr_periodo_2020_1 else ""}'
+        ),
         'data_prevista_repasse': f'{prr_periodo_2020_1.data_prevista_repasse if prr_periodo_2020_1 else ""}',
         'ultima_atualizacao': '2020-01-01 10:20:00',
         'info_acoes': info_acoes_esperado,

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -90,6 +90,7 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
         ValidacaoDespesaService.validar_rateios_serializer(
             raw_rateios=self.initial_data.get("rateios", []),
             valor_total=self.initial_data.get("valor_total"),
+            valor_original=self.initial_data.get("valor_original"),
             retem_imposto=self.initial_data.get("retem_imposto", False),
             raw_despesas_impostos=self.initial_data.get("despesas_impostos", []),
             valor_recursos_proprios=self.initial_data.get(

--- a/sme_ptrf_apps/despesas/services/validacao_despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/validacao_despesa_service.py
@@ -9,62 +9,145 @@ class ValidacaoDespesaService:
     @staticmethod
     def validar_rateios_serializer(
         valor_total,
-        raw_rateios=[],
-        raw_despesas_impostos=[],
+        valor_original,
+        raw_rateios=None,
+        raw_despesas_impostos=None,
         retem_imposto=False,
         valor_recursos_proprios=0,
     ):
+        """
+        Regras de validação dos rateios da despesa.
+
+        valor_original:
+            Representa o valor exibido no extrato comprobatório.
+            Esse campo foi criado posteriormente ao valor_rateio para armazenar o
+            valor original informado no documento, mesmo quando
+            ele difere do valor efetivamente pago.
+
+        valor_rateio:
+            Representa o valor efetivamente realizado/pago na operação.
+
+        Regras:
+
+        - A soma dos `valor_rateio` dos rateios deve ser igual ao
+        valor real (`valor_total`) da despesa + impostos (caso haja)
+
+        - A soma dos `valor_original` dos rateios deve ser igual ao
+        `valor_original` informado na despesa + impostos (caso haja)
+
+        Referência: #20303 [Associações] Incluir campos de "valor_realizado" no cadastro de despesa
+        """
+
+        raw_rateios = raw_rateios or []
+        raw_despesas_impostos = raw_despesas_impostos or []        
+    
         if not raw_rateios:
             raise serializers.ValidationError(
                 "A despesa deve conter ao menos um rateio."
             )
 
         total_rateios = sum(
-            Decimal(str(r.get("valor_rateio", 0)))
-            for r in raw_rateios
+            Decimal(str(rateio.get("valor_rateio", 0)))
+            for rateio in raw_rateios
         )
 
-        valor_real = Decimal(str(valor_total or 0)) - Decimal(
+        total_rateios_original = sum(
+            Decimal(str(rateio.get("valor_original", 0)))
+            for rateio in raw_rateios
+        )
+
+        valor_real_despesa = Decimal(str(valor_total or 0)) - Decimal(
             str(valor_recursos_proprios or 0)
         )
 
-        total_rateios_impostos = total_rateios
+        valor_original_despesa = Decimal(str(valor_original or 0))
+
+        total_rateios_com_impostos = total_rateios
+        total_rateios_original_com_impostos = total_rateios_original
 
         if retem_imposto:
-            total_impostos = sum(
-                Decimal(str(r.get("valor_total", 0)))
-                for r in raw_despesas_impostos
+            total_impostos_valor_total = sum(
+                Decimal(str(imposto.get("valor_total", 0)))
+                for imposto in raw_despesas_impostos
             )
 
-            total_rateios_impostos += total_impostos
+            total_impostos_valor_original = sum(
+                Decimal(str(imposto.get("valor_original", 0)))
+                for imposto in raw_despesas_impostos
+            )
 
-        if total_rateios_impostos != valor_real:
+            total_rateios_com_impostos += total_impostos_valor_total
+            total_rateios_original_com_impostos += total_impostos_valor_original
+
+        if total_rateios_com_impostos != valor_real_despesa:
             raise serializers.ValidationError(
-                "A soma dos rateios deve ser igual ao valor real da despesa."
+                "A soma dos valores realizados dos rateios deve "
+                "ser igual ao valor real da despesa."
+            )
+
+        if total_rateios_original_com_impostos != valor_original_despesa:
+            raise serializers.ValidationError(
+                "A soma dos valores originais dos rateios deve "
+                "ser igual ao valor original da despesa."
             )
 
         # Valida rateios do tipo capital
         for rateio in raw_rateios:
-            if rateio.get('aplicacao_recurso') == APLICACAO_CAPITAL:
-                quantidade_itens_capital = rateio.get('quantidade_itens_capital')
-                valor_item_capital = rateio.get('valor_item_capital')
+            if rateio.get("aplicacao_recurso") != APLICACAO_CAPITAL:
+                continue
 
-                if quantidade_itens_capital <= 0:
-                    raise serializers.ValidationError({
-                        'mensagem': 'Rateio de capital não pode ter quantidade menor ou igual a zero'
-                    })
+            quantidade_itens_capital = rateio.get(
+                "quantidade_itens_capital"
+            )
 
-                if valor_item_capital:
-                    valor_total_item_capital = (
-                        Decimal(str(valor_item_capital)) *
-                        Decimal(str(quantidade_itens_capital))
+            valor_item_capital = rateio.get(
+                "valor_item_capital"
+            )
+
+            if quantidade_itens_capital <= 0:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Rateio de capital não pode ter "
+                        "quantidade menor ou igual a zero"
                     )
-                    valor_rateio = Decimal(str(rateio.get('valor_rateio', 0)))
+                })
 
-                    if valor_total_item_capital != valor_rateio:
-                        raise serializers.ValidationError({
-                            'mensagem': 'Valor do rateio capital diverge do valor calculado pela quantidade de itens'
-                        })
+            if not valor_item_capital:
+                continue
+
+            valor_total_item_capital = (
+                Decimal(str(valor_item_capital))
+                * Decimal(str(quantidade_itens_capital))
+            )
+
+            valor_rateio = Decimal(
+                str(rateio.get("valor_rateio", 0))
+            )
+
+            valor_original_rateio = Decimal(
+                str(rateio.get("valor_original", 0))
+            )
+
+            """
+            Atualmente, o campo valor total do capital (valor_original) é
+            disabled e calculado com base no quantidade de unidades x valor)
+            Portanto, não pode divergir do valor realizado, igual é quando CUSTEIO.
+            """
+            if valor_total_item_capital != valor_original_rateio:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Valor total do capital diverge do valor "
+                        "calculado pela quantidade de itens"
+                    )
+                })
+
+            if valor_total_item_capital != valor_rateio:
+                raise serializers.ValidationError({
+                    "mensagem": (
+                        "Valor do rateio capital diverge do valor "
+                        "calculado pela quantidade de itens"
+                    )
+                })
 
     @staticmethod
     def validar_periodo_e_contas(

--- a/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_despesa_paa_prioridades_impacto.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_despesas/test_despesa_paa_prioridades_impacto.py
@@ -141,6 +141,7 @@ def _payload_despesa_capital(associacao, tipo_documento, tipo_transacao, conta_a
         "nome_fornecedor": "FORNECEDOR TESTE SA",
         "data_transacao": "2020-03-10",
         "valor_total": float(valor_rateio),
+        "valor_original": float(valor_rateio),
         "valor_recursos_proprios": 0,
         "motivos_pagamento_antecipado": [],
         "outros_motivos_pagamento_antecipado": "",
@@ -153,6 +154,7 @@ def _payload_despesa_capital(associacao, tipo_documento, tipo_transacao, conta_a
                 "tipo_custeio": None,
                 "especificacao_material_servico": especificacao_capital.id,
                 "valor_rateio": float(valor_rateio),
+                "valor_original": float(valor_rateio),
                 "quantidade_itens_capital": 2,
                 "valor_item_capital": float(valor_rateio) / 2,
                 "numero_processo_incorporacao_capital": "9876543210",
@@ -525,7 +527,7 @@ class TestPostDespesaCapitalComSaldoNegativo:
             associacao, tipo_documento, tipo_transacao,
             conta_associacao, acao_associacao,
             especificacao_capital,
-            valor_rateio=100,
+            valor_rateio=100,            
         )
 
         response = jwt_authenticated_client_d.post(

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_validacao_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_validacao_despesa_service.py
@@ -33,12 +33,14 @@ def test_validar_rateios_serializer_ok():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CUSTEIO,
         }
     ]
 
     ValidacaoDespesaService.validar_rateios_serializer(
         valor_total=100,
+        valor_original=100,
         raw_rateios=rateios,
         raw_despesas_impostos=[],
         retem_imposto=False,
@@ -50,6 +52,7 @@ def test_validar_rateios_serializer_sem_rateios():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=[],
         )
 
@@ -58,22 +61,24 @@ def test_validar_rateios_serializer_sem_rateios():
 
 def test_validar_rateios_serializer_soma_invalida():
     rateios = [
-        {"valor_rateio": 80, "aplicacao_recurso": APLICACAO_CUSTEIO},
+        {"valor_rateio": 80, "valor_original": 80, "aplicacao_recurso": APLICACAO_CUSTEIO},
     ]
 
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
-    assert "soma dos rateios" in str(exc.value)
+    assert "soma dos valores" in str(exc.value)
 
 
 def test_rateio_capital_quantidade_zero():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 0,
             "valor_item_capital": 50,
@@ -83,6 +88,7 @@ def test_rateio_capital_quantidade_zero():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
@@ -93,6 +99,7 @@ def test_rateio_capital_valor_divergente():
     rateios = [
         {
             "valor_rateio": 100,
+            "valor_original": 100,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 2,
             "valor_item_capital": 40,
@@ -102,6 +109,7 @@ def test_rateio_capital_valor_divergente():
     with pytest.raises(serializers.ValidationError) as exc:
         ValidacaoDespesaService.validar_rateios_serializer(
             valor_total=100,
+            valor_original=100,
             raw_rateios=rateios,
         )
 
@@ -113,6 +121,7 @@ def test_rateio_capital_valores_float_equivalentes_decimal():
     rateios = [
         {
             "valor_rateio": 1838.7,
+            "valor_original": 1838.7,
             "aplicacao_recurso": APLICACAO_CAPITAL,
             "quantidade_itens_capital": 3,
             "valor_item_capital": 612.9,
@@ -121,6 +130,7 @@ def test_rateio_capital_valores_float_equivalentes_decimal():
 
     ValidacaoDespesaService.validar_rateios_serializer(
         valor_total=1838.7,
+        valor_original=1838.7,
         raw_rateios=rateios,
     )
 
@@ -201,3 +211,87 @@ def test_validar_conta_imposto_inicio_maior(conta_ativa, recurso_legado):
         )
 
     assert "rateios de imposto" in str(exc.value)
+
+def test_validar_rateios_serializer_soma_valor_original_invalida():
+    rateios = [
+        {
+            "valor_rateio": 100,
+            "valor_original": 80,
+            "aplicacao_recurso": APLICACAO_CUSTEIO,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=100,
+            valor_original=100,
+            raw_rateios=rateios,
+        )
+
+    assert "valores originais dos rateios" in str(exc.value)
+
+
+def test_rateio_capital_valor_original_divergente():
+    rateios = [
+        {
+            "valor_rateio": 100,
+            "valor_original": 80,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 50,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=100,
+            valor_original=80,
+            raw_rateios=rateios,
+        )
+
+    assert (
+        "Valor total do capital diverge do valor calculado"
+        in str(exc.value)
+    )
+
+
+def test_rateio_capital_valor_rateio_divergente():
+    rateios = [
+        {
+            "valor_rateio": 80,
+            "valor_original": 100,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 50,
+        }
+    ]
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        ValidacaoDespesaService.validar_rateios_serializer(
+            valor_total=80,
+            valor_original=100,
+            raw_rateios=rateios,
+        )
+
+    assert (
+        "Valor do rateio capital diverge do valor calculado"
+        in str(exc.value)
+    )
+
+
+def test_rateio_capital_valores_validos():
+    rateios = [
+        {
+            "valor_rateio": 120,
+            "valor_original": 120,
+            "aplicacao_recurso": APLICACAO_CAPITAL,
+            "quantidade_itens_capital": 2,
+            "valor_item_capital": 60,
+        }
+    ]
+
+    ValidacaoDespesaService.validar_rateios_serializer(
+        valor_total=120,
+        valor_original=120,
+        raw_rateios=rateios,
+    )


### PR DESCRIPTION
Esse PR:

- Corrige a visualização da ata de retificação para a unidade.

História: [AB#149227](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149227)