### PR TITLE
fix: Ajuste de filtro de pesquisa

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -373,7 +373,7 @@ class AssociacaoAdmin(admin.ModelAdmin):
 @admin.register(ContaAssociacao)
 class ContaAssociacaoAdmin(admin.ModelAdmin):
     list_display = ('associacao', 'tipo_conta', 'status', 'data_inicio')
-    search_fields = ('uuid', 'associacao__unidade__codigo_eol', 'associacao__unidade__nome', 'associacao__nome')
+    search_fields = ('associacao__unidade__codigo_eol', 'associacao__unidade__nome', 'associacao__nome')
     list_filter = ('status', 'tipo_conta', 'associacao__unidade__tipo_unidade',
                    'associacao__unidade__dre', ('data_inicio', DateRangeFilter), RecursoContasAssociacaoListFilter)
     readonly_fields = ('uuid', 'id', 'criado_em', 'alterado_em')

--- a/sme_ptrf_apps/core/tests/tests_conta_associacao/test_conta_associacao_admin.py
+++ b/sme_ptrf_apps/core/tests/tests_conta_associacao/test_conta_associacao_admin.py
@@ -6,7 +6,7 @@ from ...admin_filters import (
 
 # Testes Conta Associação Admin
 def test_conta_associacao_search_fields(conta_associacao_admin):
-    assert conta_associacao_admin.search_fields == ('uuid', 'associacao__unidade__codigo_eol',
+    assert conta_associacao_admin.search_fields == ('associacao__unidade__codigo_eol',
                                                     'associacao__unidade__nome', 'associacao__nome')
 
 


### PR DESCRIPTION


Esse PR:

- Remove o UUID do filtro de pesquisa, evitando a coincidência com o UUID da do código EOL

