### PR TITLE
hotfix(149284): retry no endpoint de edição de despesa + otimizações

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.40.0"
+__version__ = "9.40.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -141,11 +141,30 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
 
-        return DespesaService.update(
-            instance,
-            validated_data,
-            limpar_prioridades_callback=self._limpar_prioridades_paa
-        )
+        from django.db import DatabaseError
+        import time
+
+        max_retries = 3
+        retry_count = 0
+
+        while retry_count < max_retries:
+            try:                
+                return DespesaService.update(
+                    instance,
+                    validated_data,
+                    limpar_prioridades_callback=self._limpar_prioridades_paa
+                )
+            except DatabaseError as e:
+                if "timeout" in str(e).lower() or "closed" in str(e).lower():
+                    retry_count += 1
+                    if retry_count < max_retries:
+                        log.warning(
+                            f"Timeout detectado ao atualizar despesa #{instance.id},"
+                            f" tentando novamente ({retry_count}/{max_retries})"
+                        )
+                        time.sleep(2 ** retry_count)
+                        continue
+                raise
 
     class Meta:
         model = Despesa

--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -142,16 +142,22 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
         from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
 
         from django.db import DatabaseError
+        from copy import deepcopy
         import time
 
         max_retries = 3
         retry_count = 0
 
+        payload_original = deepcopy(validated_data)
+
         while retry_count < max_retries:
-            try:                
+            try:
+                if retry_count > 0:
+                    instance.refresh_from_db()               
+
                 return DespesaService.update(
                     instance,
-                    validated_data,
+                    deepcopy(payload_original),
                     limpar_prioridades_callback=self._limpar_prioridades_paa
                 )
             except DatabaseError as e:

--- a/sme_ptrf_apps/despesas/models/despesa.py
+++ b/sme_ptrf_apps/despesas/models/despesa.py
@@ -131,7 +131,7 @@ class Despesa(ModeloBase):
 
         return
 
-    def set_despesa_anterior_ao_uso_do_sistema(self):
+    def set_despesa_anterior_ao_uso_do_sistema(self, salvar=True):
         logger.info(
             "Método set_despesa_anterior_ao_uso_do_sistema. Verificando se a flag "
             "<ajustes-despesas-anteriores> está ativa...")
@@ -164,7 +164,8 @@ class Despesa(ModeloBase):
 
             logger.info(f"Setando despesa {self} como despesa_anterior_ao_uso_do_sistema")
 
-            self.save()
+            if salvar:
+                self.save()
 
         return
 
@@ -411,11 +412,13 @@ class Despesa(ModeloBase):
 
         return completo
 
-    def atualiza_status(self):
+    def atualiza_status(self, salvar=True):
         if self.data_e_hora_de_inativacao:
             if self.status != STATUS_INATIVO:
                 self.status = STATUS_INATIVO
-                self.save()
+
+                if salvar:
+                    self.save()
             return
 
         cadastro_completo = self.cadastro_completo()
@@ -532,6 +535,10 @@ def rateio_post_save(instance, created, **kwargs):
     A existência da tabela de fornecedores é apenas para facilitar o preenchimento da despesa pelas associações
     Alterações feitas por uma associação no nome de um fornecedor não deve alterar diretamente as despesas de outras
     """
+
+    if getattr(instance, "_skip_fornecedor_signal", False):
+        return
+
     if instance and instance.cpf_cnpj_fornecedor and instance.nome_fornecedor:
         Fornecedor.atualiza_ou_cria(cpf_cnpj=instance.cpf_cnpj_fornecedor, nome=instance.nome_fornecedor)
 

--- a/sme_ptrf_apps/despesas/services/despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/despesa_service.py
@@ -102,28 +102,38 @@ class DespesaService:
     # =====================================================
     @classmethod
     @transaction.atomic
-    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None):
-        logger.info("Iniciando atualização de despesa")
+    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None):        
 
-        rateios = validated_data.pop("rateios")
-        despesas_impostos = validated_data.pop("despesas_impostos", [])
+        logger.info(f"Iniciando atualização de despesa: #{instance.id}")
+        
+        # Desliga signal por questões de performance
+        instance._skip_fornecedor_signal = True
 
-        cls._validar_datas_update(instance, validated_data)
-        motivos, outros = cls._processar_pagamento_antecipado(validated_data)
+        try:
+            rateios = validated_data.pop("rateios")
+            despesas_impostos = validated_data.pop("despesas_impostos", [])
 
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
+            cls._validar_datas_update(instance, validated_data)
+            motivos, outros = cls._processar_pagamento_antecipado(validated_data)
 
-        instance.save()
+            # Executa apenas quando há alterações de dados do fornecedor
+            cls._cria_atualiza_fornecedor(instance, validated_data)
 
-        cls._atualizar_rateios(instance, rateios)
-        cls._aplicar_motivos(instance, motivos, outros)
+            # Atualiza instancia
+            for attr, value in validated_data.items():
+                setattr(instance, attr, value)
 
-        cls._processar_impostos_update(instance, despesas_impostos)
+            cls._atualizar_rateios(instance, rateios)
+            cls._aplicar_motivos(instance, motivos, outros)
 
-        cls._finalizar_despesa(instance, rateios, limpar_prioridades_callback)
+            cls._processar_impostos_update(instance, despesas_impostos)            
 
-        return instance
+            cls._finalizar_despesa(instance, rateios, limpar_prioridades_callback)
+
+            return instance
+        finally:
+            instance._skip_fornecedor_signal = False
+
 
     # =====================================================
     # VALIDAÇÕES
@@ -318,9 +328,21 @@ class DespesaService:
                 obj = RateioDespesa.objects.create(**rateio, despesa=despesa)
                 keep.append(obj.uuid)
 
-            obj.save()
-
         RateioDespesa.objects.filter(despesa=despesa).exclude(uuid__in=keep).delete()
+
+    def _cria_atualiza_fornecedor(despesa: Despesa, validated_data: dict):
+        from sme_ptrf_apps.despesas.models.fornecedor import Fornecedor
+
+        doc_fornecedor = validated_data.get('cpf_cnpj_fornecedor')
+        nome_fornecedor = validated_data.get('nome_fornecedor')
+
+        if doc_fornecedor and nome_fornecedor:
+            if despesa.nome_fornecedor != nome_fornecedor or despesa.cpf_cnpj_fornecedor != doc_fornecedor:
+                logger.info(f"Cria/Atualiza fornecedor: {doc_fornecedor}")
+                Fornecedor.atualiza_ou_cria(
+                    cpf_cnpj=despesa.cpf_cnpj_fornecedor, 
+                    nome=despesa.nome_fornecedor
+                )
 
     # =====================================================
     # IMPOSTOS
@@ -409,8 +431,10 @@ class DespesaService:
 
         # Atualiza status dos impostos após vínculo
         for despesa_imposto in despesa.despesas_impostos.all():
+            despesa_imposto._skip_fornecedor_signal = True
             despesa_imposto.verifica_data_documento_vazio()
             despesa_imposto.atualiza_status()
+            despesa_imposto._skip_fornecedor_signal = False
 
     # =====================================================
     # FINALIZAÇÃO
@@ -423,11 +447,12 @@ class DespesaService:
 
     @staticmethod
     def _finalizar_despesa(despesa: Despesa, rateios, limpar_callback):
-        despesa.atualiza_status()
-        despesa.save()
+        despesa.atualiza_status(salvar=False)
 
         if despesa.data_transacao:
-            despesa.set_despesa_anterior_ao_uso_do_sistema()
+            despesa.set_despesa_anterior_ao_uso_do_sistema(salvar=False)
+
+        despesa.save()
 
         if despesa.status == STATUS_COMPLETO and limpar_callback:
             limpar_callback(rateios, despesa)

--- a/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/tests/tests_despesas/test_despesa_serializer.py
@@ -1,5 +1,6 @@
 import pytest
-
+from unittest.mock import Mock, patch
+from django.db import DatabaseError
 from ...api.serializers.despesa_serializer import (DespesaSerializer, DespesaCreateSerializer, DespesaListSerializer)
 
 pytestmark = pytest.mark.django_db
@@ -51,3 +52,50 @@ def test_list_serializer(despesa):
     assert serializer.data['nome_fornecedor']
     assert serializer.data['valor_total']
     assert serializer.data['valor_ptrf']
+
+def test_update_do_create_serializer_deve_fazer_retry_quando_ocorrer_timeout(despesa):
+    validated_data = {}
+
+    resultado_esperado = Mock()
+
+    with patch(
+        "sme_ptrf_apps.despesas.services.despesa_service.DespesaService.update"
+    ) as mock_update, patch("time.sleep") as mock_sleep:
+
+        mock_update.side_effect = [
+            DatabaseError("timeout na conexão"),
+            resultado_esperado,
+        ]
+       
+        resultado = DespesaCreateSerializer(despesa).update(
+            instance=despesa,
+            validated_data=validated_data
+        )
+
+        assert resultado == resultado_esperado
+        assert mock_update.call_count == 2
+
+        mock_sleep.assert_called_once_with(2)
+
+
+def test_update_do_create_nao_deve_fazer_retry_para_erros_nao_recuperaveis(
+    despesa
+):
+    validated_data = {}
+
+    with patch(
+        "sme_ptrf_apps.despesas.services.despesa_service.DespesaService.update"
+    ) as mock_update, patch("time.sleep") as mock_sleep:
+
+        mock_update.side_effect = DatabaseError(
+            "violacao de constraint"
+        )
+
+        with pytest.raises(DatabaseError):
+            DespesaCreateSerializer(despesa).update(
+                instance=despesa,
+                validated_data=validated_data
+            )
+
+        assert mock_update.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
# O que este PR faz

- Adiciona retry na edição da despesa em `api/despesas/uuid/ (PUT)`
- Aplica otimizações de performance
- Testes unitários

Referência Azure: [AB#149284](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149284)