### PR TITLE
fix(148291): Corrige erro no cadastro processo sei recurso

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/processo_associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/processo_associacao_serializer.py
@@ -81,6 +81,16 @@ class ProcessoAssociacaoCreateSerializer(serializers.ModelSerializer):
                         "periodos": f"O período {periodo.referencia} já está associado a outro ProcessoAssociacao para a associação {associacao}."
                     })
 
+        if not self.instance and not data.get('recurso'):
+            recurso = getattr(request, 'recurso', None) if request else None
+            if not recurso:
+                recurso = Recurso.objects.filter(legado=True).first()
+            if not recurso:
+                raise serializers.ValidationError({
+                    'recurso': 'Recurso não configurado no sistema.'
+                })
+            data['recurso'] = recurso
+
         return data
 
     class Meta:

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -679,16 +679,15 @@ class AssociacoesViewSet(ModelViewSet):
     @action(detail=True, url_path='processos', methods=['get'],
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
     def processos_da_associacao(self, request, uuid=None):
-        recurso_uuid = request.query_params.get('recurso_uuid')
         associacao = self.get_object()
         processos = associacao.processos.all()
+        recurso_legado = Recurso.objects.filter(legado=True).first()
 
-        # Filtragem por recurso se flag estiver ativa
-        if recurso_uuid and flag_is_active(self.request, "premio-excelencia-processo-sei"):
-            processos = processos.filter(recurso__uuid=recurso_uuid)
+        if flag_is_active(self.request, "premio-excelencia-processo-sei"):
+            recurso = getattr(self.request, 'recurso', None) or recurso_legado
+            processos = processos.filter(recurso=recurso)
         else:
-            recurso_legado = Recurso.objects.filter(legado=True).first()
-            processos = processos.filter(recurso__uuid=recurso_legado.uuid)
+            processos = processos.filter(recurso=recurso_legado)
 
         return Response(ProcessoAssociacaoRetrieveSerializer(processos, many=True).data)
 

--- a/sme_ptrf_apps/core/api/views/processos_associacao_viewset.py
+++ b/sme_ptrf_apps/core/api/views/processos_associacao_viewset.py
@@ -31,6 +31,16 @@ class ProcessosAssociacaoViewSet(mixins.RetrieveModelMixin,
         else:
             return ProcessoAssociacaoCreateSerializer
 
+    def _get_recurso_para_processo(self, recurso_uuid=None):
+        recurso_legado = Recurso.objects.filter(legado=True).first()
+
+        if flag_is_active(self.request, "premio-excelencia-processo-sei"):
+            if recurso_uuid:
+                return Recurso.objects.filter(uuid=recurso_uuid).first() or getattr(self.request, 'recurso', None) or recurso_legado
+            return getattr(self.request, 'recurso', None) or recurso_legado
+
+        return recurso_legado
+
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
 
@@ -71,42 +81,22 @@ class ProcessosAssociacaoViewSet(mixins.RetrieveModelMixin,
             return Response({"erro": "Os parâmetros 'associacao_uuid' e 'ano' são obrigatórios."}, status=400)
 
         periodos_query = Periodo.objects.filter(referencia__startswith=ano)
-        
-        if not recurso_uuid:
-            recurso_legado = Recurso.objects.filter(legado=True).first()
+        recurso = self._get_recurso_para_processo(recurso_uuid)
 
-        # Filtra por recurso se o recurso_uuid for fornecido e a flag estiver ativa,
-        # caso contrário, filtra pelo recurso legado
-        if recurso_uuid and flag_is_active(self.request, "premio-excelencia-processo-sei"):
-            recurso = Recurso.objects.filter(uuid=recurso_uuid).first()
-            periodos_query = Periodo.filter_by_recurso(periodos_query, recurso)
-        else:
-            periodos_query = Periodo.filter_by_recurso(periodos_query, recurso_legado)
+        periodos_query = Periodo.filter_by_recurso(periodos_query, recurso)
 
         # Identifica todos os períodos já vinculados a processos para a associação especificada,
         # Excluindo o próprio processo se um UUID foi fornecido.
         processos_associacao_query = ProcessoAssociacao.objects.filter(associacao__uuid=associacao_uuid)
+        processos_associacao_query = ProcessoAssociacao.filter_by_recurso(
+            processos_associacao_query,
+            recurso
+        )
 
-        if recurso_uuid and flag_is_active(self.request, "premio-excelencia-processo-sei"):
-            processos_associacao_query = ProcessoAssociacao.filter_by_recurso(
-                processos_associacao_query,
-                Recurso.objects.filter(uuid=recurso_uuid).first()
-            )
-
-            periodo_inicial_assoc = PeriodoInicialAssociacao.objects.filter(
-                associacao__uuid=associacao_uuid,
-                recurso__uuid=recurso_uuid
-            ).first()
-        else:
-            processos_associacao_query = ProcessoAssociacao.filter_by_recurso(
-                processos_associacao_query,
-                recurso_legado
-            )
-
-            periodo_inicial_assoc = PeriodoInicialAssociacao.objects.filter(
-                associacao__uuid=associacao_uuid,
-                recurso=recurso_legado
-            ).first()
+        periodo_inicial_assoc = PeriodoInicialAssociacao.objects.filter(
+            associacao__uuid=associacao_uuid,
+            recurso=recurso
+        ).first()
 
         if processo_uuid:
             processos_associacao_query = processos_associacao_query.exclude(uuid=processo_uuid)

--- a/sme_ptrf_apps/core/tests/tests_api_processos_associacoes/test_processo_associacao_create.py
+++ b/sme_ptrf_apps/core/tests/tests_api_processos_associacoes/test_processo_associacao_create.py
@@ -188,3 +188,29 @@ def test_create_processo_associacao_com_mesmo_numero_processo_para_outro_ano_na_
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         result = json.loads(response.content)
         assert result == {'numero_processo': ['Este número de processo já está sendo usado.']}
+
+
+def test_create_processo_associacao_sem_recurso_usa_recurso_do_header(
+    jwt_authenticated_client_a,
+    periodos_de_2019_ate_2023,
+    associacao_factory,
+):
+    periodo = Periodo.objects.get(referencia='2019.1')
+    associacao = associacao_factory.create()
+    recurso_legado = Recurso.objects.get(legado=True)
+
+    payload = {
+        'associacao': str(associacao.uuid),
+        'numero_processo': "6016.2026/0099999-9",
+        'ano': '2019',
+        'periodos': [str(periodo.uuid)],
+    }
+
+    with override_flag('periodos-processo-sei', active=True):
+        response = jwt_authenticated_client_a.post(
+            '/api/processos-associacao/', data=json.dumps(payload), content_type='application/json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+        result = json.loads(response.content)
+        processo = ProcessoAssociacao.objects.get(uuid=result['uuid'])
+        assert processo.recurso == recurso_legado


### PR DESCRIPTION
Esse PR:

- Resolve o recurso do processo SEI via request.recurso (header X-Recurso-Selecionado), sem exigir recurso no body na criação;
- Listagem de processos e periodos-disponiveis filtram pelo recurso do header quando premio-excelencia-processo-sei está ativa; caso contrário, usam o legado;
- Teste garantindo criação de processo sem recurso no payload.

História: [AB#148291](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148291)