### PR TITLE
refac(149869): remove campo status valores reprogramados admin

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -298,6 +298,7 @@ class AssociacaoAdmin(admin.ModelAdmin):
     )
     readonly_fields = ('uuid', 'id')
     list_display_links = ('nome', 'cnpj')
+    exclude = ('status_valores_reprogramados',)
 
     actions = ['define_status_nao_finalizado_valores_reprogramados', 'migrar_valores_reprogramados']
 


### PR DESCRIPTION
Este PR inclui:

- Remove campo de status dos valores reprogramados do formulário de Associações no admin;

História: [AB#148840](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148840)
Tarefa: [AB#149869](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149869)