### PR TITLE
fix(148912): ajusta exibição do secretário na visualização da prévia da ata

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.41.0"
+__version__ = "9.41.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/api/serializers/ata_paa_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/ata_paa_serializer.py
@@ -259,9 +259,9 @@ class AtaPaaCreateSerializer(serializers.ModelSerializer):
                     presente_serializer.is_valid(raise_exception=True)
                     presente_object = presente_serializer.save()
 
-                    if presidente:
+                    if presidente or validated_data['presidente_reuniao'] == presente['nome']:
                         presidente_participante = presente_object
-                    elif secretario:
+                    elif secretario or validated_data['secretario_reuniao'] == presente['nome']:
                         secretario_participante = presente_object
 
                     presente_object.eh_conselho_fiscal()

--- a/sme_ptrf_apps/paa/tests/ata_paa/conftest.py
+++ b/sme_ptrf_apps/paa/tests/ata_paa/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from sme_ptrf_apps.core.fixtures.factories import FlagFactory
 
 
 @pytest.fixture
@@ -9,4 +10,12 @@ def usuario_task():
         username='usuario_task_test',
         password='senha123',
         email='task@teste.com'
+    )
+
+
+@pytest.fixture
+def flag_historico_membros():
+    return FlagFactory.create(
+        name='historico-de-membros',
+        everyone=True
     )

--- a/sme_ptrf_apps/paa/tests/ata_paa/test_api_ata_paa.py
+++ b/sme_ptrf_apps/paa/tests/ata_paa/test_api_ata_paa.py
@@ -54,7 +54,7 @@ def test_api_update_ata_paa(jwt_authenticated_client_sme, flag_paa, ata_paa):
     assert registro_alterado.comentarios == "TesteXXX"
 
 
-def test_api_update_ata_paa_com_presentes(jwt_authenticated_client_sme, flag_paa, ata_paa):
+def test_api_update_ata_paa_com_presentes(jwt_authenticated_client_sme, flag_paa, flag_historico_membros, ata_paa):
     """Testa atualizar ata PAA criando presentes automaticamente"""
 
     payload = {
@@ -96,6 +96,99 @@ def test_api_update_ata_paa_com_presentes(jwt_authenticated_client_sme, flag_paa
                 "presente": True,
                 "presidente_da_reuniao": False,
                 "secretario_da_reuniao": False,
+                "conselho_fiscal": False,
+                "professor_gremio": False
+            }
+        ]
+    }
+
+    # Verifica que não há presentes antes
+    assert ata_paa.presentes_na_ata_paa.count() == 0
+
+    response = jwt_authenticated_client_sme.patch(
+        f'/api/atas-paa/{ata_paa.uuid}/',
+        data=json.dumps(payload),
+        content_type='application/json'
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # Recarrega a ata do banco
+    registro_alterado = AtaPaa.by_uuid(uuid=ata_paa.uuid)
+
+    # Verifica os dados da ata
+    assert registro_alterado.tipo_reuniao == 'ORDINARIA'
+    assert registro_alterado.convocacao == "PRIMEIRA"
+    assert registro_alterado.data_reuniao == datetime.date(2025, 6, 20)
+    assert registro_alterado.local_reuniao == "Sala de Reuniões"
+    assert registro_alterado.parecer_conselho == "APROVADA"
+    assert registro_alterado.comentarios == "Reunião de teste com presentes"
+
+    # Verifica que os presentes foram criados
+    assert registro_alterado.presentes_na_ata_paa.count() == 3
+
+    # Verifica os presentes criados
+    presentes = registro_alterado.presentes_na_ata_paa.all()
+    nomes_presentes = [p.nome for p in presentes]
+    assert "João Silva" in nomes_presentes
+    assert "Maria Santos" in nomes_presentes
+    assert "Pedro Oliveira" in nomes_presentes
+
+    # Verifica presidente e secretário
+    assert registro_alterado.presidente_da_reuniao is not None
+    assert registro_alterado.presidente_da_reuniao.nome == "João Silva"
+    assert registro_alterado.secretario_da_reuniao is not None
+    assert registro_alterado.secretario_da_reuniao.nome == "Maria Santos"
+
+    # Verifica dados de um presente específico
+    joao = presentes.get(nome="João Silva")
+    assert joao.identificacao == "1234567"
+    assert joao.cargo == "Presidente da diretoria executiva"
+    assert joao.membro is True
+    assert joao.presente is True
+
+
+def test_api_update_ata_paa_com_presentes_sem_flag_historico_membros(jwt_authenticated_client_sme, flag_paa,
+                                                                     ata_paa):
+    """Testa atualizar ata PAA criando presentes automaticamente"""
+
+    payload = {
+        "tipo_reuniao": "ORDINARIA",
+        "convocacao": "PRIMEIRA",
+        "data_reuniao": "2025-06-20",
+        "hora_reuniao": "14:00",
+        "local_reuniao": "Sala de Reuniões",
+        "parecer_conselho": "APROVADA",
+        "comentarios": "Reunião de teste com presentes",
+        "presidente_reuniao": "João Silva",
+        "secretario_reuniao": "Maria Santos",
+        "presentes_na_ata_paa": [
+            {
+                "nome": "João Silva",
+                "identificacao": "1234567",
+                "cargo": "Presidente da diretoria executiva",
+                "membro": True,
+                "presente": True,
+                "conselho_fiscal": False,
+                "professor_gremio": False
+            },
+            {
+                "nome": "Maria Santos",
+                "identificacao": "7654321",
+                "cargo": "Secretário",
+                "membro": True,
+                "presente": True,
+                "presidente_reuniao": False,
+                "secretario_reuniao": True,
+                "conselho_fiscal": False,
+                "professor_gremio": False
+            },
+            {
+                "nome": "Pedro Oliveira",
+                "identificacao": "9876543",
+                "cargo": "Tesoureiro",
+                "membro": True,
+                "presente": True,
                 "conselho_fiscal": False,
                 "professor_gremio": False
             }

--- a/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_serializer.py
+++ b/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_serializer.py
@@ -435,9 +435,38 @@ def test_update_ata_paa_sem_presentes_com_flag_historico(mock_waffle, ata_paa):
     assert ata_paa_atualizada.comentarios == 'Comentários atualizados'
 
 
-def test_update_ata_paa_adiciona_novos_presentes(ata_paa):
+def test_update_ata_paa_adiciona_novos_presentes(ata_paa, flag_historico_membros):
     """Testa que novos participantes são adicionados"""
     validated_data = {
+        'presentes_na_ata_paa': [
+            {
+                'nome': 'João Silva',
+                'cargo': 'Membro',
+                'identificacao': '12345678900',
+                'membro': True
+            },
+            {
+                'nome': 'Maria Santos',
+                'cargo': 'Membro',
+                'identificacao': '98765432100',
+                'membro': True
+            }
+        ]
+    }
+
+    serializer = AtaPaaCreateSerializer()
+    ata_paa_atualizada = serializer.update(ata_paa, validated_data)
+
+    assert ata_paa_atualizada.presentes_na_ata_paa.count() == 2
+    assert ata_paa_atualizada.presentes_na_ata_paa.filter(nome='João Silva').exists()
+    assert ata_paa_atualizada.presentes_na_ata_paa.filter(nome='Maria Santos').exists()
+
+
+def test_update_ata_paa_adiciona_novos_presentes_sem_flag_historico_membros(ata_paa):
+    """Testa que novos participantes são adicionados"""
+    validated_data = {
+        "presidente_reuniao": "João Silva",
+        "secretario_reuniao": "Maria Santos",
         'presentes_na_ata_paa': [
             {
                 'nome': 'João Silva',
@@ -543,7 +572,7 @@ def test_update_ata_paa_define_novo_presidente_com_flag_historico(mock_waffle, a
     assert ata_paa_atualizada.presidente_da_reuniao.nome == 'João Silva'
 
 
-def test_update_ata_paa_define_novo_secretario(ata_paa):
+def test_update_ata_paa_define_novo_secretario(ata_paa, flag_historico_membros):
     """ Testa definição de novo secretário da reunião """
     validated_data = {
         'presentes_na_ata_paa': [
@@ -552,6 +581,27 @@ def test_update_ata_paa_define_novo_secretario(ata_paa):
                 'cargo': 'Secretária',
                 'identificacao': '98765432100',
                 'secretario_da_reuniao': True
+            }
+        ]
+    }
+
+    serializer = AtaPaaCreateSerializer()
+    ata_paa_atualizada = serializer.update(ata_paa, validated_data)
+
+    assert ata_paa_atualizada.secretario_da_reuniao is not None
+    assert ata_paa_atualizada.secretario_da_reuniao.nome == 'Maria Santos'
+
+
+def test_update_ata_paa_define_novo_secretario_sem_flag_historico_membros(ata_paa):
+    """ Testa definição de novo secretário da reunião """
+    validated_data = {
+        "presidente_reuniao": "João Silva",
+        "secretario_reuniao": "Maria Santos",
+        'presentes_na_ata_paa': [
+            {
+                'nome': 'Maria Santos',
+                'cargo': 'Secretária',
+                'identificacao': '98765432100',
             }
         ]
     }


### PR DESCRIPTION

Esse PR:

- Ajusta exibição do secretário na visualização da prévia da ata

História [AB#148912](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148912)

