### PR TITLE
fix(148912): ajusta exibição do secretário na ata gerada - Testes

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.41.1"
+__version__ = "9.41.2"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
@@ -12,7 +12,7 @@
         Não houve manifestações.
       </p>
       {% endif %}
-      
+
       {% if dados.dados_da_ata.parecer_conselho == "APROVADA" %}
       <p class="font-12 texto-justificado pb-2 mb-0">
         Os presentes manifestaram que estão de acordo com o PAA apresentado. Sem ressalvas.
@@ -29,7 +29,7 @@
       </p>
       {% endif %}
       <p class="font-12 texto-justificado pb-2 mb-0">
-        Esgotados os assuntos, o (a) senhor (a) presidente ofereceu a palavra a quem dela desejasse fazer uso e, como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual eu, (secretário/a) lavrei a presente ata, que vai por mim assinada
+        Esgotados os assuntos, o (a) senhor (a) presidente ofereceu a palavra a quem dela desejasse fazer uso e, como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual eu, {{ dados.dados_da_ata.secretario_reuniao }} lavrei a presente ata, que vai por mim assinada.
       </p>
     </div>
   </article>


### PR DESCRIPTION

Esse PR:

- Ajusta exibição do secretário na ata gerada

História [AB#148912](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148912)

