### PR TITLE
Feature/150754 150828 exibir quando nao necessario lauda

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -614,7 +614,7 @@ class PrestacaoContaAdmin(admin.ModelAdmin):
     def get_relatorio_referencia(self, obj):
         return obj.consolidado_dre.referencia if obj.consolidado_dre else ""
 
-    get_relatorio_referencia.short_description = 'Publicação'
+    get_relatorio_referencia.short_description = 'Publicação/Relatório'
 
     def get_periodo_referencia(self, obj):
         return obj.periodo.referencia if obj.periodo else ""

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -121,6 +121,15 @@ class PrestacaoConta(ModeloBase):
         default=None
     )
 
+    def _get_instance_text_document_consolidado_pc(self):
+        from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
+
+        recurso = self.periodo.recurso
+        habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+        text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
+        return text_document_consolidado_pc
+
     @property
     def devolvida_para_acertos(self):
         return self.status == PrestacaoConta.STATUS_DEVOLVIDA
@@ -172,8 +181,11 @@ class PrestacaoConta(ModeloBase):
 
     @property
     def get_tooltip_nao_pode_retificar(self):
+        text_document_consolidado_pc = self._get_instance_text_document_consolidado_pc()
+        text_other = text_document_consolidado_pc.text_other(case="lower")
+
         if self.em_retificacao:
-            return "Esta PC foi retificada em outra publicação."
+            return f"Esta PC foi retificada em {text_other}."
         else:
             return None
 
@@ -223,10 +235,15 @@ class PrestacaoConta(ModeloBase):
 
     @property
     def get_mensagem_consolidado_tipo_original(self):
-        tipo_relatorio = "Única" if self.consolidado_dre.sequencia_de_publicacao == 0 \
-            else f'Parcial #{self.consolidado_dre.sequencia_de_publicacao}'
+        text_document_consolidado_pc = self._get_instance_text_document_consolidado_pc()
 
-        mensagem = f"Essa PC consta da Publicação {tipo_relatorio}"
+        tipo_relatorio = text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE if self.consolidado_dre.sequencia_de_publicacao == 0 \
+            else text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL
+
+        mensagem = f"Essa PC consta {text_document_consolidado_pc.text_possessive_with_type_and_sequency(
+            publication_type=tipo_relatorio,
+            sequency_number=self.consolidado_dre.sequencia_de_publicacao
+        )}"
 
         return mensagem
 
@@ -234,20 +251,26 @@ class PrestacaoConta(ModeloBase):
     def get_mensagem_consolidado_tipo_retificacao(self):
         mensagem = ""
 
-        if self.status == self.STATUS_RECEBIDA or self.status == self.STATUS_EM_ANALISE:
-            tipo_relatorio = "Única" if self.consolidado_dre.consolidado_retificado.sequencia_de_publicacao == 0 \
-                else f'Parcial #{self.consolidado_dre.consolidado_retificado.sequencia_de_publicacao}'
+        text_document_consolidado_pc = self._get_instance_text_document_consolidado_pc()
+        text_possessive_document_consolidado_pc = text_document_consolidado_pc.possessive()
 
-            mensagem = f"Essa PC consta da Publicação {tipo_relatorio}"
+        if self.status == self.STATUS_RECEBIDA or self.status == self.STATUS_EM_ANALISE:
+            tipo_relatorio = text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE if self.consolidado_dre.consolidado_retificado.sequencia_de_publicacao == 0 \
+                else text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL
+
+            mensagem = f"Essa PC consta {text_document_consolidado_pc.text_possessive_with_type_and_sequency(
+                publication_type=tipo_relatorio,
+                sequency_number=self.consolidado_dre.consolidado_retificado.sequencia_de_publicacao
+            )}"
 
         elif self.pc_concluida:
             data_publicacao = self.consolidado_dre.get_data_publicacao_do_consolidado_original
             data_publicacao_formatada = data_publicacao.strftime('%d/%m/%Y') if data_publicacao else ""
 
             if self.publicada:
-                mensagem = f"Essa PC consta da Retificação da publicação de {data_publicacao_formatada}"
+                mensagem = f"Essa PC consta da Retificação {text_possessive_document_consolidado_pc} de {data_publicacao_formatada}"
             else:
-                mensagem = f"Essa PC constará da Retificação da publicação de {data_publicacao_formatada}"
+                mensagem = f"Essa PC constará da Retificação {text_possessive_document_consolidado_pc} de {data_publicacao_formatada}"
 
         return mensagem
 
@@ -255,23 +278,26 @@ class PrestacaoConta(ModeloBase):
     def get_mensagem_consolidado_tipo_retificacao_da_retificacao(self):
         mensagem = ""
 
+        text_document_consolidado_pc = self._get_instance_text_document_consolidado_pc()
+        text_possessive_document_consolidado_pc = text_document_consolidado_pc.possessive(case="lower")
+
         if self.status == self.STATUS_RECEBIDA or self.status == self.STATUS_EM_ANALISE:
             data_publicacao = self.consolidado_dre.consolidado_retificado.get_data_publicacao_do_consolidado_original
             data_publicacao_formatada = data_publicacao.strftime('%d/%m/%Y') if data_publicacao else ""
 
-            mensagem = f"Essa PC consta da publicação retificadora de {data_publicacao_formatada}"
+            mensagem = f"Essa PC consta {text_possessive_document_consolidado_pc} retificadora de {data_publicacao_formatada}"
 
         elif self.pc_concluida:
             if self.publicada:
                 data_publicacao = self.consolidado_dre.get_data_publicacao_do_consolidado_original
                 data_publicacao_formatada = data_publicacao.strftime('%d/%m/%Y') if data_publicacao else ""
 
-                mensagem = f"Essa PC consta da publicação retificadora de {data_publicacao_formatada}"
+                mensagem = f"Essa PC consta {text_possessive_document_consolidado_pc} retificadora de {data_publicacao_formatada}"
             else:
                 data_publicacao = self.consolidado_dre.consolidado_retificado.get_data_publicacao_do_consolidado_original
                 data_publicacao_formatada = data_publicacao.strftime('%d/%m/%Y') if data_publicacao else ""
 
-                mensagem = f"Essa PC constará da retificação da publicação retificadora de {data_publicacao_formatada}"
+                mensagem = f"Essa PC constará da retificação {text_possessive_document_consolidado_pc} retificadora de {data_publicacao_formatada}"
 
         return mensagem
 
@@ -609,7 +635,7 @@ class PrestacaoConta(ModeloBase):
     def devolver(self, data_limite_ue):
         from ..services.notificacao_services import notificar_prestacao_de_contas_devolvida_para_acertos
         from ..models import DevolucaoPrestacaoConta, AnalisePrestacaoConta
-        
+
         devolucao = DevolucaoPrestacaoConta.objects.create(
             prestacao_conta=self,
             data=date.today(),

--- a/sme_ptrf_apps/core/services/lauda_pdf_service.py
+++ b/sme_ptrf_apps/core/services/lauda_pdf_service.py
@@ -17,6 +17,7 @@ from sme_ptrf_apps.dre.services.lauda_service import (
     gerar_dados_lauda_agregados_por_unidade,
     separa_status_lauda_pdf,
 )
+from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
 
 logger = logging.getLogger(__name__)
 
@@ -40,15 +41,23 @@ def _montar_titulos_publicacao_lauda(lauda, parcial):
     eh_parcial = "Parcial" if parcial["parcial"] else "Final"
     sequencia_de_publicacao = parcial["sequencia_de_publicacao_atual"]
 
+    recurso = lauda.periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+    text_possessive_lower_document_consolidado_pc = text_document_consolidado_pc.possessive(case="lower")
+
     if eh_retificacao:
         cons_ret = getattr(lauda.consolidado_dre, "consolidado_retificado", None)
         seq_num = getattr(cons_ret, "sequencia_de_publicacao", None) if cons_ret else None
         if seq_num is not None:
             titulo_sequencia_publicacao = f"Lauda referente à Parcial #{seq_num}"
         else:
-            titulo_sequencia_publicacao = "Lauda referente à retificação da publicação"
+            titulo_sequencia_publicacao = f"Lauda referente à retificação {text_possessive_lower_document_consolidado_pc}"
     elif eh_parcial == "Parcial":
-        titulo_sequencia_publicacao = f"Lauda referente à Publicação Parcial #{sequencia_de_publicacao}"
+        titulo_sequencia_publicacao = f"Lauda referente à {text_document_consolidado_pc.text_sequencial(
+            text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
+            sequencia_de_publicacao
+        )}"
     else:
         titulo_sequencia_publicacao = "Lauda final"
 
@@ -58,8 +67,9 @@ def _montar_titulos_publicacao_lauda(lauda, parcial):
         cons_ret = getattr(lauda.consolidado_dre, "consolidado_retificado", None)
         if cons_ret:
             pagina = getattr(cons_ret, "pagina_publicacao", None) or "-"
+            text_possessive_upper_document_consolidado_pc = text_document_consolidado_pc.possessive(case="upper")
             titulo_retificacao = (
-                f"RETIFICAÇÃO DA PUBLICAÇÃO DO DOC {formata_data_publicacao(lauda.consolidado_dre)} "
+                f"RETIFICAÇÃO {text_possessive_upper_document_consolidado_pc} DO DOC {formata_data_publicacao(lauda.consolidado_dre)} "
                 f"- PÁGINA {pagina}"
             )
             subtitulo_retificacao = "LEIA-SE COMO SEGUE E NÃO COMO CONSTOU:"

--- a/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
@@ -27,6 +27,7 @@ from sme_ptrf_apps.users.permissoes import (
 )
 
 from ...services.lauda_service import campo_arquivo_lauda_para_download
+from ...services.consolidado_dre_service import TextDocumentConsolidadoPC
 
 from ...services import concluir_consolidado_dre, \
     verificar_se_status_parcial_ou_total_e_retornar_sequencia_de_publicacao, \
@@ -350,10 +351,14 @@ class ConsolidadosDreViewSet(
 
         alterado_em = ata_parecer_tecnico.preenchida_em
 
+        recurso = periodo.recurso
+        habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+        text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
         if not alterado_em:
             erro = {
                 'erro': 'Ata não preenchida',
-                'mensagem': "Para fazer a publicação você precisa preencher as informações da ata.",
+                'mensagem': f"Para fazer a {text_document_consolidado_pc.normal(case="lower")} você precisa preencher as informações da ata.",
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
@@ -365,7 +370,7 @@ class ConsolidadosDreViewSet(
             erro = {
                 'erro': 'Objeto não encontrado.',
                 'mensagem': (
-                    f"Não foi possível publicar o Consolidado Dre, pois o AnoAnaliseRegularidade "
+                    f"Não foi possível {text_document_consolidado_pc.infinitive()} o Consolidado Dre, pois o AnoAnaliseRegularidade "
                     f"para o ano {ano} não foi encontrado na base."
                 ),
             }
@@ -947,19 +952,16 @@ class ConsolidadosDreViewSet(
     def marcar_como_publicado_no_diario_oficial(self, request):
         dados = request.data
 
-        if not dados or not dados.get('consolidado_dre') or not dados.get('data_publicacao') or not dados.get(
-            'pagina_publicacao'
-        ):
+        if not dados or not dados.get('consolidado_dre') or not dados.get('data_publicacao'):
             erro = {
                 'erro': 'parametros_requeridos',
-                'mensagem': 'É necessário enviar o uuid do Consolidado DRE, a data e a página de publicação'
+                'mensagem': 'É necessário enviar o uuid do Consolidado DRE e a data'
             }
             logger.info('Erro ao gerar Consolidado DRE: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         consolidado_dre_uuid = dados['consolidado_dre']
         data_publicacao = dados['data_publicacao']
-        pagina_publicacao = dados['pagina_publicacao']
 
         try:
             consolidado_dre = ConsolidadoDRE.by_uuid(consolidado_dre_uuid)
@@ -971,6 +973,21 @@ class ConsolidadosDreViewSet(
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
+
+        recurso = consolidado_dre.periodo.recurso
+        habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+        text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
+        if habilita_exibicao_de_lauda and not dados.get('pagina_publicacao'):
+            erro = {
+                'erro': 'parametros_requeridos',
+                'mensagem': "É necessário enviar a página de publicação."
+            }
+            logger.info('Erro ao gerar Consolidado DRE: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        pagina_publicacao = dados['pagina_publicacao'] or None
+
         try:
             consolidado_dre = consolidado_dre.marcar_status_sme_como_publicado(
                 data_publicacao=data_publicacao,
@@ -979,7 +996,7 @@ class ConsolidadosDreViewSet(
         except Exception:
             erro = {
                 'erro': 'Erro ao passar o relatório para status_sme_publicado',
-                'mensagem': "Não foi possível passar o relarório para o status de publicado no Diário Oficial",
+                'mensagem': f"Não foi possível passar o relarório para o status de {text_document_consolidado_pc.text_in_past_male_with_where()}",
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
@@ -1015,9 +1032,13 @@ class ConsolidadosDreViewSet(
         try:
             consolidado_dre = consolidado_dre.marcar_status_sme_como_nao_publicado()
         except Exception:
+            recurso = consolidado_dre.periodo.recurso
+            habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+            text_lower_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
             erro = {
                 'erro': 'Erro ao passar o relatório para status_sme_nao_publicado',
-                'mensagem': "Não foi possível passar o relarório para o status de Não Publicado no Diário Oficial",
+                'mensagem': f"Não foi possível passar o relarório para o status de {text_lower_document_consolidado_pc.text_complete_erro_mark_as_no_publicated_consolidado()}",
             }
             logger.info('Erro: %r', erro)
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)

--- a/sme_ptrf_apps/dre/models/consolidado_dre.py
+++ b/sme_ptrf_apps/dre/models/consolidado_dre.py
@@ -233,10 +233,17 @@ class ConsolidadoDRE(ModeloBase):
 
     @property
     def referencia(self):
+        from ..services.consolidado_dre_service import TextDocumentConsolidadoPC
+
+        recurso = self.periodo.recurso
+        habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+        text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+        text_possessive_document_consolidado_pc = text_document_consolidado_pc.possessive()
+
         if self.eh_retificacao:
-            return f"Retificação da publicação de {self.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y') if self.consolidado_retificado.data_publicacao else ''}"
+            return f"Retificação {text_possessive_document_consolidado_pc} de {self.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y') if self.consolidado_retificado.data_publicacao else ''}"
         else:
-            return "Única" if self.sequencia_de_publicacao == 0 else f'Parcial #{self.sequencia_de_publicacao}'
+            return text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE if self.sequencia_de_publicacao == 0 else f'{text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL} #{self.sequencia_de_publicacao}'
 
 
     @property
@@ -295,7 +302,10 @@ class ConsolidadoDRE(ModeloBase):
         self.desfazer_analise_atual()
         self.status_sme = self.STATUS_SME_PUBLICADO
         self.data_publicacao = data_publicacao
-        self.pagina_publicacao = pagina_publicacao
+
+        if pagina_publicacao:
+            self.pagina_publicacao = pagina_publicacao
+
         self.data_de_inicio_da_analise = None
         self.responsavel_pela_analise = None
         self.save()

--- a/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
+++ b/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
@@ -143,11 +143,17 @@ def gerar_arquivo_ata_parecer_tecnico(
 
 
 def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre(dre, periodo, ata_de_parecer_tecnico=None, usuario=None, parcial=None):
+    from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
+
     lista_contas_aprovadas = []  # PCs aprovadas precisam ser separadas por conta
     lista_contas_aprovadas_ressalva = []  # PCs aprovadas com ressalva precisam ser separadas por conta
     lista_contas_reprovadas = []  # PCs reprovadas precisam ser separadas por conta
     lista_motivos_aprovadas_ressalva = []
     lista_motivos_reprovacao = []
+
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda if recurso else False
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
 
     titulo_sequencia_publicacao = None
     if parcial:
@@ -156,9 +162,15 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
         sequencia_de_publicacao = parcial['sequencia_de_publicacao_atual']
 
         if eh_parcial == "Parcial":
-            titulo_sequencia_publicacao = f'Publicação Parcial #{sequencia_de_publicacao}'
+            titulo_sequencia_publicacao = text_document_consolidado_pc.text_sequencial(
+                publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
+                sequence_number=sequencia_de_publicacao
+            )
         else:
-            titulo_sequencia_publicacao = "Publicação Única"
+            titulo_sequencia_publicacao = text_document_consolidado_pc.text_with_type_document(
+                publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE,
+            )
+
 
     motivo_retificacao = None
     eh_retificacao = False
@@ -168,7 +180,7 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
             motivo_retificacao = ata_de_parecer_tecnico.consolidado_dre.motivo_retificacao
             publicacao_parcial_que_gerou_a_retificacao = ata_de_parecer_tecnico.consolidado_dre.consolidado_retificado
             data_publicacao = publicacao_parcial_que_gerou_a_retificacao.data_publicacao if publicacao_parcial_que_gerou_a_retificacao and publicacao_parcial_que_gerou_a_retificacao.data_publicacao else ''
-            titulo_sequencia_publicacao = f"Retificação da publicação de {data_publicacao.strftime('%d/%m/%Y')}"
+            titulo_sequencia_publicacao = f"Retificação {text_document_consolidado_pc.possessive(case="lower")} de {data_publicacao.strftime('%d/%m/%Y')}"
 
     cabecalho = {
         "titulo": periodo.recurso.nome,

--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -15,6 +15,201 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+class TextDocumentConsolidadoPC:
+    PUBLICACAO = "Publicação"
+    RELATORIO = "Relatório"
+    PUBLICACOES = "Publicações"
+    RELATORIOS = "Relatórios"
+
+    PUBLICATION_TYPE_PARTIAL = "Parcial"
+    PUBLICATION_TYPE_RECTIFICATION = "Retificação"
+    PUBLICATION_TYPE_UNIQUE = "Única"
+
+    def __init__(self, is_enable_lauda):
+        self._is_enable_lauda = is_enable_lauda
+
+
+    def _get_quantity_test(_, quantity, quantity_name_singular=None, quantity_name_plural=None):
+        if quantity == 1:
+            name_obj = quantity_name_singular if quantity_name_singular else "PC"
+
+            return f"- 1 {name_obj}"
+
+        if quantity > 1:
+            name_obj = quantity_name_plural if quantity_name_plural else "PCs"
+
+            return f"- {quantity} {name_obj}"
+
+        return ""
+
+
+    def get_tranform_publication_type(self, publication_type):
+        if publication_type == self.PUBLICATION_TYPE_UNIQUE and not self._is_enable_lauda:
+            return "Único"
+
+        return publication_type
+
+
+    def infinitive(self):
+        if self._is_enable_lauda:
+            return "publicar"
+
+        return "enviar externamente"
+
+
+    def text_in_past_and_plural(self):
+        if self._is_enable_lauda:
+            return "publicadas"
+
+        return "enviadas"
+
+
+    def text_in_past_male_with_where(self):
+        if self._is_enable_lauda:
+            return "publicado no Diário Oficial"
+
+        return "enviado externamente"
+
+
+    def text_in(self):
+        if self._is_enable_lauda:
+            return "nas publicações"
+
+        return "nos relatórios"
+
+
+    def text_with_refer(self):
+        if self._is_enable_lauda:
+            return f"na referida {self.normal(case="lower")}"
+
+        return f"no referido {self.normal(case="lower")}"
+
+
+    def text_complete_erro_mark_as_publicated_consolidado(self):
+        if self._is_enable_lauda:
+            return ", a data e a página de publicação"
+
+        return " e a data do envio externo da documentação"
+
+
+    def text_complete_erro_mark_as_no_publicated_consolidado(self):
+        if self._is_enable_lauda:
+            return "Não Publicado no Diário Oficial"
+
+        return "Não Enviado Externamente no Diário Oficial"
+
+
+    def normal(self, case=None):
+        text_name = self.RELATORIO
+
+        if self._is_enable_lauda:
+            text_name = self.PUBLICACAO
+
+        if case == "lower":
+            text_name = text_name.lower()
+
+        if case == "upper":
+            text_name = text_name.upper()
+
+        return text_name
+
+
+    def normal_plural(self, case=None):
+        text_name = self.RELATORIOS
+
+        if self._is_enable_lauda:
+            text_name = self.PUBLICACOES
+
+        if case == "lower":
+            text_name = text_name.lower()
+
+        if case == "upper":
+            text_name = text_name.upper()
+
+        return text_name
+
+
+    def possessive(self, case=None):
+        possessive_type = "da" if self._is_enable_lauda else "do"
+
+        text_normal = self.normal()
+
+        if case == "lower":
+            text_normal = text_normal.lower()
+
+        if case == "upper":
+            text_normal = text_normal.upper()
+
+        return f'{possessive_type} {text_normal}'
+
+
+    def possessive_plural(self, case=None):
+        possessive_type = "das" if self._is_enable_lauda else "dos"
+
+        text_normal = self.normal_plural()
+        text_concatenated = f'{possessive_type} {text_normal}'
+
+        if case == "lower":
+            text_concatenated = text_concatenated.lower()
+
+        if case == "upper":
+            text_concatenated = text_concatenated.upper()
+
+        return text_concatenated
+
+
+    def text_other(self, case=None):
+        other_type = "outra" if self._is_enable_lauda else "outro"
+
+        if case == "lower":
+            other_type = other_type.lower()
+
+        if case == "upper":
+            other_type = other_type.upper()
+
+        return f'{other_type} {self.normal(case=case)}'
+
+
+    def text_possessive_with_type_and_sequency(self, publication_type, sequency_number):
+        text_document = self.possessive()
+        text_sequency_number = f'#{sequency_number}' if sequency_number else ''
+
+        return f'{text_document} {self.get_tranform_publication_type(publication_type)} {text_sequency_number}'
+
+
+    def text_with_type_document(self, publication_type):
+        text_document = self.normal()
+
+        return f'{text_document} {self.get_tranform_publication_type(publication_type)}'
+
+
+    def text_sequencial(self, publication_type, sequence_number):
+        return f'{self.normal()} {self.get_tranform_publication_type(publication_type)} #{sequence_number}'
+
+
+    def text_sequencial_with_quantity(self, publication_type, sequency_number, quantity_unities, quantity_name_singular=None, quantity_name_plural=None):
+        return f'{self.text_sequencial(publication_type, sequency_number)} {self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)}'
+
+
+    def text_with_quantity(self, publication_type, quantity, quantity_name_singular=None, quantity_name_plural=None):
+        return f'{self.text_with_type_document(publication_type)} {self._get_quantity_test(quantity, quantity_name_singular, quantity_name_plural)}'
+
+
+    def publication_name(self, publication_type, quantity_unities, publication_text, sequency_number, quantity_name_singular=None, quantity_name_plural=None):
+        if publication_type == self.PUBLICATION_TYPE_PARTIAL:
+            return self.text_sequencial_with_quantity(publication_type, sequency_number, quantity_unities)
+
+        if publication_type == self.PUBLICATION_TYPE_RECTIFICATION:
+            return f'{publication_text} {self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)}'
+
+        return self.text_with_quantity(publication_type, quantity_unities)
+
+
+    def text_action(self):
+        if self._is_enable_lauda:
+            return self.PUBLICACAO
+
+        return "Envio da Documentação"
 
 def criar_ata_e_atribuir_ao_consolidado_dre(dre=None, periodo=None, consolidado_dre=None, sequencia_de_publicacao=None, eh_retificacao=False):
     if eh_retificacao:
@@ -43,6 +238,12 @@ def criar_ata_e_atribuir_ao_consolidado_dre(dre=None, periodo=None, consolidado_
 def retornar_ja_publicadas(dre, periodo):
     consolidados_dre = ConsolidadoDRE.objects.filter(dre=dre, periodo=periodo, versao='FINAL').order_by(
         'sequencia_de_publicacao', 'sequencia_de_retificacao')
+
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+    text_possessive_document_consolidado_pc = text_document_consolidado_pc.possessive()
+
     # Pegando o valor máximo da sequencia de publicacao para habilitar ou não o botão de remover data de publicação
     valor_maximo_sequencia_de_publicacao = consolidados_dre.aggregate(max_sequencia_de_publicacao=Coalesce(
         Max('sequencia_de_publicacao'), Value(0)))['max_sequencia_de_publicacao']
@@ -50,39 +251,29 @@ def retornar_ja_publicadas(dre, periodo):
     publicacoes_anteriores = []
 
     for consolidado_dre in consolidados_dre:
-
-        tipo_publicacao = "Única"
-
-        if consolidado_dre.eh_parcial:
-            tipo_publicacao = "Parcial"
+        tipo_publicacao = "Parcial" if consolidado_dre.eh_parcial else "Única"
 
         sequencia = consolidado_dre.sequencia_de_publicacao
 
         qtde_unidades = consolidado_dre.pcs_do_consolidado.all().count()
 
-        texto_qtde_unidades = ""
-        if qtde_unidades == 1:
-            texto_qtde_unidades = " - 1 PC"
-        elif qtde_unidades > 1:
-            texto_qtde_unidades = f' - {qtde_unidades} PCs'
+        data_publicacao_retificacao = consolidado_dre.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y') if consolidado_dre.consolidado_retificado and consolidado_dre.consolidado_retificado.data_publicacao else ''
+        tipo_publicacao = f"Retificação {text_possessive_document_consolidado_pc} de {data_publicacao_retificacao}" if consolidado_dre.eh_retificacao else tipo_publicacao
 
-        tipo_publicacao = f"Retificação da Publicação de {consolidado_dre.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y') if consolidado_dre.consolidado_retificado and consolidado_dre.consolidado_retificado.data_publicacao else ''}" if consolidado_dre.eh_retificacao else tipo_publicacao
-        if tipo_publicacao == 'Parcial':
-            nome_publicacao = f'Publicação {tipo_publicacao} #{sequencia}{texto_qtde_unidades}'
-        elif tipo_publicacao.startswith('Retificação'):
-            nome_publicacao = f'{tipo_publicacao} {texto_qtde_unidades}'
-        else:
-            nome_publicacao = f'Publicação Única{texto_qtde_unidades}'
+        publication_type = text_document_consolidado_pc.PUBLICATION_TYPE_RECTIFICATION if tipo_publicacao.startswith('Retificação') else text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL
+        publication_text = tipo_publicacao if tipo_publicacao.startswith('Retificação') else None
+
+        nome_publicacao = text_document_consolidado_pc.publication_name(
+            publication_type=publication_type,
+            quantity_unities=qtde_unidades,
+            publication_text=publication_text,
+            sequency_number=sequencia
+        )
 
         # Rever regra de ja publicado para retificacoes
+        ja_publicado = True
         if consolidado_dre.eh_retificacao:
-            if consolidado_dre.laudas_do_consolidado_dre.all():
-                ja_publicado = True
-            else:
-                ja_publicado = False
-
-        else:
-            ja_publicado = True
+            ja_publicado = True if consolidado_dre.laudas_do_consolidado_dre.all() else False
 
         if consolidado_dre.eh_retificacao:
             total_pcs_retificacao = consolidado_dre.prestacoes_de_conta_do_consolidado_dre.all()
@@ -218,21 +409,26 @@ def retornar_proxima_publicacao(dre, periodo, sequencia_de_publicacao, sequencia
         publicada=False
     ).count()
 
-    texto_qtde_unidades = ""
     proxima_publicacao = None
+
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
 
     # Incluindo verificação se não é uma retificacao para nao gerar o bloco
     if qtde_unidades > 0:
-
-        if qtde_unidades == 1:
-            texto_qtde_unidades = " - 1 PC"
-        elif qtde_unidades > 1:
-            texto_qtde_unidades = f' - {qtde_unidades} PCs'
-
         if sequencia_de_publicacao['parcial']:
-            titulo_relatorio = f'Publicação Parcial #{sequencia_de_publicacao_atual}{texto_qtde_unidades}'
+            titulo_relatorio = text_document_consolidado_pc.text_sequencial_with_quantity(
+                publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
+                sequency_number=sequencia_de_publicacao_atual,
+                quantity_unities=qtde_unidades
+            )
         else:
-            titulo_relatorio = f'Publicação Única{texto_qtde_unidades}'
+            titulo_relatorio = text_document_consolidado_pc.text_sequencial_with_quantity(
+                publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE,
+                sequency_number=sequencia_de_publicacao_atual,
+                quantity_unities=qtde_unidades
+            )
 
         # verificando se a publicacao anterior foi marcada como publicada no DO, para permitir gerar a próxima publicação
         if sequencia_de_publicacao_atual == 1 or not sequencia_de_publicacao['parcial']:
@@ -1162,12 +1358,12 @@ class ListagemPorStatusComFiltros(AcompanhamentoDeRelatoriosConsolidados):
         return self.__status_sme
 
     @staticmethod
-    def retorna_titulo_por_status(chave):
+    def retorna_titulo_por_status(chave, habilita_exibicao_de_lauda=False):
 
         titulos_por_status = {
             'DRES_SEM_RELATORIOS_GERADOS': "Não gerado",
-            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: "Não publicada no D.O.",
-            ConsolidadoDRE.STATUS_SME_PUBLICADO: "Publicada no D.O.",
+            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: "Não publicada no D.O." if habilita_exibicao_de_lauda else "Não publicada externamente",
+            ConsolidadoDRE.STATUS_SME_PUBLICADO: "Publicada no D.O." if habilita_exibicao_de_lauda else "Publicada externamente",
             ConsolidadoDRE.STATUS_SME_EM_ANALISE: "Em análise",
             ConsolidadoDRE.STATUS_SME_DEVOLVIDO: "Devolvida para acertos",
             ConsolidadoDRE.STATUS_SME_ANALISADO: "Relatórios analisados",
@@ -1231,13 +1427,16 @@ class ListagemPorStatusComFiltros(AcompanhamentoDeRelatoriosConsolidados):
                             Count('prestacoes_de_conta_do_consolidado_dre'), Value(0)))['total_pcs_retificacoes']
                         total_unidades_no_relatorio += qtde_unidades_retificacoes
 
+                    recurso = self.periodo.recurso if self.periodo else None
+                    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda if recurso else False
+
                     obj = {
                         "nome_da_dre": dre.nome,
                         "tipo_relatorio": tipo_de_relatorio,
                         "total_unidades_no_relatorio": total_unidades_no_relatorio,
                         "data_recebimento": self.formata_data(consolidado.data_de_inicio_da_analise) if consolidado.data_de_inicio_da_analise else None,
                         "status_sme": consolidado.status_sme,
-                        "status_sme_label": self.retorna_titulo_por_status(consolidado.status_sme),
+                        "status_sme_label": self.retorna_titulo_por_status(consolidado.status_sme, habilita_exibicao_de_lauda),
                         "pode_visualizar": True,
                         "uuid_consolidado_dre": f"{consolidado.uuid}",
                         "uuid_dre": f"{dre.uuid}",

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -10,7 +10,7 @@ from sme_ptrf_apps.dre.models import ParametrosDre
 from django.db.models import Max, Value, Count
 from django.db.models.functions import Coalesce
 
-from sme_ptrf_apps.dre.services.consolidado_dre_service import verifica_se_eh_relatorio_publicacoes_parciais
+from sme_ptrf_apps.dre.services.consolidado_dre_service import verifica_se_eh_relatorio_publicacoes_parciais, TextDocumentConsolidadoPC
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +19,7 @@ def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, 
     try:
         LOGGER.info("Gerando relatório consolidado...")
 
+        text_document_consolidado_pc = retorna_dict_text_documento_consolidado_pc(periodo)
         cabecalho = cria_cabecalho(periodo, parcial, previa, consolidado_dre)
         bloco_consolidado_das_publicacoes_parciais = cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo) if eh_consolidado_de_publicacoes_parciais else None
         data_geracao_documento = cria_data_geracao_documento(usuario, dre, parcial, previa)
@@ -52,6 +53,7 @@ def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, 
         """
 
         dados_demonstrativo = {
+            "text_document_consolidado_pc": text_document_consolidado_pc,
             "cabecalho": cabecalho,
             "bloco_consolidado_das_publicacoes_parciais": bloco_consolidado_das_publicacoes_parciais,
             "data_geracao_documento": data_geracao_documento,
@@ -74,6 +76,10 @@ def cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo):
     consolidados_dre = ConsolidadoDRE.objects.filter(dre=dre, periodo=periodo, versao="FINAL").order_by("sequencia_de_publicacao", "alterado_em")
     consolidado_das_publicacoes_parciais_list = []
 
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
     for consolidado in consolidados_dre:
         numero_sequencia = consolidado.sequencia_de_publicacao if consolidado.sequencia_de_publicacao else ""
 
@@ -83,10 +89,10 @@ def cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo):
 
             if(consolidado_origem_retificacao.count() > 0 and consolidado_origem_retificacao[0].data_publicacao):
                 data_publicacao_consolidado_origem_retificacao = consolidado_origem_retificacao[0].data_publicacao.strftime("%d/%m/%Y")
-                titulo_parcial = f"Retificação da publicação de {data_publicacao_consolidado_origem_retificacao}"
+                titulo_parcial = f"Retificação {text_document_consolidado_pc.possessive(case='lower')} de {data_publicacao_consolidado_origem_retificacao}"
 
         elif(not consolidado.eh_parcial):
-            titulo_parcial = f"Única"
+            titulo_parcial = text_document_consolidado_pc.get_tranform_publication_type(text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE)
 
         else:
             titulo_parcial = f"Parcial #{numero_sequencia}"
@@ -104,8 +110,30 @@ def cria_bloco_consolidado_das_publicacoes_parciais(dre, periodo):
     return consolidado_das_publicacoes_parciais_list
 
 
+def retorna_dict_text_documento_consolidado_pc(periodo):
+    from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
+
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
+    response = {
+        'text_refer': text_document_consolidado_pc.text_with_refer(),
+        'text_in_past_and_plural': text_document_consolidado_pc.text_in_past_and_plural(),
+        'text_in': text_document_consolidado_pc.text_in(),
+        'text_possessive_plural': text_document_consolidado_pc.possessive_plural(),
+        'text_action': text_document_consolidado_pc.text_action(),
+    }
+
+    return response
+
+
 def cria_cabecalho(periodo, parcial, previa, consolidado_dre):
     LOGGER.info("Iniciando cabecalho...")
+
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
 
     eh_parcial = parcial['parcial']
     sequencia_de_publicacao = parcial['sequencia_de_publicacao_atual']
@@ -114,18 +142,30 @@ def cria_cabecalho(periodo, parcial, previa, consolidado_dre):
     if previa and eh_retificacao:
         titulo_sequencia_publicacao = f'{consolidado_dre.referencia} (Prévia)'
     elif previa and eh_parcial:
-        titulo_sequencia_publicacao = f'Publicação Parcial #{sequencia_de_publicacao} (Prévia)'
+        text = text_document_consolidado_pc.text_sequencial(
+            publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
+            sequence_number=sequencia_de_publicacao
+        )
+        titulo_sequencia_publicacao = f'{text} (Prévia)'
     elif previa and not eh_parcial:
-        titulo_sequencia_publicacao = f'Publicação Única (Prévia)'
+        text = text_document_consolidado_pc.text_with_type_document(
+            publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE
+        )
+        titulo_sequencia_publicacao = f'{text} (Prévia)'
     elif not previa and eh_retificacao:
         titulo_sequencia_publicacao = f'{consolidado_dre.referencia}'
     elif not previa and eh_parcial:
-        titulo_sequencia_publicacao = f'Publicação Parcial #{sequencia_de_publicacao}'
+        titulo_sequencia_publicacao = text_document_consolidado_pc.text_sequencial(
+            publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
+            sequence_number=sequencia_de_publicacao
+        )
     elif not previa and not eh_parcial and sequencia_de_publicacao == 0:
-        titulo_sequencia_publicacao = 'Publicação Única'
+        titulo_sequencia_publicacao = text_document_consolidado_pc.text_with_type_document(
+            publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE
+        )
     else:
         # Nesse caso é o relatório do consolidado de publicações parciais
-        titulo_sequencia_publicacao = f'Relatório Consolidado'
+        titulo_sequencia_publicacao = 'Relatório Consolidado'
 
     cabecalho = {
         "recurso": periodo.recurso.nome,

--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -13,6 +13,7 @@ from sme_ptrf_apps.core.models import (
 from sme_ptrf_apps.dre.models import RelatorioConsolidadoDRE, ObsDevolucaoRelatorioConsolidadoDRE, \
     JustificativaRelatorioConsolidadoDRE, ConsolidadoDRE
 from sme_ptrf_apps.receitas.models import Receita
+from .consolidado_dre_service import TextDocumentConsolidadoPC
 
 from ..services.dados_demo_execucao_fisico_financeira_service import gerar_dados_demo_execucao_fisico_financeira
 from .demo_execucao_fisico_financeiro_pdf_service import gerar_arquivo_demonstrativo_execucao_fisico_financeiro_pdf
@@ -78,6 +79,11 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
     dre_uuid = dre.uuid
     periodo_uuid = periodo.uuid
 
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+    text_possessive_document_consolidado_pc = text_document_consolidado_pc.possessive()
+
     if eh_retificacao:
         eh_parcial = consolidado_dre.eh_parcial
         qtde_unidades = consolidado_dre.pcs_do_consolidado.all().count()
@@ -85,13 +91,15 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
         associacoes_do_consolidado = consolidado_dre.pcs_do_consolidado.values_list("associacao_id", flat=True).distinct()
 
         if consolidado_dre.consolidado_retificado and consolidado_dre.consolidado_retificado.data_publicacao:
-            titulo_parcial = f"Retificação da Publicação de {consolidado_dre.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y')} - {qtde_unidades} unidade(s)"
+            titulo_parcial = f"Retificação {text_possessive_document_consolidado_pc} de {consolidado_dre.consolidado_retificado.data_publicacao.strftime('%d/%m/%Y')} - {qtde_unidades} unidade(s)"
         else:
             titulo_parcial = ""
     else:
         parcial = verificar_se_status_parcial_ou_total_e_retornar_sequencia_de_publicacao(dre_uuid, periodo_uuid)
         eh_parcial = parcial['parcial']
         sequencia_de_publicacao = parcial['sequencia_de_publicacao_atual']
+
+        publication_type = text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL if eh_parcial else text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE
 
         # TODO Tratativa dos Bugs: 91797, 93549 e 93018 da Sprint 65
         # Gerava divergência em Tela do Relatório Consolidado em Tela
@@ -108,9 +116,22 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
             sequencia_de_publicacao_do_consolidado = consolidado_dre.sequencia_de_publicacao
 
             if sequencia_de_publicacao_do_consolidado > 0:
-                titulo_parcial = f"Publicação Parcial #{sequencia_de_publicacao_do_consolidado} - {qtde_unidades} unidade(s)" if eh_parcial else f"Publicação Única {qtde_unidades} unidade(s)"
+                if publication_type == text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL:
+                    titulo_parcial = text_document_consolidado_pc.text_sequencial_with_quantity(publication_type=publication_type,
+                                                                                           sequency_number=sequencia_de_publicacao_do_consolidado,
+                                                                                           quantity_unities=qtde_unidades,
+                                                                                           quantity_name_singular="unidade",
+                                                                                           quantity_name_plural="unidade(s)")
+
+                if publication_type == text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE:
+                    titulo_parcial = text_document_consolidado_pc.text_with_quantity(
+                        publication_type=publication_type,
+                        quantity=qtde_unidades,
+                        quantity_name_singular="unidade",
+                        quantity_name_plural="unidade(s)"
+                    )
             else:
-                titulo_parcial = "Publicação Única"
+                titulo_parcial = text_document_consolidado_pc.text_with_type_document(publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE)
         else:
             pcs = PrestacaoConta.objects.filter(
                 periodo=periodo,
@@ -124,9 +145,22 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
             associacoes_do_consolidado = pcs.values_list("associacao_id", flat=True).distinct()
 
             if sequencia_de_publicacao > 0:
-                titulo_parcial = f"Publicação Parcial #{sequencia_de_publicacao} - {qtde_unidades} unidade(s)" if eh_parcial else f"Publicação Única {qtde_unidades} unidade(s)"
+                if publication_type == text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL:
+                    titulo_parcial = text_document_consolidado_pc.text_sequencial_with_quantity(publication_type=publication_type,
+                                                                                           sequency_number=sequencia_de_publicacao,
+                                                                                           quantity_unities=qtde_unidades,
+                                                                                           quantity_name_singular="unidade",
+                                                                                           quantity_name_plural="unidade(s)")
+
+                if publication_type == text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE:
+                    titulo_parcial = text_document_consolidado_pc.text_with_quantity(
+                        publication_type=publication_type,
+                        quantity=qtde_unidades,
+                        quantity_name_singular="unidade",
+                        quantity_name_plural="unidade(s)"
+                    )
             else:
-                titulo_parcial = "Publicação Única"
+                titulo_parcial = text_document_consolidado_pc.text_with_type_document(publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE)
 
 
     dados = {
@@ -1128,6 +1162,10 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
             prestacoes_de_conta_da_associacao__status__in=['APROVADA', 'APROVADA_RESSALVA', 'REPROVADA']
         )
 
+    recurso = periodo.recurso
+    habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+    text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
     for associacao in associacoes_da_dre.all():
 
         prestacao_conta = associacao.prestacoes_de_conta_da_associacao.filter(periodo=periodo).first()
@@ -1140,10 +1178,10 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
 
             if(consolidado_origem_retificacao.count() > 0 and consolidado_origem_retificacao[0].data_publicacao):
                 data_publicacao_consolidado_origem_retificacao = consolidado_origem_retificacao[0].data_publicacao.strftime("%d/%m/%Y")
-                referencia_consolidado = f"Retificação da publicação de {data_publicacao_consolidado_origem_retificacao}"
+                referencia_consolidado = f"Retificação {text_document_consolidado_pc.possessive()} de {data_publicacao_consolidado_origem_retificacao}"
 
         elif(not prestacao_conta.consolidado_dre.eh_parcial):
-            referencia_consolidado = f"Única"
+            referencia_consolidado = text_document_consolidado_pc.get_tranform_publication_type(text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE)
 
         else:
             referencia_consolidado = f"Parcial #{prestacao_conta.consolidado_dre.sequencia_de_publicacao}"
@@ -1152,9 +1190,9 @@ def informacoes_execucao_financeira_unidades_do_consolidado_dre(
         objeto_tipo_de_conta = []
 
         contas_da_associacao = associacao.contas.all()
- 
+
         recurso = periodo.recurso if periodo.recurso else None
- 
+
         if recurso:
             contas_da_associacao = ContaAssociacao.filter_by_recurso(contas_da_associacao, recurso)
 

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
@@ -607,7 +607,7 @@ def test_api_get_info_execucao_financeira_relatorio_consolidado_dre_final(
                 }
             }
         ],
-        'titulo_parcial': 'Publicação Única 1 unidade(s)'
+        'titulo_parcial': 'Publicação Única - 1 unidade'
     }
 
     assert response.status_code == status.HTTP_200_OK

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
@@ -26,7 +26,7 @@
         <th class="th-fundo-branco">14 - Rejeitadas</th>
         <th class="th-fundo-branco">15 - Em análise</th>
         <th class="th-fundo-branco">16 - Não apresentadas</th>
-        <th class="th-fundo-branco">17 - UEs publicadas anteriormente</th>
+        <th class="th-fundo-branco">17 - UEs {{ dados.text_document_consolidado_pc.text_in_past_and_plural }} anteriormente</th>
         <th class="th-fundo-branco">18 - Total</th>
 
         <th class="th-fundo-branco">19 - UEs Retificadas</th>
@@ -65,9 +65,9 @@
             <span class="font-10 pt-2 pb-2">Coluna 18 - É a soma das colunas 12 a 17.</span>
             <br/>
             {% if dados.execucao_fisica.eh_relatorio_consolidado_publicacoes_parciais %}
-              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada nas publicações parciais.</span>
+              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_in }} parciais.</span>
             {% else %}
-              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada na referida publicação.</span>
+              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_refer }}.</span>
             {% endif %}
           </div>
         </div>

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela_consolidado_das_publicacoes_parciais.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela_consolidado_das_publicacoes_parciais.html
@@ -5,8 +5,8 @@
   <table class="table table-bordered">
     <thead>
     <tr>
-      <th class="py-2 font-12" scope="col" style="width: 50%">Consolidação das Publicações:</th>
-      <th class="py-2 font-12" scope="col">Data de Publicação:</th>
+      <th class="py-2 font-12" scope="col" style="width: 50%">Consolidação {{ dados.text_document_consolidado_pc.text_possessive_plural }}:</th>
+      <th class="py-2 font-12" scope="col">Data de {{ dados.text_document_consolidado_pc.text_action }}:</th>
       <th class="py-2 font-12" scope="col">Número de Unidades:</th>
     </tr>
     </thead>


### PR DESCRIPTION
Este PR inclui:

- Altera exibição de "Publicação" para formato de "Relatório", somente nomenclatura;
- Funcionalidade visando a adição do campo habilita_exibicao_de_lauda no modelo de recurso;
- Cria uma classe "TextoDocumentoConsolidadoPC" para centralizar as mudanças dos textos;
- Ajuste em testes unitários;

Histórias: [AB#150754](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150754) e [AB#150828](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150828)
Tarefas: [AB#150855](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150855) e [AB#151048](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151048)