### PR TITLE
hotfix: marcar lançamento como atualizado ao editar despesa

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.41.2"
+__version__ = "9.41.3"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/despesas/services/despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/despesa_service.py
@@ -9,6 +9,11 @@ from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, AP
 from sme_ptrf_apps.despesas.models import Despesa, RateioDespesa
 from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaCreateSerializer
 
+from sme_ptrf_apps.core.models.solicitacao_acerto_lancamento import SolicitacaoAcertoLancamento
+from sme_ptrf_apps.core.models.tipo_acerto_lancamento import TipoAcertoLancamento
+from sme_ptrf_apps.core.models.analise_lancamento_prestacao_conta import AnaliseLancamentoPrestacaoConta
+from sme_ptrf_apps.core.services.analise_lancamento_prestacao_conta_service import AnaliseLancamentoPrestacaoContaService
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,6 +136,9 @@ class DespesaService:
 
             cls._finalizar_despesa(instance, rateios, limpar_prioridades_callback)
 
+            # Fluxo de PC
+            cls._marcar_lancamento_como_atualizado(instance)
+
             return instance
         finally:
             instance._skip_fornecedor_signal = False
@@ -212,6 +220,21 @@ class DespesaService:
     def _atualizar_rateios(despesa: Despesa, rateios):
         keep = []
 
+        uuids = [
+            rateio["uuid"]
+            for rateio in rateios
+            if "uuid" in rateio
+        ]
+
+        rateios_existentes = {
+            str(rateio.uuid): rateio
+            for rateio in (
+                RateioDespesa.objects
+                .filter(uuid__in=uuids)
+                .order_by("uuid")
+            )
+        }
+
         for rateio in rateios:
 
             rateio["eh_despesa_sem_comprovacao_fiscal"] = despesa.eh_despesa_sem_comprovacao_fiscal
@@ -222,9 +245,9 @@ class DespesaService:
                     f"Encontrada chave uuid no rateio {rateio['uuid']} R${rateio['valor_rateio']}. Será atualizado."
                 )
 
-                rateio_para_atualizar = RateioDespesa.objects.filter(
-                    uuid=rateio["uuid"]
-                ).first()
+                rateio_para_atualizar = rateios_existentes.get(
+                    str(rateio["uuid"])
+                )
 
                 if rateio_para_atualizar:
 
@@ -317,9 +340,8 @@ class DespesaService:
                             f"no rateio {rateio['uuid']}"
                         )
 
-                    RateioDespesa.objects.filter(uuid=rateio["uuid"]).update(**rateio)
-                    obj = RateioDespesa.objects.get(uuid=rateio["uuid"])
-                    keep.append(obj.uuid)
+                    RateioDespesa.objects.filter(uuid=rateio["uuid"]).update(**rateio)                    
+                    keep.append(rateio_para_atualizar.uuid)
                 else:
                     logger.info(f"Rateio NÃO encontrado {rateio['uuid']} R${rateio['valor_rateio']}")
                     continue
@@ -331,6 +353,7 @@ class DespesaService:
 
         RateioDespesa.objects.filter(despesa=despesa).exclude(uuid__in=keep).delete()
 
+    @staticmethod
     def _cria_atualiza_fornecedor(despesa: Despesa, validated_data: dict):
         from sme_ptrf_apps.despesas.models.fornecedor import Fornecedor
 
@@ -484,3 +507,46 @@ class DespesaService:
 
         if despesa.status == STATUS_COMPLETO and limpar_callback:
             limpar_callback(rateios, despesa)
+
+    @staticmethod
+    def _marcar_lancamento_como_atualizado(despesa: Despesa):
+        """
+        Marca o lançamento como atualizado quando existir uma solicitação
+        pendente de edição de lançamento em uma prestação de contas devolvida.
+        """
+        prestacao_conta = despesa.prestacao_conta
+
+        if not prestacao_conta or prestacao_conta.status != PrestacaoConta.STATUS_DEVOLVIDA:
+            return
+
+        lancamento_analise = (
+            AnaliseLancamentoPrestacaoConta.objects.filter(
+                despesa=despesa,
+                lancamento_atualizado=False,
+                tipo_lancamento=AnaliseLancamentoPrestacaoConta.TIPO_LANCAMENTO_GASTO,
+                status_realizacao=AnaliseLancamentoPrestacaoConta.STATUS_REALIZACAO_PENDENTE,
+            )
+            .first()
+        )
+
+        if not lancamento_analise:
+            return
+
+        possui_solicitacao_pendente = (
+            lancamento_analise.solicitacoes_de_ajuste_da_analise.filter(
+                tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
+                status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE,
+            )
+            .exists()
+        )
+
+        if not possui_solicitacao_pendente:
+            return
+
+        AnaliseLancamentoPrestacaoContaService.marcar_lancamento_como_atualizado(
+            lancamento_analise
+        )
+
+        logger.info(
+            f"Despesa {despesa.uuid} com lançamento marcado como atualizado."
+        )

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
@@ -9,6 +9,14 @@ from rest_framework import serializers
 from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
 from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CUSTEIO
 
+from sme_ptrf_apps.core.models import (
+    PrestacaoConta,
+    AnaliseLancamentoPrestacaoConta, 
+    TipoAcertoLancamento,
+    SolicitacaoAcertoLancamento
+)
+
+
 pytestmark = pytest.mark.django_db
 
 
@@ -713,3 +721,96 @@ def test_update_imposto_herda_conciliacao_quando_pc_devolvida(
         rateio_imposto.periodo_conciliacao_id
         == rateio_origem.periodo_conciliacao_id
     )
+
+
+def criar_cenario_marcar_lancamento_como_atualizado(
+    prestacao_conta_factory,
+    solicitacao_acerto_lancamento_factory,
+    analise_prestacao_conta_factory,
+    tipo_acerto_lancamento_factory,
+    analise_lancamento_prestacao_conta_factory,
+    despesa_factory,
+    associacao,
+    periodo_2020_2,
+    status_prestacao=PrestacaoConta.STATUS_DEVOLVIDA,
+    lancamento_atualizado=False,
+):
+    prestacao_conta_factory(
+        status=status_prestacao,
+        periodo=periodo_2020_2,
+        associacao=associacao,
+    )
+
+    analise_prestacao = analise_prestacao_conta_factory()
+
+    tipo_acerto = tipo_acerto_lancamento_factory(
+        categoria=TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO
+    )
+
+    despesa = despesa_factory(
+        associacao=associacao,
+        numero_documento="123456",
+        cpf_cnpj_fornecedor="11.478.276/0001-04",
+        data_transacao=periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=3),
+        data_documento=periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=3),
+        nome_fornecedor="Fornecedor SA",
+        valor_total=50.00,
+        valor_recursos_proprios=0,
+    )
+
+    analise_lancamento = analise_lancamento_prestacao_conta_factory(
+        analise_prestacao_conta=analise_prestacao,
+        despesa=despesa,
+        lancamento_atualizado=lancamento_atualizado,
+        tipo_lancamento=AnaliseLancamentoPrestacaoConta.TIPO_LANCAMENTO_GASTO,
+        status_realizacao=AnaliseLancamentoPrestacaoConta.STATUS_REALIZACAO_PENDENTE,
+    )
+
+    solicitacao_acerto_lancamento_factory(
+        analise_lancamento=analise_lancamento,
+        tipo_acerto=tipo_acerto,
+        status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE,
+    )
+
+    return despesa, analise_lancamento
+
+
+def test_marca_lancamento_como_atualizado_quando_tudo_ok():
+    despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        status_prestacao=PrestacaoConta.STATUS_DEVOLVIDA,
+        lancamento_atualizado=False,
+    )
+
+    assert not analise_lancamento.lancamento_atualizado
+
+    DespesaService._marcar_lancamento_como_atualizado(despesa)
+
+    analise_lancamento.refresh_from_db()
+
+    assert analise_lancamento.lancamento_atualizado
+
+
+def test_marca_lancamento_como_atualizado_quando_lancamento_atualizado():
+    despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        status_prestacao=PrestacaoConta.STATUS_DEVOLVIDA,
+        lancamento_atualizado=True,
+    )
+
+    DespesaService._marcar_lancamento_como_atualizado(despesa)
+
+    analise_lancamento.refresh_from_db()
+
+    assert analise_lancamento.lancamento_atualizado
+
+
+def test_nao_marca_lancamento_quando_prestacao_em_analise():
+    despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        status_prestacao=PrestacaoConta.STATUS_EM_ANALISE,
+        lancamento_atualizado=False,
+    )
+
+    DespesaService._marcar_lancamento_como_atualizado(despesa)
+
+    analise_lancamento.refresh_from_db()
+
+    assert not analise_lancamento.lancamento_atualizado

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
@@ -775,8 +775,25 @@ def criar_cenario_marcar_lancamento_como_atualizado(
     return despesa, analise_lancamento
 
 
-def test_marca_lancamento_como_atualizado_quando_tudo_ok():
+def test_marca_lancamento_como_atualizado_quando_tudo_ok(
+        prestacao_conta_factory,
+        solicitacao_acerto_lancamento_factory,
+        analise_prestacao_conta_factory,
+        tipo_acerto_lancamento_factory,
+        analise_lancamento_prestacao_conta_factory,
+        despesa_factory,
+        associacao,
+        periodo_2020_2
+    ):
     despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        prestacao_conta_factory,
+        solicitacao_acerto_lancamento_factory,
+        analise_prestacao_conta_factory,
+        tipo_acerto_lancamento_factory,
+        analise_lancamento_prestacao_conta_factory,
+        despesa_factory,
+        associacao,
+        periodo_2020_2,
         status_prestacao=PrestacaoConta.STATUS_DEVOLVIDA,
         lancamento_atualizado=False,
     )
@@ -790,8 +807,25 @@ def test_marca_lancamento_como_atualizado_quando_tudo_ok():
     assert analise_lancamento.lancamento_atualizado
 
 
-def test_marca_lancamento_como_atualizado_quando_lancamento_atualizado():
+def test_marca_lancamento_como_atualizado_quando_lancamento_atualizado(
+    prestacao_conta_factory,
+    solicitacao_acerto_lancamento_factory,
+    analise_prestacao_conta_factory,
+    tipo_acerto_lancamento_factory,
+    analise_lancamento_prestacao_conta_factory,
+    despesa_factory,
+    associacao,
+    periodo_2020_2
+):
     despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        prestacao_conta_factory,
+        solicitacao_acerto_lancamento_factory,
+        analise_prestacao_conta_factory,
+        tipo_acerto_lancamento_factory,
+        analise_lancamento_prestacao_conta_factory,
+        despesa_factory,
+        associacao,
+        periodo_2020_2,
         status_prestacao=PrestacaoConta.STATUS_DEVOLVIDA,
         lancamento_atualizado=True,
     )
@@ -803,8 +837,25 @@ def test_marca_lancamento_como_atualizado_quando_lancamento_atualizado():
     assert analise_lancamento.lancamento_atualizado
 
 
-def test_nao_marca_lancamento_quando_prestacao_em_analise():
+def test_nao_marca_lancamento_quando_prestacao_em_analise(
+    prestacao_conta_factory,
+    solicitacao_acerto_lancamento_factory,
+    analise_prestacao_conta_factory,
+    tipo_acerto_lancamento_factory,
+    analise_lancamento_prestacao_conta_factory,
+    despesa_factory,
+    associacao,
+    periodo_2020_2
+):
     despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_atualizado(
+        prestacao_conta_factory,
+        solicitacao_acerto_lancamento_factory,
+        analise_prestacao_conta_factory,
+        tipo_acerto_lancamento_factory,
+        analise_lancamento_prestacao_conta_factory,
+        despesa_factory,
+        associacao,
+        periodo_2020_2,
         status_prestacao=PrestacaoConta.STATUS_EM_ANALISE,
         lancamento_atualizado=False,
     )


### PR DESCRIPTION
# O que este PR faz

- habilita a opção de marcar lançamento como atualizado ao editar despesa
- testes unitários
