### PR TITLE
Refactor/151936 alterar texto geracao ata relacao bens

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1317,7 +1317,8 @@ class RelacaoBensAdmin(admin.ModelAdmin):
         from .services.relacao_bens import gerar_arquivo_relacao_de_bens_dados_persistidos
         for item in queryset:
             recurso_nome = item.conta_associacao.tipo_conta.recurso.nome
-            gerar_arquivo_relacao_de_bens_dados_persistidos(item, recurso_nome)
+            recurso_nome_exibicao = item.conta_associacao.tipo_conta.recurso.nome_exibicao
+            gerar_arquivo_relacao_de_bens_dados_persistidos(item, recurso_nome, recurso_nome_exibicao)
 
 
 class ItemRelatorioRelacaoDeBensInline(admin.TabularInline):

--- a/sme_ptrf_apps/core/models/recurso.py
+++ b/sme_ptrf_apps/core/models/recurso.py
@@ -93,6 +93,12 @@ class Recurso(ModeloIdNome, TemAtivo):
     def __str__(self):
         return self.nome
 
+    @property
+    def get_text_valores_reprogramados_ata(self):
+        if self.nome == "Prêmio Excelência Educacional":
+            return "valores estes que serão tratados conforme a legislação vigente"
+
+        return "valores estes que foram reprogramados"
 
 @receiver(models.signals.post_delete, sender=Recurso)
 def auto_delete_file_on_delete(sender, instance, **kwargs):

--- a/sme_ptrf_apps/core/services/ata_dados_service.py
+++ b/sme_ptrf_apps/core/services/ata_dados_service.py
@@ -151,9 +151,12 @@ def data_por_extenso(data):
 def cria_cabecalho(ata):
     """ GERA CABECALHO DOCUMENTO EM PDF ATA """
 
+    text_valores_reprogramados_ata = ata.periodo.recurso.get_text_valores_reprogramados_ata
+
     cabecalho = {
         "titulo": ata.periodo.recurso.nome,
         "recurso": ata.periodo.recurso.nome,
+        "text_valores_reprogramados_ata": text_valores_reprogramados_ata,
         "subtitulo": "Prestação de Contas",
         "tipo_ata": 'Apresentação' if ata.tipo_ata == 'APRESENTACAO' else 'Retificação',
         "periodo_referencia": ata.periodo.referencia,

--- a/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/dados_demo_financeiro_service.py
@@ -20,7 +20,7 @@ from waffle import get_waffle_flag_model
 LOGGER = logging.getLogger(__name__)
 
 def gerar_dados_demonstrativo_financeiro(usuario, acoes, periodo, conta_associacao, prestacao, observacao_conciliacao, previa=False):
-    
+
     try:
         LOGGER.info("GERANDO DADOS DEMONSTRATIVO...")
         rateios_conferidos = RateioDespesa.rateios_da_conta_associacao_no_periodo(
@@ -116,6 +116,7 @@ def gerar_dados_demonstrativo_financeiro(usuario, acoes, periodo, conta_associac
 def cria_cabecalho(periodo, conta_associacao, previa):
     cabecalho = {
         "recurso": periodo.recurso.nome,
+        "recurso_nome_exibicao": periodo.recurso.nome_exibicao,
         "titulo": "Demonstrativo Financeiro - PRÉVIA" if previa else "Demonstrativo Financeiro - FINAL",
         "periodo": str(periodo),
         "periodo_referencia": periodo.referencia,
@@ -901,10 +902,10 @@ def tem_movimentacao(resumo_acao):
 
     valor_absoluto_linha_custeio_despesa = abs(resumo_acao["linha_custeio"]["despesa_realizada"]) if \
         resumo_acao["linha_custeio"]["despesa_realizada"] != '' else 0
-    
+
     valor_absoluto_linha_custeio_despesa_nao_realizada = abs(resumo_acao["linha_custeio"]["despesa_nao_realizada"]) if \
         resumo_acao["linha_custeio"]["despesa_nao_realizada"] != '' else 0
-    
+
     valor_absoluto_linha_custeio_despesa_nao_realizada_anterior = abs(resumo_acao["linha_custeio"]["despesa_nao_demostrada_outros_periodos"]) if \
         resumo_acao["linha_custeio"]["despesa_nao_demostrada_outros_periodos"] != '' else 0
 
@@ -921,10 +922,10 @@ def tem_movimentacao(resumo_acao):
 
     valor_absoluto_linha_capital_despesa = abs(resumo_acao["linha_capital"]["despesa_realizada"]) if \
         resumo_acao["linha_capital"]["despesa_realizada"] != '' else 0
-    
+
     valor_absoluto_linha_capital_despesa_nao_realizada = abs(resumo_acao["linha_capital"]["despesa_nao_realizada"]) if \
         resumo_acao["linha_capital"]["despesa_nao_realizada"] != '' else 0
-    
+
     valor_absoluto_linha_capital_despesa_nao_realizada_anterior = abs(resumo_acao["linha_capital"]["despesa_nao_demostrada_outros_periodos"]) if \
         resumo_acao["linha_capital"]["despesa_nao_demostrada_outros_periodos"] != '' else 0
 

--- a/sme_ptrf_apps/core/services/recuperacao_dados_persistindos_demo_financeiro_service.py
+++ b/sme_ptrf_apps/core/services/recuperacao_dados_persistindos_demo_financeiro_service.py
@@ -22,6 +22,7 @@ class RecuperaDadosDemoFinanceiro:
     def retorna_dados_cabecalho(self):
         cabecalho = {
             "recurso": self.demonstrativo.prestacao_conta.periodo.recurso.nome,
+            "recurso_nome_exibicao": self.demonstrativo.prestacao_conta.periodo.recurso.nome_exibicao,
             "periodo_referencia": self.dados.periodo_referencia,
             "periodo_data_inicio": self.formata_data(self.dados.periodo_data_inicio),
             "periodo_data_fim": self.formata_data(self.dados.periodo_data_fim),

--- a/sme_ptrf_apps/core/services/relacao_bens.py
+++ b/sme_ptrf_apps/core/services/relacao_bens.py
@@ -14,13 +14,14 @@ from ..services.relacao_bens_pdf_service import gerar_arquivo_relacao_de_bens_pd
 LOGGER = logging.getLogger(__name__)
 
 
-def gerar_arquivo_relacao_de_bens_dados_persistidos(relacao_bens, recurso_nome):
+def gerar_arquivo_relacao_de_bens_dados_persistidos(relacao_bens, recurso_nome, recurso_nome_exibicao):
     relatorio_persistido = relacao_bens.relatoriorelacaobens_set.last()
     if relatorio_persistido:
         gerar_arquivo_relacao_de_bens_pdf(
             dados_relacao_de_bens=formatar_e_retornar_dados_relatorio_relacao_bens(
                 relatorio_persistido,
-                recurso_nome
+                recurso_nome,
+                recurso_nome_exibicao,
             ),
             relacao_bens=relacao_bens
         )
@@ -61,10 +62,14 @@ def apagar_previas_relacao_de_bens(periodo, conta_associacao):
         relacao_bens.delete()
 
 
-def _retornar_dados_relatorio_relacao_de_bens(relacao_bens, recurso_nome):
+def _retornar_dados_relatorio_relacao_de_bens(relacao_bens, recurso_nome, recurso_nome_exibicao):
     relatorio_persistido = relacao_bens.relatoriorelacaobens_set.last()
     if relatorio_persistido:
-        return formatar_e_retornar_dados_relatorio_relacao_bens(relatorio_persistido, recurso_nome)
+        return formatar_e_retornar_dados_relatorio_relacao_bens(
+            relatorio_persistido,
+            recurso_nome,
+            recurso_nome_exibicao
+        )
     return None
 
 

--- a/sme_ptrf_apps/core/services/relacao_bens_dados_service.py
+++ b/sme_ptrf_apps/core/services/relacao_bens_dados_service.py
@@ -45,6 +45,7 @@ def cria_cabecalho(periodo, conta_associacao):
 
     cabecalho = {
         "recurso": periodo.recurso.nome,
+        "recurso_nome_exibicao": periodo.recurso.nome_exibicao,
         "periodo_referencia": periodo.referencia,
         "periodo_data_inicio": formata_data(periodo.data_inicio_realizacao_despesas),
         "periodo_data_fim": formata_data(periodo.data_fim_realizacao_despesas),
@@ -289,7 +290,7 @@ def persistir_dados_relacao_bens(periodo, conta_associacao, rateios, relacao_ben
     LOGGER.info(f'Dados da relação bens persistidos {relatorio} com sucesso.')
 
 
-def formatar_e_retornar_dados_relatorio_relacao_bens(relatorio, recurso_nome):
+def formatar_e_retornar_dados_relatorio_relacao_bens(relatorio, recurso_nome, recurso_nome_exibicao):
     linhas = []
 
     for item in relatorio.bens.all():
@@ -308,6 +309,7 @@ def formatar_e_retornar_dados_relatorio_relacao_bens(relatorio, recurso_nome):
     dados_relacao_de_bens = {
         "cabecalho": {
             "recurso": recurso_nome,
+            "recurso_nome_exibicao": recurso_nome_exibicao,
             "periodo_referencia": relatorio.periodo_referencia,
             "periodo_data_inicio": formata_data(relatorio.periodo_data_inicio),
             "periodo_data_fim": formata_data(relatorio.periodo_data_fim),

--- a/sme_ptrf_apps/core/tasks/gerar_relacao_de_bens.py
+++ b/sme_ptrf_apps/core/tasks/gerar_relacao_de_bens.py
@@ -49,16 +49,17 @@ def gerar_relacao_bens_async(self, id_task, prestacao_conta_uuid, username=""):
         rel_bens_logger.info(f'Iniciando task gerar_relacao_bens_async, tentativa {tentativa}.')
 
         if not pc_service.requer_gerar_documentos:
-            rel_bens_logger.info(f'PC não requer geração de documentos. Relação de bens não gerada.')
+            rel_bens_logger.info('PC não requer geração de documentos. Relação de bens não gerada.')
             return
 
         prestacao = pc_service.prestacao
         recurso_nome = prestacao.periodo.recurso.nome
+        recurso_nome_exibicao = prestacao.periodo.recurso.nome_exibicao
 
         relacao_bens = prestacao.relacoes_de_bens_da_prestacao.filter(versao=RelacaoBens.VERSAO_FINAL)
 
         for relacao in relacao_bens:
-            dados = _retornar_dados_relatorio_relacao_de_bens(relacao, recurso_nome)
+            dados = _retornar_dados_relatorio_relacao_de_bens(relacao, recurso_nome, recurso_nome_exibicao)
 
             if dados:
                 gerar_arquivo_relacao_de_bens_pdf(dados, relacao)
@@ -66,7 +67,7 @@ def gerar_relacao_bens_async(self, id_task, prestacao_conta_uuid, username=""):
                 rel_bens_logger.info(f'Arquivo relação bens PDF gerado para a conta {relacao.conta_associacao}.')
             else:
                 rel_bens_logger.warning(
-                    f'Dados persistidos da relação de bens não encontrados.',
+                    'Dados persistidos da relação de bens não encontrados.',
                     extra={'observacao': f'relacao: {relacao}'}
                 )
 

--- a/sme_ptrf_apps/core/tests/tests_relacao_bens/test_gerar_arquivo_relacao_de_bens.py
+++ b/sme_ptrf_apps/core/tests/tests_relacao_bens/test_gerar_arquivo_relacao_de_bens.py
@@ -46,4 +46,9 @@ def test_persistir_arquivo_sem_rateios_retorna_none(periodo, conta_associacao):
 def test_gerar_arquivo_dados_persistidos_sem_relatorio_nao_falha(relacao_bens_final):
     # Quando não há RelatorioRelacaoBens associado, não deve lançar exceção
     recurso_nome = relacao_bens_final.conta_associacao.tipo_conta.recurso.nome or None
-    gerar_arquivo_relacao_de_bens_dados_persistidos(relacao_bens=relacao_bens_final, recurso_nome=recurso_nome)
+    recurso_nome_exibicao = relacao_bens_final.conta_associacao.tipo_conta.recurso.nome_exibicao or None
+    gerar_arquivo_relacao_de_bens_dados_persistidos(
+        relacao_bens=relacao_bens_final,
+        recurso_nome=recurso_nome,
+        recurso_nome_exibicao=recurso_nome_exibicao
+    )

--- a/sme_ptrf_apps/core/tests/tests_services/tests_relacao_bens_service/test_relacao_bens_service.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_relacao_bens_service/test_relacao_bens_service.py
@@ -138,14 +138,20 @@ def test_persistir_relatorio_final_relacao_bens_com_relatorios_anteriores(period
     assert relatorio.count() == 1
 
 
-def test_formatar_e_retornar_dados_relatorio_relacao_bens(relacao_bens_factory, item_relatorio_relacao_de_bens_factory, relatorio_relacao_bens_factory):
+def test_formatar_e_retornar_dados_relatorio_relacao_bens(relacao_bens_factory, item_relatorio_relacao_de_bens_factory,
+                                                          relatorio_relacao_bens_factory):
     relacao_bens = relacao_bens_factory.create()
     relatorio_instance = relatorio_relacao_bens_factory.create(relacao_bens=relacao_bens)
     item_relatorio_relacao_de_bens_factory.create(relatorio=relatorio_instance)
 
     recurso_nome = relacao_bens.conta_associacao.tipo_conta.recurso.nome
+    recurso_nome_exibicao = relacao_bens.conta_associacao.tipo_conta.recurso.nome_exibicao
 
-    resultado = formatar_e_retornar_dados_relatorio_relacao_bens(relatorio_instance, recurso_nome)
+    resultado = formatar_e_retornar_dados_relatorio_relacao_bens(
+        relatorio_instance,
+        recurso_nome,
+        recurso_nome_exibicao,
+    )
 
     assert 'cabecalho' in resultado
     assert 'periodo_referencia' in resultado['cabecalho']

--- a/sme_ptrf_apps/templates/pdf/ata/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata/pdf.html
@@ -325,8 +325,8 @@
         agência {{ conta.conta_associacao.agencia }} os valores de
         R$ {{ conta.totais.saldo_atual_custeio|formata_valor }}
         para saldo de custeio, R$ {{ conta.totais.saldo_atual_capital|formata_valor }}, para saldo de capital e
-        R$ {{ conta.totais.saldo_atual_livre|formata_valor }} para saldo de livre aplicação, valores estes que foram
-        reprogramados, além de
+        R$ {{ conta.totais.saldo_atual_livre|formata_valor }} para saldo de livre aplicação, {{ dados.cabecalho.text_valores_reprogramados_ata }},
+        além de
         R$ {{ conta.totais.despesas_nao_conciliadas|addition:conta.totais.despesas_nao_conciliadas_anteriores|formata_valor }}
         relativo a despesas pendentes de compensação bancária, totalizando
         R$ {{ conta.totais.saldo_bancario_total|formata_valor }}.</p>
@@ -343,7 +343,7 @@
         para saldo de custeio, R$ {{ conta.totais.saldo_atual_capital|formata_valor }}, para saldo de capital e
         R$ {{ conta.totais.saldo_atual_livre|formata_valor }} para saldo de livre aplicação, totalizando
         R$ {{ conta.totais.saldo_bancario_total|formata_valor }},
-        valores estes que foram reprogramados.</p>
+        {{ dados.cabecalho.text_valores_reprogramados_ata }}.</p>
     {% endif %}
 
     {% comment %} FIM Texto por ação {% endcomment %}

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_financeiro/pdf-horizontal.html
@@ -10,7 +10,7 @@
   <link href="{{ base_static_url }}/css/bootstrap/bootstrap-4.6.0.min.css" rel="stylesheet">
   <link href="{{ base_static_url }}/css/pdf-demo-financeiro-horizontal.css" rel="stylesheet">
 
-  <title>Demonstrativo Financeiro PTRF</title>
+  <title>Demonstrativo Financeiro {{ dados.cabecalho.recurso_nome_exibicao }}</title>
 </head>
 <body>
 {% if dados.previa %}

--- a/sme_ptrf_apps/templates/pdf/relacao_de_bens/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relacao_de_bens/pdf.html
@@ -11,7 +11,7 @@
     <link href="{{ base_static_url }}/css/bootstrap/bootstrap-4.6.0.min.css" rel="stylesheet">
     <link href="{{ base_static_url }}/css/relacao-de-bens-pdf.css" rel="stylesheet">
 
-  <title>Relação de Bens PTRF</title>
+  <title>Relação de Bens {{ dados.cabecalho.recurso_nome_exibicao }}</title>
 </head>
 <body>
 {% if dados.previa %}
@@ -129,7 +129,7 @@
       </p>
       <div class="col-12 border mt-3">
         <p class="pt-2 mb-1">Declaro, sob as penas de Lei, que os bens acima relacionados, adquiridos ou produzidos com
-          recursos do PTRF foram doados à Prefeitura do Município de São Paulo/ Secretaria Municipal de Educação, para
+          recursos do {{ dados.cabecalho.recurso_nome_exibicao }} foram doados à Prefeitura do Município de São Paulo/ Secretaria Municipal de Educação, para
           serem incorporados ao patrimônio público e destinados à
           (ao) {{ dados.identificacao_apm.tipo_unidade }} {{ dados.identificacao_apm.nome_unidade }}, responsável por sua
           guarda e conservação.</p>


### PR DESCRIPTION
Este PR inclui:

- Altera textos de ata quando o recurso selecionado for o Prêmio de Excelência Educacional;
- Atualiza o texto das abas dos pdfs para pegar o nome de exibição do recurso selecionado;
- Altera no documento de relação de bens no bloco 3 o texto para pegar o nome de exibição do recurso selecionado;
- Ajusta testes unitários;

História: [AB#151936](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151936)
Tarefa: [AB#152005](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152005)