### PR TITLE
feat(145736): Exibe documentos anteriores em Retificação

### DIFF
--- a/sme_ptrf_apps/paa/api/serializers/renderizador_paa_serializer.py
+++ b/sme_ptrf_apps/paa/api/serializers/renderizador_paa_serializer.py
@@ -90,6 +90,7 @@ class RenderizadorPaaSerializer(serializers.Serializer):
     pode_retificar = serializers.BooleanField()
     esta_em_retificacao = serializers.BooleanField()
     exibe_dados_retificacao = serializers.BooleanField()
+    ciclo_retificacao_sem_documento = serializers.BooleanField()
     unidade = serializers.DictField()
     original = RenderizadorBlocoDocumentacaoSerializer()
     retificacao = RenderizadorBlocoDocumentacaoSerializer(allow_null=True)
@@ -288,41 +289,38 @@ class RenderizadorPaaBuilder:
             self.paa.atas_da_paa.filter(tipo_ata=tipo_ata).order_by('-pk').first()
         )
 
-    def _doc_retificacao_ciclo_atual(self) -> Optional[DocumentoPaa]:
-        """Retorna o documento de retificação gerado no ciclo atual.
+    def _doc_retificacao_concluido(self) -> Optional[DocumentoPaa]:
+        """Documento de retificação FINAL CONCLUIDO mais recente (ciclo anterior ao corrente).
 
-        Quando o PAA está em retificação, o banco pode conter o documento de
-        uma retificação anterior enquanto o novo ainda não foi gerado. O UUID do
-        documento mais recente é comparado com o UUID registrado no snapshot da
-        réplica: se coincidirem, o documento pertence ao ciclo anterior e o
-        método retorna None, sinalizando ao bloco de renderização que a geração
-        ainda está pendente.
-
-        Returns:
-            Instância de DocumentoPaa do ciclo atual, ou None se ainda não gerado.
+        Usado como fallback quando o ciclo atual ainda não gerou seu próprio documento,
+        para manter os dados da retificação anterior visíveis na UI.
         """
-        return CicloRetificacaoService(self.paa).documento_atual
+        return (
+            self.paa.documentopaa_set
+            .filter(
+                retificacao=True,
+                versao=DocumentoPaa.VersaoChoices.FINAL,
+                status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
+            )
+            .order_by('-versao_documento')
+            .first()
+        )
 
-    def _numero_versao_retificacao(self, doc_retificacao: Optional[DocumentoPaa]) -> str:
-        """Retorna o número da versão de retificação para o título da seção.
+    def _ata_retificacao_concluida(self) -> Optional[AtaPaa]:
+        """Ata de retificação CONCLUIDA mais recente (ciclo anterior ao corrente).
 
-        Quando o documento do ciclo atual já existe, usa diretamente seu
-        ``versao_documento``. Quando ainda não foi gerado (ciclo em andamento),
-        infere o número a partir do snapshot da réplica: versao_documento do
-        ciclo anterior + 1. Retorna '' quando o número não é determinável.
-
-        Args:
-            doc_retificacao: Documento de retificação do ciclo atual, ou None
-                quando ainda não gerado.
-
-        Returns:
-            String com o número da versão (ex.: '1', '2'), ou '' como fallback.
+        Usada como fallback junto com ``_doc_retificacao_concluido`` quando
+        o ciclo atual ainda não gerou seu próprio documento.
         """
-        if doc_retificacao:
-            return str(doc_retificacao.versao_documento)
-        if not self.paa.status_em_retificacao:
-            return ''
-        return str(CicloRetificacaoService(self.paa).numero_versao)
+        return (
+            self.paa.atas_da_paa
+            .filter(
+                tipo_ata=AtaPaa.ATA_RETIFICACAO,
+                status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+            )
+            .order_by('-pk')
+            .first()
+        )
 
     def _pode_retificar(self) -> bool:
         if self.paa.status_em_retificacao:
@@ -354,15 +352,38 @@ class RenderizadorPaaBuilder:
         """
         doc_original = obter_documento_final_por_retificacao(self.paa, False)
         ata_original = self._ata_por_tipo(AtaPaa.ATA_APRESENTACAO)
-        ata_retificacao = self._ata_por_tipo(AtaPaa.ATA_RETIFICACAO)
 
         if self.paa.status_em_retificacao:
             ciclo = CicloRetificacaoService(self.paa)
-            doc_retificacao = ciclo.documento_atual
-            versao_retificacao = str(ciclo.numero_versao)
+            ciclo_doc_atual = ciclo.documento_atual
+            # True quando o ciclo corrente ainda não gerou seu próprio documento.
+            # Usado pelo frontend para exibir o botão de retificação sem depender
+            # do campo versao do documento exibido (que pode ser fallback do ciclo anterior).
+            ciclo_retificacao_sem_documento = ciclo_doc_atual is None
+
+            if ciclo_doc_atual:
+                # Ciclo atual já gerou seu documento → exibe dados do ciclo corrente.
+                doc_retificacao = ciclo_doc_atual
+                versao_retificacao = str(doc_retificacao.versao_documento)
+                ata_retificacao = self._ata_por_tipo(AtaPaa.ATA_RETIFICACAO)
+            else:
+                doc_anterior = self._doc_retificacao_concluido()
+                if doc_anterior:
+                    # Rn (n≥2): ciclo atual sem doc ainda → exibe dados do ciclo anterior
+                    # concluído até que o ciclo corrente gere o seu próprio documento.
+                    doc_retificacao = doc_anterior
+                    ata_retificacao = self._ata_retificacao_concluida()
+                    versao_retificacao = str(doc_anterior.versao_documento)
+                else:
+                    # R1: não há ciclo anterior → exibe pendente com o número do ciclo atual.
+                    doc_retificacao = None
+                    ata_retificacao = self._ata_por_tipo(AtaPaa.ATA_RETIFICACAO)
+                    versao_retificacao = str(ciclo.numero_versao)
         else:
+            ciclo_retificacao_sem_documento = False
             doc_retificacao = obter_documento_final_por_retificacao(self.paa, True)
             versao_retificacao = str(doc_retificacao.versao_documento) if doc_retificacao else ''
+            ata_retificacao = self._ata_por_tipo(AtaPaa.ATA_RETIFICACAO)
 
         bloco_docs_originais = {
             'secao_titulo': 'PAA Original',
@@ -374,7 +395,7 @@ class RenderizadorPaaBuilder:
             self.paa.status_em_retificacao or doc_retificacao or ata_retificacao
         )
         bloco_docs_retificacao = {
-            'secao_titulo': f'PAA Retificado #{versao_retificacao}',
+            'secao_titulo': f'PAA Retificado #{versao_retificacao}' if versao_retificacao else 'PAA Retificado',
             'documento': self._documento_render(doc_retificacao, True),
             'ata': self._ata_render(ata_retificacao, True, eh_paa_vigente),
         } if exibe_dados_retificacao else None
@@ -384,6 +405,7 @@ class RenderizadorPaaBuilder:
             'pode_retificar': self._pode_retificar(),
             'esta_em_retificacao': self.paa.status_em_retificacao,
             'exibe_dados_retificacao': exibe_dados_retificacao,
+            'ciclo_retificacao_sem_documento': ciclo_retificacao_sem_documento,
             'unidade': self._unidade(),
             'original': bloco_docs_originais,
             'retificacao': bloco_docs_retificacao,

--- a/sme_ptrf_apps/paa/models/ata_paa.py
+++ b/sme_ptrf_apps/paa/models/ata_paa.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from auditlog.models import AuditlogHistoryField
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from waffle import get_waffle_flag_model
@@ -241,7 +243,7 @@ class AtaPaa(ModeloBase):
         """
             É utilizado em PC (PrestacaoContaObterDocumentoPAASerializer) e no PAA (vigentes e anteriores)
         """
-        tipo_documento = 'Documento final %s' % 'retificado ' if self.tipo_retificacao else ''
+        tipo_documento = 'Documento final %s' % ('retificado ' if self.tipo_retificacao else '')
         if self.status_geracao_pdf == self.STATUS_CONCLUIDO:
             return f'{tipo_documento} gerado em {self.alterado_em.strftime("%d/%m/%Y às %H:%M")}'
 
@@ -293,3 +295,14 @@ class AtaPaa(ModeloBase):
     class Meta:
         verbose_name = "Ata PAA"
         verbose_name_plural = "Atas PAA"
+
+
+@receiver(post_delete, sender=AtaPaa)
+def ata_paa_post_delete(instance, **kwargs):
+    """
+    Remove o arquivo físico do storage ao apagar o registro. Necessário porque
+    o Django não apaga arquivos de FileField automaticamente, nem em
+    instance.delete() nem em queryset.delete().
+    """
+    if instance.arquivo_pdf:
+        instance.arquivo_pdf.delete(save=False)

--- a/sme_ptrf_apps/paa/models/documento_paa.py
+++ b/sme_ptrf_apps/paa/models/documento_paa.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from sme_ptrf_apps.core.models_abstracts import ModeloBase
 from auditlog.models import AuditlogHistoryField
 from auditlog.registry import auditlog
@@ -114,6 +116,17 @@ def obter_documento_final_por_retificacao(paa, retificacao: bool):
         .order_by('-pk')
         .first()
     )
+
+
+@receiver(post_delete, sender=DocumentoPaa)
+def documento_paa_post_delete(instance, **kwargs):
+    """
+    Remove o arquivo físico do storage ao apagar o registro. Necessário porque
+    o Django não apaga arquivos de FileField automaticamente, nem em
+    instance.delete() nem em queryset.delete().
+    """
+    if instance.arquivo_pdf:
+        instance.arquivo_pdf.delete(save=False)
 
 
 auditlog.register(DocumentoPaa)

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
@@ -257,6 +257,45 @@ class TestAnnotateStatusGeracao:
         qs = _qs().filter(pk=paa.pk)
         assert qs.first().get_status_andamento() == PaaStatusAndamentoEnum.FORA_FLUXO.name
 
+    def test_status_em_retificacao_com_ata_em_processamento_retorna_gerado_parcialmente(
+        self,
+        paa_factory,
+        periodo_paa_factory,
+        associacao,
+        documento_paa_factory,
+        ata_paa_factory,
+        replica_paa_factory,
+    ):
+        """
+        Réplica + doc retificação concluído + ata EM_PROCESSAMENTO → GERADO_PARCIALMENTE.
+        Durante a geração da ata (task Celery), a ata vai de NAO_GERADO para EM_PROCESSAMENTO.
+        Antes da correção, ata_retificacao_iniciada só considerava NAO_GERADO, fazendo o PAA
+        desaparecer da listagem durante a geração. Com a correção, EM_PROCESSAMENTO também conta
+        como ata iniciada e o PAA permanece em GERADO_PARCIALMENTE.
+        """
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(
+            periodo_paa=periodo,
+            associacao=associacao,
+            status=PaaStatusEnum.EM_RETIFICACAO.name,
+        )
+        documento_paa_factory.create(
+            paa=paa,
+            versao=DocumentoPaa.VersaoChoices.FINAL,
+            status_geracao=DocumentoPaa.StatusChoices.CONCLUIDO,
+            retificacao=True,
+        )
+        ata_paa_factory.create(
+            paa=paa,
+            status_geracao_pdf=AtaPaa.STATUS_EM_PROCESSAMENTO,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+        )
+        replica_paa_factory.create(paa=paa)
+
+        qs = _qs().filter(pk=paa.pk).paas_gerados_e_parciais()
+        assert qs.first() is not None
+        assert qs.first().status_andamento == PaaStatusAndamentoEnum.GERADO_PARCIALMENTE.name
+
 
 class TestFilterPorStatusGeracao:
     def test_filtra_somente_gerados(

--- a/sme_ptrf_apps/paa/tests/renderizador_paa/test_renderizador_paa_builder.py
+++ b/sme_ptrf_apps/paa/tests/renderizador_paa/test_renderizador_paa_builder.py
@@ -28,146 +28,244 @@ def _builder(paa):
     return RenderizadorPaaBuilder(paa)
 
 
-# _doc_retificacao_ciclo_atual
-class TestDocRetificacaoCicloAtual:
+# _doc_retificacao_concluido
+class TestDocRetificacaoConcluido:
     """
-    Verifica que _doc_retificacao_ciclo_atual retorna o documento do ciclo corrente
-    ou None quando o único doc existente pertence ao ciclo anterior.
+    Verifica que _doc_retificacao_concluido retorna o documento de retificação
+    FINAL+CONCLUIDO mais recente (por versao_documento desc), usado como fallback
+    quando o ciclo atual ainda não gerou seu próprio documento (cenário Rn).
     """
 
-    def test_retorna_none_sem_documento(self, paa_factory, replica_paa_factory):
+    def test_retorna_none_sem_documentos_retificacao(self, paa_factory):
         """Sem nenhum doc retificado → None."""
         paa = _paa_em_retificacao(paa_factory)
-        replica_paa_factory(
-            paa=paa,
-            historico={'documento_retificado': {'uuid': None, 'versao_documento': None}},
-        )
-        assert _builder(paa)._doc_retificacao_ciclo_atual() is None
+        assert _builder(paa)._doc_retificacao_concluido() is None
 
-    def test_retorna_none_quando_doc_pertence_ao_ciclo_anterior(
-        self, paa_factory, documento_paa_factory, replica_paa_factory
-    ):
-        """UUID do doc == UUID no snapshot → doc de R1 → None durante R2."""
+    def test_retorna_none_quando_doc_nao_esta_concluido(self, paa_factory, documento_paa_factory):
+        """Doc retificado EM_PROCESSAMENTO não conta como CONCLUIDO → None."""
         paa = _paa_em_retificacao(paa_factory)
-        doc_r1 = documento_paa_factory(
+        documento_paa_factory(paa=paa, retificacao=True, versao=FINAL, status_geracao=EM_PROCESSAMENTO)
+        assert _builder(paa)._doc_retificacao_concluido() is None
+
+    def test_retorna_documento_concluido_unico(self, paa_factory, documento_paa_factory):
+        """Um único doc CONCLUIDO → retornado."""
+        paa = _paa_em_retificacao(paa_factory)
+        doc = documento_paa_factory(
             paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
         )
-        replica_paa_factory(
-            paa=paa,
-            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
-        )
-        assert _builder(paa)._doc_retificacao_ciclo_atual() is None
-
-    def test_retorna_doc_quando_pertence_ao_ciclo_atual_concluido(
-        self, paa_factory, documento_paa_factory, replica_paa_factory
-    ):
-        """UUID do doc ≠ UUID no snapshot → doc de R2 CONCLUIDO retornado."""
-        paa = _paa_em_retificacao(paa_factory)
-        doc_r1 = documento_paa_factory(
-            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
-        )
-        doc_r2 = documento_paa_factory(
-            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=2
-        )
-        replica_paa_factory(
-            paa=paa,
-            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
-        )
-        result = _builder(paa)._doc_retificacao_ciclo_atual()
-        assert result is not None
-        assert result.pk == doc_r2.pk
-
-    def test_retorna_doc_quando_pertence_ao_ciclo_atual_em_processamento(
-        self, paa_factory, documento_paa_factory, replica_paa_factory
-    ):
-        """Doc de R2 EM_PROCESSAMENTO (task em andamento) também é retornado."""
-        paa = _paa_em_retificacao(paa_factory)
-        doc_r1 = documento_paa_factory(
-            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
-        )
-        doc_r2 = documento_paa_factory(
-            paa=paa, retificacao=True, versao=FINAL, status_geracao=EM_PROCESSAMENTO, versao_documento=2
-        )
-        replica_paa_factory(
-            paa=paa,
-            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
-        )
-        result = _builder(paa)._doc_retificacao_ciclo_atual()
-        assert result is not None
-        assert result.pk == doc_r2.pk
-
-    def test_retorna_doc_sem_replica(self, paa_factory, documento_paa_factory):
-        """Sem réplica, qualquer doc existente é retornado (sem referência de snapshot)."""
-        paa = _paa_em_retificacao(paa_factory)
-        doc = documento_paa_factory(paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO)
-        result = _builder(paa)._doc_retificacao_ciclo_atual()
+        result = _builder(paa)._doc_retificacao_concluido()
         assert result is not None
         assert result.pk == doc.pk
 
-
-# _numero_versao_retificacao
-class TestNumeroVersaoRetificacao:
-    """
-    Verifica que _numero_versao_retificacao retorna a string correta com o número
-    da versão de retificação, inferindo do snapshot quando o doc ainda não foi gerado.
-    """
-
-    def test_usa_versao_do_documento_quando_disponivel(self, paa_factory, documento_paa_factory):
-        """Doc passado diretamente → usa doc.versao_documento."""
-        paa = paa_factory()
-        doc = documento_paa_factory(
-            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=3
+    def test_retorna_doc_mais_recente_por_versao_documento(self, paa_factory, documento_paa_factory):
+        """Com dois docs CONCLUIDOS, retorna o de maior versao_documento."""
+        paa = _paa_em_retificacao(paa_factory)
+        documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
         )
-        assert _builder(paa)._numero_versao_retificacao(doc) == '3'
+        doc_r2 = documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=2
+        )
+        result = _builder(paa)._doc_retificacao_concluido()
+        assert result.pk == doc_r2.pk
 
-    def test_retorna_vazio_quando_sem_doc_e_nao_em_retificacao(self, paa_factory):
-        """doc=None e PAA fora de retificação → '' (sem versão determinável)."""
+    def test_ignora_doc_nao_retificacao(self, paa_factory, documento_paa_factory):
+        """Doc original (retificacao=False) não é retornado."""
+        paa = _paa_em_retificacao(paa_factory)
+        documento_paa_factory(paa=paa, retificacao=False, versao=FINAL, status_geracao=CONCLUIDO)
+        assert _builder(paa)._doc_retificacao_concluido() is None
+
+
+# _ata_retificacao_concluida
+class TestAtaRetificacaoConcluida:
+    """
+    Verifica que _ata_retificacao_concluida retorna a ata de retificação CONCLUIDA
+    mais recente (por pk desc), usada como fallback quando o ciclo atual ainda não
+    gerou documento.
+    """
+
+    def test_retorna_none_sem_ata_retificacao(self, paa_factory):
+        """Sem nenhuma ata de retificação → None."""
+        paa = _paa_em_retificacao(paa_factory)
+        assert _builder(paa)._ata_retificacao_concluida() is None
+
+    def test_retorna_none_quando_ata_nao_concluida(self, paa_factory, ata_paa_factory):
+        """Ata STATUS_NAO_GERADO não conta como CONCLUIDA → None."""
+        paa = _paa_em_retificacao(paa_factory)
+        ata_paa_factory(paa=paa, tipo_ata=AtaPaa.ATA_RETIFICACAO, status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO)
+        assert _builder(paa)._ata_retificacao_concluida() is None
+
+    def test_retorna_ata_concluida_unica(self, paa_factory, ata_paa_factory):
+        """Uma única ata CONCLUIDA → retornada."""
+        paa = _paa_em_retificacao(paa_factory)
+        ata = ata_paa_factory(
+            paa=paa, tipo_ata=AtaPaa.ATA_RETIFICACAO, status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO
+        )
+        result = _builder(paa)._ata_retificacao_concluida()
+        assert result is not None
+        assert result.pk == ata.pk
+
+    def test_retorna_ata_mais_recente_por_pk(self, paa_factory, ata_paa_factory):
+        """Com duas atas CONCLUIDAS, retorna a de maior pk."""
+        paa = _paa_em_retificacao(paa_factory)
+        ata_paa_factory(paa=paa, tipo_ata=AtaPaa.ATA_RETIFICACAO, status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO)
+        ata_r2 = ata_paa_factory(
+            paa=paa, tipo_ata=AtaPaa.ATA_RETIFICACAO, status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO
+        )
+        result = _builder(paa)._ata_retificacao_concluida()
+        assert result.pk == ata_r2.pk
+
+    def test_ignora_ata_apresentacao(self, paa_factory, ata_paa_factory):
+        """Ata do tipo ATA_APRESENTACAO não é retornada."""
+        paa = _paa_em_retificacao(paa_factory)
+        ata_paa_factory(paa=paa, tipo_ata=AtaPaa.ATA_APRESENTACAO, status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO)
+        assert _builder(paa)._ata_retificacao_concluida() is None
+
+
+# ciclo_retificacao_sem_documento (campo em build())
+class TestBuildCicloRetificacaoSemDocumento:
+    """
+    Verifica que ciclo_retificacao_sem_documento no resultado de build() é True quando
+    o PAA está em EM_RETIFICACAO e o ciclo corrente ainda não gerou documento, e False
+    em todos os demais casos.
+    """
+
+    def test_falso_quando_paa_nao_em_retificacao(self, paa_factory):
+        """PAA fora de retificação → ciclo_retificacao_sem_documento=False."""
         paa = paa_factory()
-        assert _builder(paa)._numero_versao_retificacao(None) == ''
+        with patch(
+            'sme_ptrf_apps.paa.api.serializers.renderizador_paa_serializer.RetificacaoPaaService'
+        ) as mock:
+            mock.return_value.valida_pode_retificar.side_effect = ValidacaoRetificacao('não pode')
+            result = _builder(paa).build()
+        assert result['ciclo_retificacao_sem_documento'] is False
 
-    def test_infere_versao_1_para_r1_pendente_sem_snapshot_anterior(
-        self, paa_factory, replica_paa_factory
-    ):
-        """R1 em andamento: snapshot sem doc anterior → versao_documento=None → número 1."""
+    def test_verdadeiro_quando_r1_sem_documento(self, paa_factory, replica_paa_factory):
+        """R1: réplica sem snapshot anterior, sem doc gerado → True."""
         paa = _paa_em_retificacao(paa_factory)
         replica_paa_factory(
             paa=paa,
             historico={'documento_retificado': {'uuid': None, 'versao_documento': None}},
         )
-        assert _builder(paa)._numero_versao_retificacao(None) == '1'
+        result = _builder(paa).build()
+        assert result['ciclo_retificacao_sem_documento'] is True
 
-    def test_infere_versao_2_para_r2_pendente_com_snapshot_r1(
-        self, paa_factory, replica_paa_factory
+    def test_falso_quando_r1_tem_documento_gerado(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
     ):
-        """R2 em andamento: snapshot tem versao_documento=1 → número inferido = 2."""
+        """R1 com doc gerado no ciclo atual → False."""
         paa = _paa_em_retificacao(paa_factory)
         replica_paa_factory(
             paa=paa,
-            historico={'documento_retificado': {'uuid': 'qualquer-uuid', 'versao_documento': 1}},
+            historico={'documento_retificado': {'uuid': None, 'versao_documento': None}},
         )
-        assert _builder(paa)._numero_versao_retificacao(None) == '2'
+        documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
+        )
+        result = _builder(paa).build()
+        assert result['ciclo_retificacao_sem_documento'] is False
 
-    def test_infere_versao_1_quando_nao_ha_replica(self, paa_factory):
-        """Sem réplica (DoesNotExist): fallback para '1'."""
-        paa = _paa_em_retificacao(paa_factory)
-        assert _builder(paa)._numero_versao_retificacao(None) == '1'
-
-    def test_r2_com_doc_gerado_retorna_versao_do_doc(
-        self, paa_factory, documento_paa_factory, replica_paa_factory
+    def test_verdadeiro_quando_r2_sem_documento_proprio(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
     ):
-        """R2 com doc já gerado: usa doc.versao_documento=2, não o snapshot."""
+        """R2: snapshot aponta para doc R1 e nenhum doc R2 existe → True."""
         paa = _paa_em_retificacao(paa_factory)
         doc_r1 = documento_paa_factory(
             paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
         )
-        doc_r2 = documento_paa_factory(
+        replica_paa_factory(
+            paa=paa,
+            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
+        )
+        result = _builder(paa).build()
+        assert result['ciclo_retificacao_sem_documento'] is True
+
+    def test_falso_quando_r2_tem_documento_proprio(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
+    ):
+        """R2: snapshot aponta para doc R1 e doc R2 gerado → False."""
+        paa = _paa_em_retificacao(paa_factory)
+        doc_r1 = documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
+        )
+        documento_paa_factory(
             paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=2
         )
         replica_paa_factory(
             paa=paa,
             historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
         )
-        assert _builder(paa)._numero_versao_retificacao(doc_r2) == '2'
+        result = _builder(paa).build()
+        assert result['ciclo_retificacao_sem_documento'] is False
+
+
+# build() — Rn fallback: exibe dados do ciclo anterior quando ciclo atual não tem doc
+class TestBuildRnFallback:
+    """
+    Verifica que quando o PAA está em EM_RETIFICACAO e o ciclo atual ainda não gerou
+    documento, o bloco retificacao exibe os dados do ciclo anterior (fallback), e não
+    fica em branco.
+    """
+
+    def test_r2_sem_doc_usa_secao_titulo_com_versao_r1(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
+    ):
+        """R2 sem doc próprio: secao_titulo deve referenciar a versão do doc R1 (fallback)."""
+        paa = _paa_em_retificacao(paa_factory)
+        doc_r1 = documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
+        )
+        replica_paa_factory(
+            paa=paa,
+            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
+        )
+        result = _builder(paa).build()
+        assert result['retificacao'] is not None
+        assert result['retificacao']['secao_titulo'] == 'PAA Retificado #1'
+
+    def test_r2_sem_doc_exibe_dados_retificacao_true(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
+    ):
+        """R2 sem doc próprio: exibe_dados_retificacao deve ser True (bloco não oculto)."""
+        paa = _paa_em_retificacao(paa_factory)
+        doc_r1 = documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
+        )
+        replica_paa_factory(
+            paa=paa,
+            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
+        )
+        result = _builder(paa).build()
+        assert result['exibe_dados_retificacao'] is True
+
+    def test_r1_pendente_usa_secao_titulo_com_versao_1(self, paa_factory, replica_paa_factory):
+        """R1 sem doc (inicial): secao_titulo com número '1' inferido do ciclo."""
+        paa = _paa_em_retificacao(paa_factory)
+        replica_paa_factory(
+            paa=paa,
+            historico={'documento_retificado': {'uuid': None, 'versao_documento': None}},
+        )
+        result = _builder(paa).build()
+        assert result['retificacao'] is not None
+        assert result['retificacao']['secao_titulo'] == 'PAA Retificado #1'
+
+    def test_r2_com_doc_proprio_usa_versao_r2(
+        self, paa_factory, replica_paa_factory, documento_paa_factory
+    ):
+        """R2 com doc R2 gerado: secao_titulo deve referenciar versão 2."""
+        paa = _paa_em_retificacao(paa_factory)
+        doc_r1 = documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=1
+        )
+        documento_paa_factory(
+            paa=paa, retificacao=True, versao=FINAL, status_geracao=CONCLUIDO, versao_documento=2
+        )
+        replica_paa_factory(
+            paa=paa,
+            historico={'documento_retificado': {'uuid': str(doc_r1.uuid), 'versao_documento': 1}},
+        )
+        result = _builder(paa).build()
+        assert result['retificacao']['secao_titulo'] == 'PAA Retificado #2'
 
 
 # _cor_status_geracao

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_service_retificacao.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_service_retificacao.py
@@ -11,6 +11,7 @@ from sme_ptrf_apps.paa.services.ata_paa_service import (
     validar_geracao_ata_paa,
     _salvar_log_replica,
     _remover_replica,
+    _apagar_atas_retificacao_anteriores,
 )
 
 pytestmark = pytest.mark.django_db
@@ -493,3 +494,115 @@ class TestGerarArquivoAtaPaaRetificacao:
 
         assert resultado is not None
         assert not LogReplicaPaa.objects.filter(paa=ata_retificacao_nao_gerada.paa).exists()
+
+
+class TestApagarAtasRetificacaoAnteriores:
+    """
+    Verifica que _apagar_atas_retificacao_anteriores remove todas as atas ATA_RETIFICACAO
+    do PAA, exceto a ata atual (ata_paa passada como argumento).
+    Espelha o comportamento de DocumentoPaaService.apagar_documento_anteriores.
+    """
+
+    def test_apaga_atas_anteriores_mantendo_a_atual(self, paa_em_retificacao, ata_paa_factory):
+        """R2: ata R1 deve ser removida ao concluir ata R2."""
+        ata_r1 = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        ata_r2 = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        _apagar_atas_retificacao_anteriores(ata_r2)
+
+        assert not AtaPaa.objects.filter(pk=ata_r1.pk).exists()
+        assert AtaPaa.objects.filter(pk=ata_r2.pk).exists()
+
+    def test_sem_atas_anteriores_nao_causa_erro(self, paa_em_retificacao, ata_paa_factory):
+        """Quando só existe a ata atual, nenhum registro é removido e não há erro."""
+        ata_atual = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        _apagar_atas_retificacao_anteriores(ata_atual)
+
+        assert AtaPaa.objects.filter(pk=ata_atual.pk).exists()
+
+    def test_nao_remove_ata_apresentacao(self, paa_em_retificacao, ata_paa_factory):
+        """Atas do tipo ATA_APRESENTACAO não devem ser removidas."""
+        ata_apresentacao = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_APRESENTACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        ata_retificacao = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        _apagar_atas_retificacao_anteriores(ata_retificacao)
+
+        assert AtaPaa.objects.filter(pk=ata_apresentacao.pk).exists()
+        assert AtaPaa.objects.filter(pk=ata_retificacao.pk).exists()
+
+    def test_apaga_multiplas_atas_anteriores(self, paa_em_retificacao, ata_paa_factory):
+        """Múltiplas atas anteriores devem ser todas removidas ao concluir a atual."""
+        ata_r1 = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        ata_r2_antiga = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        ata_atual = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        _apagar_atas_retificacao_anteriores(ata_atual)
+
+        assert not AtaPaa.objects.filter(pk=ata_r1.pk).exists()
+        assert not AtaPaa.objects.filter(pk=ata_r2_antiga.pk).exists()
+        assert AtaPaa.objects.filter(pk=ata_atual.pk).exists()
+
+    def test_gerar_ata_retificacao_apaga_atas_anteriores(
+        self,
+        paa_em_retificacao,
+        ata_paa_factory,
+        replica_padrao,
+        usuario,
+    ):
+        """
+        Integração: gerar_arquivo_ata_paa_retificacao deve chamar
+        _apagar_atas_retificacao_anteriores e remover ata de ciclo anterior.
+        """
+        ata_r1_antiga = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_CONCLUIDO,
+        )
+        ata_atual = ata_paa_factory.create(
+            paa=paa_em_retificacao,
+            tipo_ata=AtaPaa.ATA_RETIFICACAO,
+            status_geracao_pdf=AtaPaa.STATUS_NAO_GERADO,
+        )
+
+        with (
+            patch('sme_ptrf_apps.paa.services.ata_paa_service.gerar_dados_ata_paa', return_value={'cabecalho': {}}),
+            patch('sme_ptrf_apps.paa.services.ata_paa_service.gerar_arquivo_ata_paa_pdf'),
+            patch('sme_ptrf_apps.paa.services.ata_paa_service.PaaService.concluir_paa'),
+        ):
+            gerar_arquivo_ata_paa_retificacao(ata_paa=ata_atual, usuario=usuario)
+
+        assert not AtaPaa.objects.filter(pk=ata_r1_antiga.pk).exists()
+        assert AtaPaa.objects.filter(pk=ata_atual.pk).exists()


### PR DESCRIPTION

Esse PR:

- Exibe documentos anteriores de retificação até que o documento final do ciclo corrente seja gerado.
- remove fisicamente arquivos pdf de Documentos e Atas do PAA que foram retificados, para evitar armazenamento de arquivos órfãos
- testes unitários

História [AB#145736](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145736)
