### PR TITLE
fix(147522): Adiciona time sleep para não gerar paralelismo na geração dos documentos prévia e final do PAA. - Hom

### DIFF
--- a/sme_ptrf_apps/paa/api/views/paa_viewset.py
+++ b/sme_ptrf_apps/paa/api/views/paa_viewset.py
@@ -7,6 +7,7 @@ e fluxos de retificação do PAA.
 """
 import logging
 from datetime import datetime
+from time import sleep
 from django.http import HttpResponse
 from django.http import Http404
 from django.db.models import Q
@@ -658,6 +659,7 @@ class PaaViewSet(WaffleFlagMixin, PaaBloqueiaAlteracaoMixin, ModelViewSet):
         Returns:
             Resposta de agendamento da rotina assíncrona ou status 400.
         """
+        sleep(2)  # Time sleep para não gerar paralelismo da geração da prévia com a geração do documento final.
         paa = self.get_object()
         usuario = request.user
 


### PR DESCRIPTION

Esse PR:

- Adiciona time sleep para não gerar paralelismo na geração dos documentos prévia e final do PAA.

História: [AB#147522](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/147522)
Task: [AB#151444](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151444)
