### PR TITLE
Hotfix(9.42.1) - corrige dre nao consegue reabrir pc

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.42.0"
+__version__ = "9.42.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
+++ b/sme_ptrf_apps/core/api/views/prestacoes_contas_viewset.py
@@ -399,10 +399,17 @@ class PrestacoesContasViewSet(mixins.RetrieveModelMixin,
 
         prestacao_de_contas = PrestacaoConta.by_uuid(uuid)
 
+        recurso = None
+
         if prestacao_de_contas:
             associacao = prestacao_de_contas.associacao
+            recurso = prestacao_de_contas.periodo.recurso
+
             prestacao_de_contas_posteriores = PrestacaoConta.objects.filter(
                 associacao=associacao, id__gt=prestacao_de_contas.id)
+
+            if recurso and prestacao_de_contas_posteriores:
+                prestacao_de_contas_posteriores = prestacao_de_contas_posteriores.filter(periodo__recurso=recurso)
 
             if prestacao_de_contas_posteriores:
                 response = {

--- a/sme_ptrf_apps/core/models/prestacao_conta.py
+++ b/sme_ptrf_apps/core/models/prestacao_conta.py
@@ -239,7 +239,7 @@ class PrestacaoConta(ModeloBase):
 
         tipo_relatorio = text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE if self.consolidado_dre.sequencia_de_publicacao == 0 \
             else text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL
-        
+
         text_consolidado_pc = text_document_consolidado_pc.text_possessive_with_type_and_sequency(
             publication_type=tipo_relatorio,
             sequency_number=self.consolidado_dre.sequencia_de_publicacao
@@ -734,7 +734,8 @@ class PrestacaoConta(ModeloBase):
                 return True
 
         pode_rebrir_pc = not self.associacao.fechamentos_associacao.filter(
-            periodo__referencia__gt=self.periodo.referencia
+            periodo__referencia__gt=self.periodo.referencia,
+            periodo__recurso=self.periodo.recurso
         ).exists()
         return pode_rebrir_pc
 


### PR DESCRIPTION
Esse PR:

- Corrige DRE não consegue reabrir ou devolver a PC
- Na View de PC dentro da action reabrir passou a filtrar periodo__recurso=recurso, antes isso não acontecia
- Na função pode_devolver() do modelo de PC, o filtro buscava fechamentos da associação em qualquer período posterior com referência maior — sem considerar o Recurso
- Atualiza Versão para 9.42.1

História: [AB#152946](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152946) e Tarefa: [AB#152980](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152980)