### PR TITLE
Feature/152167 parametrizacoes tipos de acertos em lancamentos

### DIFF
--- a/sme_ptrf_apps/conftest.py
+++ b/sme_ptrf_apps/conftest.py
@@ -115,7 +115,8 @@ def _garantir_recurso_legado(db):
             "nome_exibicao": "PTRF",
             "cor": "#01585E",
             "permite_saldo_conta_negativo": False,
-            "permite_saldo_acoes_negativo": True
+            "permite_saldo_acoes_negativo": True,
+            "habilita_exibicao_de_lauda": True,
         },
     )
 

--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -1663,9 +1663,9 @@ class AnaliseLancamentoPrestacaoContaAdmin(admin.ModelAdmin):
 
 @admin.register(TipoAcertoLancamento)
 class TipoAcertoLancamentoAdmin(admin.ModelAdmin):
-    list_display = ['nome', 'categoria', 'ativo']
+    list_display = ['nome', 'categoria', 'recurso', 'ativo']
     search_fields = ['nome', 'categoria']
-    list_filter = ['nome', 'categoria', 'ativo']
+    list_filter = ['nome', 'categoria', 'ativo', 'recurso']
     readonly_fields = ('uuid', 'id', 'criado_em', 'alterado_em')
 
 

--- a/sme_ptrf_apps/core/api/serializers/tipo_acerto_lancamento_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/tipo_acerto_lancamento_serializer.py
@@ -1,18 +1,29 @@
 from rest_framework import serializers
 
-from ...models import TipoAcertoLancamento
+from sme_ptrf_apps.receitas.fixtures.factories.tipo_receita_factory import Recurso
+
+from ...models import SolicitacaoAcertoLancamento, TipoAcertoLancamento
 from sme_ptrf_apps.utils.update_instance_from_dict import update_instance_from_dict
 
 
 class TipoAcertoLancamentoSerializer(serializers.ModelSerializer):
+
+    recurso = serializers.SlugRelatedField(
+        slug_field='uuid',
+        required=True,
+        queryset=Recurso.objects.all()
+    )
+
     def create(self, validated_data):
         nome = validated_data['nome']
+        categoria = validated_data.get('categoria', None)
+        recurso = validated_data.get('recurso', None)
 
-        nome_ja_cadastrado = TipoAcertoLancamento.objects.filter(nome=nome).all()
+        nome_ja_cadastrado = TipoAcertoLancamento.objects.filter(nome=nome, categoria=categoria, recurso=recurso).all()
 
         if nome_ja_cadastrado:
             raise serializers.ValidationError(
-                {"detail": "Já existe um tipo de acerto de lançamento com esse nome."}
+                {"detail": "Já existe um tipo de acerto de lançamento com esse nome e categoria para esse recurso."}
             )
 
         tipo_lancamento_criado = TipoAcertoLancamento.objects.create(**validated_data)
@@ -21,14 +32,23 @@ class TipoAcertoLancamentoSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         nome = validated_data.get("nome", None)
+        categoria = validated_data.get("categoria", instance.categoria)
 
         if nome and instance.nome != nome:
-            nome_ja_cadastrado = TipoAcertoLancamento.objects.filter(nome=nome).all()
+            recurso = validated_data.get("recurso", instance.recurso)
+            nome_ja_cadastrado = TipoAcertoLancamento.objects.filter(nome=nome, categoria=categoria, recurso=recurso).all()
 
             if nome_ja_cadastrado:
                 raise serializers.ValidationError(
-                    {"detail": "Já existe um tipo de acerto de lançamento com esse nome."}
+                    {"detail": "Já existe um tipo de acerto de lançamento com esse nome e categoria para esse recurso."}
                 )
+
+        if categoria != instance.categoria and SolicitacaoAcertoLancamento.objects.filter(
+            tipo_acerto=instance
+        ).exists():
+            raise serializers.ValidationError(
+                {"non_field_errors": "Não é permitido alterar. Pois existem solicitações de acertos vinculadas."}
+            )
 
         update_instance_from_dict(instance, validated_data, save=True)
 
@@ -36,4 +56,4 @@ class TipoAcertoLancamentoSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TipoAcertoLancamento
-        fields = ('id', 'nome', 'categoria', 'ativo', 'uuid', 'pode_alterar_saldo_conciliacao')
+        fields = ('id', 'nome', 'categoria', 'ativo', 'uuid', 'pode_alterar_saldo_conciliacao', 'recurso')

--- a/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
+++ b/sme_ptrf_apps/core/api/views/tipos_acerto_lancamento_viewset.py
@@ -2,9 +2,10 @@ from rest_framework import mixins, status, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 from ..serializers.tipo_acerto_lancamento_serializer import TipoAcertoLancamentoSerializer
-from ...models import TipoAcertoLancamento
+from ...models import TipoAcertoLancamento, Recurso
 from sme_ptrf_apps.users.permissoes import PermissaoApiDre
 from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
 from rest_framework.decorators import action
 from drf_spectacular.utils import (
     extend_schema,
@@ -78,6 +79,13 @@ class TiposAcertoLancamentoViewSet(mixins.ListModelMixin,
         if ativo is not None:
             qs = qs.filter(ativo=ativo)
 
+        recurso_uuid = self.request.query_params.get('recurso_uuid')
+        if recurso_uuid is not None:
+            recurso = Recurso.objects.filter(uuid=recurso_uuid).first()
+            if recurso is None:
+                raise ValidationError({'detail': 'Recurso não encontrado.'})
+            qs = TipoAcertoLancamento.filter_by_recurso(qs, recurso)
+
         return qs.order_by('id')
 
     def destroy(self, request, *args, **kwargs):
@@ -101,11 +109,19 @@ class TiposAcertoLancamentoViewSet(mixins.ListModelMixin,
     def tabelas(self, request):
         aplicavel_despesas_periodos_anteriores = request.query_params.get('aplicavel_despesas_periodos_anteriores')
         is_repasse = request.query_params.get('is_repasse')
+        recurso_uuid = request.query_params.get('recurso_uuid')
+        recurso = None
+
+        if recurso_uuid is not None:
+            recurso = Recurso.objects.filter(uuid=recurso_uuid).first()
+            if recurso is None:
+                raise ValidationError({'detail': 'Recurso não encontrado.'})
+
 
         result = {
             "categorias": TipoAcertoLancamento.categorias(),
             "agrupado_por_categorias": TipoAcertoLancamento.agrupado_por_categoria(
-                aplicavel_despesas_periodos_anteriores, is_repasse)
+                aplicavel_despesas_periodos_anteriores, is_repasse, recurso=recurso)
         }
 
         return Response(result, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/core/fixtures/factories/tipo_acerto_lancamento_factory.py
+++ b/sme_ptrf_apps/core/fixtures/factories/tipo_acerto_lancamento_factory.py
@@ -1,6 +1,7 @@
 from sme_ptrf_apps.core.models.tipo_acerto_lancamento import TipoAcertoLancamento
+from sme_ptrf_apps.core.models.recurso import Recurso
 from faker import Faker
-from factory import Sequence, LazyAttribute
+from factory import Sequence, LazyAttribute, LazyFunction
 from factory.django import DjangoModelFactory
 
 fake = Faker("pt_BR")
@@ -13,3 +14,4 @@ class TipoAcertoLancamentoFactory(DjangoModelFactory):
     nome = Sequence(lambda n: fake.unique.word())
     categoria = LazyAttribute(lambda x: fake.random_element(
         elements=[choice[0] for choice in TipoAcertoLancamento.CATEGORIA_CHOICES]))
+    recurso = LazyFunction(lambda: Recurso.objects.get(legado=True))

--- a/sme_ptrf_apps/core/migrations/0448_tipoacertolancamento_recurso.py
+++ b/sme_ptrf_apps/core/migrations/0448_tipoacertolancamento_recurso.py
@@ -1,0 +1,68 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+NOME_RECURSO_PREMIO = "Prêmio Excelência Educacional"
+
+
+def vincula_recurso_legado_e_copia_para_premio(apps, schema_editor):
+    Recurso = apps.get_model("core", "Recurso")
+    TipoAcertoLancamento = apps.get_model("core", "TipoAcertoLancamento")
+
+    recurso_legado = Recurso.objects.get(legado=True)
+    TipoAcertoLancamento.objects.filter(recurso__isnull=True).update(
+        recurso=recurso_legado
+    )
+
+    recurso_premio = Recurso.objects.filter(nome=NOME_RECURSO_PREMIO).first()
+    if not recurso_premio:
+        return
+
+    tipos_acerto_legado = TipoAcertoLancamento.objects.filter(
+        recurso=recurso_legado
+    )
+
+    for tipo_acerto in tipos_acerto_legado.iterator():
+        TipoAcertoLancamento.objects.update_or_create(
+            nome=tipo_acerto.nome,
+            categoria=tipo_acerto.categoria,
+            recurso=recurso_premio,
+            defaults={
+                "pode_alterar_saldo_conciliacao": (
+                    tipo_acerto.pode_alterar_saldo_conciliacao
+                ),
+                "ativo": tipo_acerto.ativo,
+            },
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0447_corrige_tipo_acerto_documento_solicitacoes_premio"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tipoacertolancamento",
+            name="recurso",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to="core.recurso",
+                verbose_name="Recurso",
+            ),
+        ),
+        migrations.RunPython(
+            vincula_recurso_legado_e_copia_para_premio,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="tipoacertolancamento",
+            name="recurso",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                to="core.recurso",
+                verbose_name="Recurso",
+            ),
+        ),
+    ]

--- a/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
+++ b/sme_ptrf_apps/core/models/tipo_acerto_lancamento.py
@@ -48,8 +48,15 @@ class TipoAcertoLancamento(ModeloIdNome):
 
     ativo = models.BooleanField('Ativo', default=True)
 
+    recurso = models.ForeignKey(
+        "core.Recurso",
+        verbose_name="Recurso",
+        on_delete=models.PROTECT,
+        null=False
+    )
+
     @classmethod
-    def agrupado_por_categoria(cls, aplicavel_despesas_periodos_anteriores=False, is_repasse=False):
+    def agrupado_por_categoria(cls, aplicavel_despesas_periodos_anteriores=False, is_repasse=False, recurso=None):
         from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
 
         categorias_a_ignorar = None
@@ -70,12 +77,16 @@ class TipoAcertoLancamento(ModeloIdNome):
                 TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
             ]
 
-        return TipoAcertoLancamentoService.agrupado_por_categoria(cls.CATEGORIA_CHOICES, categorias_a_ignorar)
+        return TipoAcertoLancamentoService.agrupado_por_categoria(cls.CATEGORIA_CHOICES, categorias_a_ignorar, recurso=recurso)
 
     @classmethod
     def categorias(cls):
         from sme_ptrf_apps.core.services import TipoAcertoLancamentoService
         return TipoAcertoLancamentoService.categorias(cls.CATEGORIA_CHOICES)
+
+    @classmethod
+    def filter_by_recurso(cls, queryset, recurso):
+        return queryset.filter(recurso=recurso)
 
     class Meta:
         verbose_name = "Tipo de acerto em lançamentos"

--- a/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
@@ -4,7 +4,8 @@ from ...utils.choices_to_json import choices_to_json
 
 class TipoAcertoLancamentoAgrupadoPorCategoria:
 
-    def __init__(self, choices, categorias_a_ignorar):
+    def __init__(self, choices, categorias_a_ignorar, recurso=None):
+        self.recurso = recurso
         self.choices = choices
         self.categorias_a_ignorar = categorias_a_ignorar if categorias_a_ignorar is not None else []
         self.__set_agrupamento()
@@ -21,6 +22,9 @@ class TipoAcertoLancamentoAgrupadoPorCategoria:
 
             tipos_acertos_lancamentos = TipoAcertoLancamento.objects.filter(
                 categoria=categoria_id).filter(ativo=True).values("id", "nome", "categoria", "ativo", "uuid")
+
+            if self.recurso is not None:
+                tipos_acertos_lancamentos = tipos_acertos_lancamentos.filter(recurso=self.recurso)
 
             if not tipos_acertos_lancamentos:
                 continue
@@ -92,9 +96,9 @@ class TipoAcertoLancamentoCategorias:
 
 class TipoAcertoLancamentoService:
     @classmethod
-    def agrupado_por_categoria(cls, choices, categorias_a_ignorar=None):
+    def agrupado_por_categoria(cls, choices, categorias_a_ignorar=None, recurso=None):
         return TipoAcertoLancamentoAgrupadoPorCategoria(
-            choices=choices, categorias_a_ignorar=categorias_a_ignorar).agrupamento
+            choices=choices, categorias_a_ignorar=categorias_a_ignorar, recurso=recurso).agrupamento
 
     @classmethod
     def categorias(cls, choices):

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/conftest.py
@@ -4,18 +4,18 @@ import datetime
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_create():
-    return baker.make('TipoAcertoLancamento', nome='Teste nome igual', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_create(recurso_legado):
+    return baker.make('TipoAcertoLancamento', nome='Teste nome igual', categoria='DEVOLUCAO', recurso=recurso_legado)
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_delete():
-    return baker.make('TipoAcertoLancamento', nome='Teste', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_delete(recurso_legado):
+    return baker.make('TipoAcertoLancamento', nome='Teste', categoria='DEVOLUCAO', recurso=recurso_legado)
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_delete_02():
-    return baker.make('TipoAcertoLancamento', nome='Teste 2', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_delete_02(recurso_legado):
+    return baker.make('TipoAcertoLancamento', nome='Teste 2', categoria='DEVOLUCAO', recurso=recurso_legado)
 
 
 @pytest.fixture
@@ -65,29 +65,51 @@ def prestacao_conta_delete(periodo_2020_1, associacao):
 
 
 @pytest.fixture
-def tipo_acerto_lancamento():
-    return baker.make('TipoAcertoLancamento', nome='Teste lanca', categoria='EXCLUSAO_LANCAMENTO')
+def tipo_acerto_lancamento(recurso_legado):
+    return baker.make(
+        'TipoAcertoLancamento',
+        nome='Teste lanca',
+        categoria='EXCLUSAO_LANCAMENTO',
+        recurso=recurso_legado
+    )
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_02():
-    return baker.make('TipoAcertoLancamento', nome='Teste filtro nome', categoria='EDICAO_LANCAMENTO', ativo=False)
+def tipo_acerto_lancamento_02(recurso_legado):
+    return baker.make(
+        'TipoAcertoLancamento',
+        nome='Teste filtro nome',
+        categoria='EDICAO_LANCAMENTO',
+        ativo=False,
+        recurso=recurso_legado
+    )
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_03():
-    return baker.make('TipoAcertoLancamento', nome='tipo lancamento', categoria='EXCLUSAO_LANCAMENTO', ativo=False)
+def tipo_acerto_lancamento_03(recurso_legado):
+    return baker.make(
+        'TipoAcertoLancamento',
+        nome='tipo lancamento',
+        categoria='EXCLUSAO_LANCAMENTO',
+        ativo=False,
+        recurso=recurso_legado
+    )
 
 @pytest.fixture
-def tipo_acerto_lancamento_retrieve():
-    return baker.make('TipoAcertoLancamento', nome='Teste retrieve', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_retrieve(recurso_legado):
+    return baker.make('TipoAcertoLancamento', nome='Teste retrieve', categoria='DEVOLUCAO', recurso=recurso_legado)
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_update():
-    return baker.make('TipoAcertoLancamento', nome='Teste update', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_update(recurso_legado):
+    return baker.make('TipoAcertoLancamento', nome='Teste update', categoria='DEVOLUCAO', recurso=recurso_legado)
 
 
 @pytest.fixture
-def tipo_acerto_lancamento_update_nome_igual():
-    return baker.make('TipoAcertoLancamento', nome='Teste nome igual update', categoria='DEVOLUCAO')
+def tipo_acerto_lancamento_update_nome_igual(recurso_legado):
+    return baker.make(
+        'TipoAcertoLancamento',
+        nome='Teste nome igual update',
+        categoria='DEVOLUCAO',
+        recurso=recurso_legado
+    )

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_create.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_create.py
@@ -6,11 +6,12 @@ from sme_ptrf_apps.core.models import TipoAcertoLancamento
 pytestmark = pytest.mark.django_db
 
 
-def test_create_tipo_acerto_lancamento(jwt_authenticated_client_a):
+def test_create_tipo_acerto_lancamento(jwt_authenticated_client_a, recurso_legado):
     payload_novo_tipo_acerto = {
         "nome": "tipo acerto teste",
         "categoria": TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO,
         "pode_alterar_saldo_conciliacao": False,
+        "recurso": str(recurso_legado.uuid),
     }
 
     response = jwt_authenticated_client_a.post(
@@ -23,12 +24,18 @@ def test_create_tipo_acerto_lancamento(jwt_authenticated_client_a):
     assert response.status_code == status.HTTP_201_CREATED
     assert TipoAcertoLancamento.objects.filter(uuid=result['uuid']).exists()
     assert result['pode_alterar_saldo_conciliacao'] == payload_novo_tipo_acerto['pode_alterar_saldo_conciliacao']
+    assert result['recurso'] == payload_novo_tipo_acerto['recurso']
 
 
-def test_create_tipo_acerto_lancamento_nome_igual(jwt_authenticated_client_a, tipo_acerto_lancamento_create):
+def test_create_tipo_acerto_lancamento_nome_igual(
+    jwt_authenticated_client_a,
+    tipo_acerto_lancamento_create,
+    recurso_legado
+):
     payload_novo_tipo_acerto = {
         "nome": "Teste nome igual",
-        "categoria": TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+        "categoria": TipoAcertoLancamento.CATEGORIA_DEVOLUCAO,
+        "recurso": str(recurso_legado.uuid),
     }
 
     response = jwt_authenticated_client_a.post(
@@ -38,7 +45,7 @@ def test_create_tipo_acerto_lancamento_nome_igual(jwt_authenticated_client_a, ti
 
     result = json.loads(response.content)
     resultado_esperado = {
-        'detail': 'Já existe um tipo de acerto de lançamento com esse nome.'
+        'detail': 'Já existe um tipo de acerto de lançamento com esse nome e categoria para esse recurso.'
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_list.py
@@ -17,7 +17,8 @@ def test_api_list_tipos_acerto_lancamento(jwt_authenticated_client_a, tipo_acert
             'id': tipo_acerto_lancamento.id,
             'nome': 'Teste lanca',
             'categoria': 'EXCLUSAO_LANCAMENTO',
-            'uuid': f'{tipo_acerto_lancamento.uuid}'
+            'uuid': f'{tipo_acerto_lancamento.uuid}',
+            'recurso': f'{tipo_acerto_lancamento.recurso.uuid}'
         }
     ]
 
@@ -43,7 +44,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_nome(
             'categoria': tipo_acerto_lancamento.categoria,
             'ativo': tipo_acerto_lancamento.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento.uuid}'
+            'uuid': f'{tipo_acerto_lancamento.uuid}',
+            'recurso': f'{tipo_acerto_lancamento.recurso.uuid}'
         },
         {
             'id': tipo_acerto_lancamento_02.id,
@@ -51,7 +53,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_nome(
             'categoria': tipo_acerto_lancamento_02.categoria,
             'ativo': tipo_acerto_lancamento_02.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_02.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_02.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_02.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_02.recurso.uuid}'
         },
     ]
 
@@ -77,7 +80,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_categoria(
             'categoria': tipo_acerto_lancamento.categoria,
             'ativo': tipo_acerto_lancamento.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento.uuid}'
+            'uuid': f'{tipo_acerto_lancamento.uuid}',
+            'recurso': f'{tipo_acerto_lancamento.recurso.uuid}'
         },
         {
             'id': tipo_acerto_lancamento_02.id,
@@ -85,7 +89,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_categoria(
             'categoria': tipo_acerto_lancamento_02.categoria,
             'ativo': tipo_acerto_lancamento_02.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_02.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_02.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_02.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_02.recurso.uuid}'
         },
         {
             'id': tipo_acerto_lancamento_03.id,
@@ -93,7 +98,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_categoria(
             'categoria': tipo_acerto_lancamento_03.categoria,
             'ativo': tipo_acerto_lancamento_03.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_03.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_03.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_03.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_03.recurso.uuid}'
         },
     ]
 
@@ -119,7 +125,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_ativo(
             'categoria': tipo_acerto_lancamento_02.categoria,
             'ativo': tipo_acerto_lancamento_02.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_02.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_02.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_02.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_02.recurso.uuid}'
         },
         {
             'id': tipo_acerto_lancamento_03.id,
@@ -127,7 +134,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_ativo(
             'categoria': tipo_acerto_lancamento_03.categoria,
             'ativo': tipo_acerto_lancamento_03.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_03.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_03.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_03.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_03.recurso.uuid}'
         },
     ]
 
@@ -153,7 +161,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_composto(
             'categoria': tipo_acerto_lancamento.categoria,
             'ativo': tipo_acerto_lancamento.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento.uuid}'
+            'uuid': f'{tipo_acerto_lancamento.uuid}',
+            'recurso': f'{tipo_acerto_lancamento.recurso.uuid}'
         },
         {
             'id': tipo_acerto_lancamento_03.id,
@@ -161,7 +170,8 @@ def test_api_list_tipos_acerto_lancamento_filtro_composto(
             'categoria': tipo_acerto_lancamento_03.categoria,
             'ativo': tipo_acerto_lancamento_03.ativo,
             'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_03.pode_alterar_saldo_conciliacao,
-            'uuid': f'{tipo_acerto_lancamento_03.uuid}'
+            'uuid': f'{tipo_acerto_lancamento_03.uuid}',
+            'recurso': f'{tipo_acerto_lancamento_03.recurso.uuid}'
         },
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_retrieve.py
@@ -18,7 +18,8 @@ def test_retrieve_tipo_acerto_lancamento(jwt_authenticated_client_a, tipo_acerto
         'categoria': "DEVOLUCAO",
         'ativo': True,
         'pode_alterar_saldo_conciliacao': tipo_acerto_lancamento_retrieve.pode_alterar_saldo_conciliacao,
-        'uuid': f'{tipo_acerto_lancamento_retrieve.uuid}'
+        'uuid': f'{tipo_acerto_lancamento_retrieve.uuid}',
+        'recurso': f'{tipo_acerto_lancamento_retrieve.recurso.uuid}'
     }
 
     assert response.status_code == status.HTTP_200_OK

--- a/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_update.py
+++ b/sme_ptrf_apps/core/tests/tests_api_tipos_acerto_lancamento/test_tipos_acerto_lancamento_update.py
@@ -31,7 +31,7 @@ def test_update_tipo_acerto_lancamento_nome_igual(
 ):
     payload_novo_tipo_acerto = {
         "nome": "Teste nome igual update",
-        "categoria": TipoAcertoLancamento.CATEGORIA_SOLICITACAO_ESCLARECIMENTO
+        "categoria": TipoAcertoLancamento.CATEGORIA_DEVOLUCAO
     }
 
     response = jwt_authenticated_client_a.patch(
@@ -41,10 +41,9 @@ def test_update_tipo_acerto_lancamento_nome_igual(
 
     result = json.loads(response.content)
     resultado_esperado = {
-        'detail': 'Já existe um tipo de acerto de lançamento com esse nome.'
+        'detail': 'Já existe um tipo de acerto de lançamento com esse nome e categoria para esse recurso.'
     }
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert len(TipoAcertoLancamento.objects.filter(nome="Teste nome igual update").all()) == 1
     assert resultado_esperado == result
-


### PR DESCRIPTION
Esse PR:

- Altera testes e fixtures de TipoAcertoLancamento para incluir Recurso 
- Adiciona Recurso ao modelo de TipoAcertoLancamento e altera Factory 
- Cria migração para popular TipoAcertoLancamento para Recurso Prêmio
- Atualiza admin de TipoAcertoLancamento para incluir campo Recurso
- Adiciona campo 'recurso' ao serializer e atualiza lógica de criação e update.

História: [AB#152090](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152090) e Tarefa: [AB#152167](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152167)
 

