### PR TITLE
Feature/151135 trata comissao responsavel analise pc

### DIFF
--- a/sme_ptrf_apps/core/services/notificacao_services/notificacao_solicitacao_encerramento_conta_bancaria_service.py
+++ b/sme_ptrf_apps/core/services/notificacao_services/notificacao_solicitacao_encerramento_conta_bancaria_service.py
@@ -25,7 +25,7 @@ def notificar_solicitacao_encerramento_conta_bancaria(conta_associacao, enviar_e
             logging.info(f"O usuario {usuario} não é membro de nenhuma comissão da DRE {associacao.unidade.dre}")
             continue
 
-        if not membro_comissao.pertence_a_comissao_exame_contas:
+        if not membro_comissao.pertence_a_comissao_exame_contas(recurso):
             logging.info(f"O usuario {usuario} não é membro da comissão de exame de contas")
             continue
 

--- a/sme_ptrf_apps/core/tests/tests_notificacoes_services/conftest.py
+++ b/sme_ptrf_apps/core/tests/tests_notificacoes_services/conftest.py
@@ -9,6 +9,8 @@ from model_bakery import baker
 from sme_ptrf_apps.users.models import Grupo
 from sme_ptrf_apps.core.models import STATUS_IMPLANTACAO, SolicitacaoEncerramentoContaAssociacao
 
+from sme_ptrf_apps.dre.fixtures.factories import ComissaoFactory
+
 
 @pytest.fixture
 def unidade_a(dre):
@@ -692,13 +694,13 @@ def parametro_comissao_exame_conta(comissao_a):
 
 
 @pytest.fixture
-def comissao_a():
-    return baker.make('Comissao', nome='A')
+def comissao_a(recurso_legado):
+    return ComissaoFactory(nome="A", responsavel_analise_pc=True, recursos=[recurso_legado])
 
 
 @pytest.fixture
 def comissao_b():
-    return baker.make('Comissao', nome='B')
+    return ComissaoFactory(nome="B")
 
 
 @pytest.fixture

--- a/sme_ptrf_apps/dre/admin.py
+++ b/sme_ptrf_apps/dre/admin.py
@@ -38,11 +38,6 @@ class ItensVerificacaoInline(admin.TabularInline):
     model = ItemVerificacaoRegularidade
 
 
-@admin.register(ParametrosDre)
-class ParametrosDreAdmin(admin.ModelAdmin):
-    exclude = ('tipo_conta_um', 'tipo_conta_dois',)
-
-
 @admin.register(Lauda)
 class LaudaAdmin(admin.ModelAdmin):
 

--- a/sme_ptrf_apps/dre/api/views/ata_parecer_tecnico_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/ata_parecer_tecnico_viewset.py
@@ -7,9 +7,9 @@ from sme_ptrf_apps.users.permissoes import (
     PermissaoAPIApenasDreComLeituraOuGravacao, PermissaoAPITodosComGravacao
 )
 
-from sme_ptrf_apps.dre.models import AtaParecerTecnico
+from sme_ptrf_apps.dre.models import AtaParecerTecnico, Comissao
 from sme_ptrf_apps.dre.models import ParametrosDre
-from sme_ptrf_apps.core.models import Unidade, Periodo
+from sme_ptrf_apps.core.models import Unidade, Periodo, Recurso
 import logging
 from sme_ptrf_apps.dre.api.serializers.ata_parecer_tecnico_serializer import (
     AtaParecerTecnicoSerializer,
@@ -147,6 +147,25 @@ class AtaParecerTecnicoViewset(viewsets.ModelViewSet):
     def membros_comissao_exame_contas(self, request):
         dre_uuid = self.request.query_params.get('dre')
         ata_uuid = request.query_params.get('ata')
+        recurso_uuid = self.request.query_params.get('recurso_uuid')
+
+        if not recurso_uuid:
+            erro = {
+                'erro': 'falta_de_informacoes',
+                'mensagem': 'Faltou informar o uuid do recurso.'
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            recurso = Recurso.objects.get(uuid=recurso_uuid)
+        except Recurso.DoesNotExist:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': f"O objeto recurso para o uuid {recurso_uuid} não foi encontrado na base."
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         if not dre_uuid:
             erro = {
@@ -183,8 +202,17 @@ class AtaParecerTecnicoViewset(viewsets.ModelViewSet):
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         ata = AtaParecerTecnico.objects.filter(uuid=ata_uuid).first()
-        comissoes = ParametrosDre.get().comissao_exame_contas
-        membros = comissoes.membros.filter(dre=dre).values("uuid", "rf", "nome", "cargo")
+
+        comissao = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
+
+        if not comissao:
+            erro = {
+                'erro': 'Objeto não encontrado.',
+                'mensagem': "Nenhuma comissão encontrada para o recurso fornecido."
+            }
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
+
+        membros = comissao.membros.filter(dre=dre).values("uuid", "rf", "nome", "cargo")
 
         lista = []
         for membro in membros:

--- a/sme_ptrf_apps/dre/api/views/comissoes_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/comissoes_viewset.py
@@ -25,6 +25,25 @@ class ComissoesViewSet(viewsets.ModelViewSet):
     queryset = Comissao.objects.all()
     serializer_class = ComissaoSerializer
 
+    @action(detail=False, url_path='comissao-responsavel-analise-pc-por-recurso', methods=['get'],
+            permission_classes=[IsAuthenticated])
+    def comissao_responsavel_analise_pc_por_recurso(self, request):
+        recurso_uuid = request.query_params.get('recurso_uuid', None)
+        if not recurso_uuid:
+            raise DRFValidationError({
+                "non_field_errors": "O parâmetro recurso_uuid é obrigatório."
+            })
+
+        comissao = self.get_queryset().filter(recursos__uuid=recurso_uuid, responsavel_analise_pc=True).distinct()
+
+        if not comissao.exists():
+            raise DRFValidationError({
+                "non_field_errors": "Nenhuma comissão encontrada para o recurso fornecido."
+            })
+
+        serializer = self.get_serializer(comissao.first(), many=False)
+        return Response(serializer.data)
+
 
 class ComissoesParametrizacaoViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]

--- a/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
+++ b/sme_ptrf_apps/dre/api/views/consolidados_dre_viewset.py
@@ -12,6 +12,7 @@ from django.db.utils import IntegrityError
 from drf_spectacular.utils import extend_schema_view
 
 from sme_ptrf_apps.core.models import Unidade, Periodo, Associacao
+from sme_ptrf_apps.dre.models import Comissao
 from ..serializers.ata_parecer_tecnico_serializer import AtaParecerTecnicoLookUpSerializer
 from ...models import ConsolidadoDRE, RelatorioConsolidadoDRE, AnoAnaliseRegularidade, AtaParecerTecnico, Lauda, \
     AnaliseConsolidadoDre
@@ -354,6 +355,17 @@ class ConsolidadosDreViewSet(
         recurso = periodo.recurso
         habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
         text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
+        comissao = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
+
+        if not comissao:
+            erro = {
+                'erro': 'Comissão não encontrada',
+                'mensagem': ("Não há comissão indicada como responsável pela análise de prestação de contas. "
+                             "Favor entrar em contato com a SME.")
+            }
+            logger.info('Erro: %r', erro)
+            return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         if not alterado_em:
             erro = {

--- a/sme_ptrf_apps/dre/models/comissao.py
+++ b/sme_ptrf_apps/dre/models/comissao.py
@@ -25,7 +25,6 @@ class Comissao(ModeloIdNome):
     def get_membros_comissao(comissao_instance):
         return comissao_instance.membros.all()
 
-
     @classmethod
     def verifica_dres_membros_comissao_tem_recursos(cls, comissao_instance, recursos):
         from sme_ptrf_apps.core.services.recursos_service import RecursoService
@@ -41,7 +40,6 @@ class Comissao(ModeloIdNome):
                 return False
 
         return True
-
 
     @classmethod
     def is_valid_data(cls, nome, recursos=None, responsavel_analise_pc=False, instance_id=None):
@@ -85,6 +83,14 @@ class Comissao(ModeloIdNome):
 
         return True, ""
 
+    @classmethod
+    def get_comissao_responsavel_analise_pc_por_recurso(cls, recurso):
+        comissoes = cls.objects.filter(recursos=recurso, responsavel_analise_pc=True)
+
+        if comissoes.exists():
+            return comissoes.first()
+
+        return None
 
     def _recursos_para_validacao(self):
         recursos = getattr(self, '_recursos_validacao', None)
@@ -109,7 +115,6 @@ class Comissao(ModeloIdNome):
 
         if not is_valid:
             raise ValidationError(error_message)
-
 
 
 auditlog.register(Comissao)

--- a/sme_ptrf_apps/dre/models/membro_comissao.py
+++ b/sme_ptrf_apps/dre/models/membro_comissao.py
@@ -45,10 +45,14 @@ class MembroComissao(ModeloBase):
         self.comissoes.set(comissoes)
         self.save()
 
-    @property
-    def pertence_a_comissao_exame_contas(self):
-        from sme_ptrf_apps.dre.models import ParametrosDre
-        comissao_exame_contas = ParametrosDre.get().comissao_exame_contas
+    def pertence_a_comissao_exame_contas(self, recurso):
+        from sme_ptrf_apps.dre.models import Comissao
+
+        comissao_exame_contas = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
+
+        if not comissao_exame_contas:
+            return False
+
         return True if comissao_exame_contas in self.comissoes.all() else False
 
     class Meta:

--- a/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
+++ b/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
@@ -144,6 +144,7 @@ def gerar_arquivo_ata_parecer_tecnico(
 
 def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre(dre, periodo, ata_de_parecer_tecnico=None, usuario=None, parcial=None):
     from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
+    from sme_ptrf_apps.dre.models import Comissao
 
     lista_contas_aprovadas = []  # PCs aprovadas precisam ser separadas por conta
     lista_contas_aprovadas_ressalva = []  # PCs aprovadas com ressalva precisam ser separadas por conta
@@ -154,6 +155,9 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
     recurso = periodo.recurso
     habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda if recurso else False
     text_document_consolidado_pc = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)
+
+    comissao = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
+    comissao_nome = comissao.nome if comissao else "-"
 
     titulo_sequencia_publicacao = None
     if parcial:
@@ -170,7 +174,6 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
             titulo_sequencia_publicacao = text_document_consolidado_pc.text_with_type_document(
                 publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE,
             )
-
 
     motivo_retificacao = None
     eh_retificacao = False
@@ -201,7 +204,8 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
         "periodo_data_inicio": formata_data(periodo.data_inicio_realizacao_despesas),
         "periodo_data_fim": formata_data(periodo.data_fim_realizacao_despesas),
         "comentarios": ata_de_parecer_tecnico.comentarios,
-        "motivo_retificacao": motivo_retificacao
+        "motivo_retificacao": motivo_retificacao,
+        "comissao_responsavel_pc": comissao_nome,
     }
     presentes_na_ata = {
         "presentes": get_presentes_na_ata(ata_de_parecer_tecnico)

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from sme_ptrf_apps.dre.models import JustificativaRelatorioConsolidadoDRE, AnoAnaliseRegularidade, ConsolidadoDRE
 from sme_ptrf_apps.core.models import Associacao, PrestacaoConta, TipoConta, Unidade
-from sme_ptrf_apps.dre.models import ParametrosDre
+from sme_ptrf_apps.dre.models import ParametrosDre, Comissao
 
 from django.db.models import Max, Value, Count
 from django.db.models.functions import Coalesce
@@ -28,7 +28,7 @@ def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, 
         execucao_fisica = cria_execucao_fisica(dre, periodo, apenas_nao_publicadas, consolidado_dre, eh_consolidado_de_publicacoes_parciais)
         dados_fisicos_financeiros = cria_dados_fisicos_financeiros(dre, periodo, apenas_nao_publicadas, eh_consolidado_de_publicacoes_parciais, consolidado_dre)
 
-        assinatura_dre = cria_assinaturas_dre(dre)
+        assinatura_dre = cria_assinaturas_dre(dre, periodo)
 
         """
             Mapeamento campos x pdf - Campos usados em cada um dos blocos do PDF:
@@ -891,16 +891,18 @@ def cria_dados_fisicos_financeiros(dre, periodo, apenas_nao_publicadas, eh_conso
     return informacoes
 
 
-def cria_assinaturas_dre(dre):
+def cria_assinaturas_dre(dre, periodo):
     """Bloco 5 - Autenticação: Parte de assinaturas"""
+
+    recurso = periodo.recurso
+    comissao = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
 
     membros = []
 
-    if ParametrosDre.objects.all():
-        comissoes = ParametrosDre.get().comissao_exame_contas
-        membros = comissoes.membros.filter(dre=dre).values("rf", "nome", "cargo")
+    if comissao:
+        membros = comissao.membros.filter(dre=dre).values("rf", "nome", "cargo")
     else:
-        LOGGER.info(f"Não foi encontrado nenhum Parametro DRE, verificar no admin")
+        LOGGER.info("Não foi encontrado nenhuma comissão responsável pela análise de prestação de contas.")
 
     dados = {
         "membros": membros,

--- a/sme_ptrf_apps/dre/services/dre_service/__tests__/conftest.py
+++ b/sme_ptrf_apps/dre/services/dre_service/__tests__/conftest.py
@@ -2,6 +2,8 @@ import pytest
 from model_bakery import baker
 from django.contrib.auth import get_user_model
 
+from sme_ptrf_apps.dre.fixtures.factories import ComissaoFactory
+
 User = get_user_model()
 
 
@@ -28,8 +30,8 @@ def outra_dre():
 
 
 @pytest.fixture
-def comissao_contas():
-    return baker.make('Comissao', nome='Exame de Contas')
+def comissao_contas(recurso_legado):
+    return ComissaoFactory(nome="Exame de Contas", responsavel_analise_pc=True, recursos=[recurso_legado])
 
 
 @pytest.fixture

--- a/sme_ptrf_apps/dre/services/dre_service/__tests__/test_get_comissao_contas.py
+++ b/sme_ptrf_apps/dre/services/dre_service/__tests__/test_get_comissao_contas.py
@@ -13,10 +13,11 @@ def test_get_comissao_contas(
     pedro_membro_outra_comissao_da_dre,
     maria_membro_comissao_exame_contas_de_outra_dre,
     parametros_dre_comissoes,
+    recurso_legado,
 ):
     dre_service = DreService(dre_valida)
 
-    comissao = dre_service.get_comissao_exame_contas()
+    comissao = dre_service.get_comissao_exame_contas(recurso_legado)
 
     assert comissao.count() == 2
     assert comissao.filter(nome=jose_membro_comissao_exame_contas_da_dre.nome).exists()

--- a/sme_ptrf_apps/dre/services/dre_service/dre_service.py
+++ b/sme_ptrf_apps/dre/services/dre_service/dre_service.py
@@ -1,7 +1,7 @@
 import logging
 
 from sme_ptrf_apps.core.models import Unidade
-from sme_ptrf_apps.dre.models import ParametrosDre, MembroComissao
+from sme_ptrf_apps.dre.models import ParametrosDre, MembroComissao, Comissao
 
 logger = logging.getLogger(__name__)
 
@@ -17,12 +17,17 @@ class DreService:
 
         self.dre = dre
 
-    def get_comissao_exame_contas(self):
-        comissao_exame_contas = ParametrosDre.get().comissao_exame_contas
-        membros_comissao = MembroComissao.objects.filter(
-            dre=self.dre,
-            comissoes=comissao_exame_contas
-        )
+    def get_comissao_exame_contas(self, recurso):
+        comissao_exame_contas = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
+
+        membros_comissao = []
+
+        if comissao_exame_contas:
+            membros_comissao = MembroComissao.objects.filter(
+                dre=self.dre,
+                comissoes=comissao_exame_contas
+            )
+
         return membros_comissao
 
     def notificar_devolucao_consolidado(self, consolidado_dre, enviar_email=True):
@@ -30,9 +35,10 @@ class DreService:
         from sme_ptrf_apps.core.models import Notificacao
 
         logger.info(
-            f'Notificando a devolução para acertos do consolidado da DRE  {consolidado_dre.dre.nome} ref {consolidado_dre.periodo.referencia}.')
+            f'Notificando a devolução para acertos do consolidado da DRE {consolidado_dre.dre.nome} ref {consolidado_dre.periodo.referencia}.')
 
-        comissao_contas = self.get_comissao_exame_contas()
+        recurso = consolidado_dre.periodo.recurso
+        comissao_contas = self.get_comissao_exame_contas(recurso)
 
         user_model = get_user_model()
         for membro in comissao_contas:

--- a/sme_ptrf_apps/dre/services/notificacao_service/class_notificacao_comentario_de_analise_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/services/notificacao_service/class_notificacao_comentario_de_analise_consolidado_dre.py
@@ -1,5 +1,5 @@
 from sme_ptrf_apps.core.models import Notificacao
-from sme_ptrf_apps.dre.models import ComentarioAnaliseConsolidadoDRE, ParametrosDre, MembroComissao
+from sme_ptrf_apps.dre.models import ComentarioAnaliseConsolidadoDRE, Comissao, MembroComissao
 from django.contrib.auth import get_user_model
 from .class_notificacao_service import NotificacaoService
 import logging
@@ -21,12 +21,14 @@ class NotificacaoComentarioDeAnaliseConsolidadoDre(NotificacaoService):
         remetente = Notificacao.REMETENTE_NOTIFICACAO_SME
         titulo = f"Comentário feito em seu relatório consolidado de {self.periodo.referencia}."
 
-        comissao_exame_contas = ParametrosDre.objects.first().comissao_exame_contas if ParametrosDre.objects.exists() else None
+        recurso = self.periodo.recurso
+        comissao_exame_contas = Comissao.get_comissao_responsavel_analise_pc_por_recurso(recurso)
 
         if comissao_exame_contas:
 
             # Criando uma lista de RF's para selecionar o objeto User com cada RF
-            lista_de_rf = [membro.rf for membro in MembroComissao.objects.filter(comissoes=comissao_exame_contas, dre=self.dre)]
+            lista_de_rf = [membro.rf for membro in MembroComissao.objects.filter(comissoes=comissao_exame_contas,
+                                                                                 dre=self.dre)]
 
             # Define destinatários
             usuarios = User.objects.filter(username__in=lista_de_rf)

--- a/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/conftest.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/conftest.py
@@ -7,6 +7,8 @@ from django.contrib.auth import get_user_model
 
 from ...models import ConsolidadoDRE
 
+from sme_ptrf_apps.dre.fixtures.factories import ComissaoFactory
+
 pytestmark = pytest.mark.django_db
 
 
@@ -413,3 +415,8 @@ def lauda_teste_api(
         usuario=usuario_dre_teste_api,
         status='GERADA_TOTAL',
     )
+
+
+@pytest.fixture
+def comissao_exame_contas_publicar_consolidado(recurso_legado):
+    return ComissaoFactory(nome="Exame de Contas do PTRF", responsavel_analise_pc=True, recursos=[recurso_legado])

--- a/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_publicar_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_consolidado_dre/test_action_publicar_consolidado_dre.py
@@ -28,7 +28,8 @@ def test_publicar_consolidado_dre_ata_preenchida_deve_passar(
     unidade_teste_api_consolidado_dre_01,
     associacao_teste_api_consolidado_dre_01,
     unidade_teste_api_consolidado_dre_02,
-    associacao_teste_api_consolidado_dre_02
+    associacao_teste_api_consolidado_dre_02,
+    comissao_exame_contas_publicar_consolidado
 ):
     response = jwt_authenticated_client_dre.post(
         '/api/consolidados-dre/publicar/',
@@ -54,7 +55,8 @@ def test_publicar_consolidado_dre_ata_nao_prenchida(
     unidade_teste_api_consolidado_dre_01,
     associacao_teste_api_consolidado_dre_01,
     unidade_teste_api_consolidado_dre_02,
-    associacao_teste_api_consolidado_dre_02
+    associacao_teste_api_consolidado_dre_02,
+    comissao_exame_contas_publicar_consolidado
 ):
     response = jwt_authenticated_client_dre.post(
         '/api/consolidados-dre/publicar/',
@@ -65,9 +67,9 @@ def test_publicar_consolidado_dre_ata_nao_prenchida(
     result = json.loads(response.content)
 
     resultado_esperado = {
-                'erro': 'Ata não preenchida',
-                'mensagem': f"Para fazer a publicação você precisa preencher as informações da ata."
-            }
+        'erro': 'Ata não preenchida',
+        'mensagem': "Para fazer a publicação você precisa preencher as informações da ata."
+    }
 
     assert result == resultado_esperado
 

--- a/sme_ptrf_apps/dre/tests/tests_services/tests_notificacoes_services/conftest.py
+++ b/sme_ptrf_apps/dre/tests/tests_services/tests_notificacoes_services/conftest.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 from freezegun import freeze_time
 import pytest
 from model_bakery import baker
+from sme_ptrf_apps.dre.fixtures.factories.comissao_factory import ComissaoFactory
 from sme_ptrf_apps.dre.models import ConsolidadoDRE, TecnicoDre
 from django.contrib.auth.models import Permission
 from sme_ptrf_apps.users.models import Grupo
@@ -152,8 +153,8 @@ def comentario_analise_consolidado_dre_03(consolidado_dre_teste_api_comentario_a
 
 
 @pytest.fixture
-def comissao_exame_contas_teste_service():
-    return baker.make('Comissao', nome='Exame de Contas')
+def comissao_exame_contas_teste_service(recurso_legado):
+    return ComissaoFactory(nome="Exame de Contas do PTRF", responsavel_analise_pc=True, recursos=[recurso_legado])
 
 
 @pytest.fixture

--- a/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/partials/dados-sobre-a-reuniao.html
+++ b/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/partials/dados-sobre-a-reuniao.html
@@ -6,11 +6,11 @@
   <p class="font-12 mb-1">
     {{ dados.dados_texto_da_ata.data_reuniao_por_extenso }},
     à(s) {{ dados.dados_texto_da_ata.hora_reuniao }},
-    reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de
+    reuniu-se a {{ dados.dados_texto_da_ata.comissao_responsavel_pc }} da Diretoria Regional de
     Educação {{ dados.cabecalho.nome_dre }}, instituída pela Portaria DRE - {{ dados.cabecalho.nome_dre }}
     nº {{ dados.cabecalho.numero_portaria }}/{{ dados.cabecalho.data_portaria|date:"Y" }}
     de {{ dados.cabecalho.data_portaria|date:"d/m/Y" }}, para
-    análise de prestações de contas RETIFICADAS dos recursos transferidos pelo {{ dados.cabecalho.titulo }}, 
+    análise de prestações de contas RETIFICADAS dos recursos transferidos pelo {{ dados.cabecalho.titulo }},
     período de {{ dados.dados_texto_da_ata.periodo_data_inicio }}
     até {{ dados.dados_texto_da_ata.periodo_data_fim }}, em virtude dos seguintes motivos:
   </p>
@@ -18,7 +18,7 @@
 {% else %}
   <p class="font-12">{{ dados.dados_texto_da_ata.data_reuniao_por_extenso }},
     à(s) {{ dados.dados_texto_da_ata.hora_reuniao }},
-    reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de
+    reuniu-se a {{ dados.dados_texto_da_ata.comissao_responsavel_pc }} da Diretoria Regional de
     Educação {{ dados.cabecalho.nome_dre }}, instituída pela Portaria DRE - {{ dados.cabecalho.nome_dre }}
     nº {{ dados.cabecalho.numero_portaria }}/{{ dados.cabecalho.data_portaria|date:"Y" }}
     de {{ dados.cabecalho.data_portaria|date:"d/m/Y" }}, para


### PR DESCRIPTION
Este PR inclui:

- Troca a utilização da comissao_exame_contas do modelo de ParametrosDRE para a utilização atualizada da comissão responsável pela pc baseada no novo campo do modelo de Comissao (responsavel_analise_pc);
- Atualiza o nome da comissão responsável pelo recurso na geração da ata;
- Cria um endpoint para buscar a comissão responsável;
- Adiciona nova regra para geração da ata no endpoint "publicar", onde só poderá realizar a geração caso tenha comissão responsável para o recurso selecionado;
- Realiza ajustes em testes unitários;

História: [AB#150333](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150333)
Tarefa: [AB#151135](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151135)