### PR TITLE
feat(152693): Condiciona exibição de PCs aprovadas com ressalvas na ata de parecer técnico conclusivo.

### DIFF
--- a/sme_ptrf_apps/core/models/recurso.py
+++ b/sme_ptrf_apps/core/models/recurso.py
@@ -150,9 +150,13 @@ class Recurso(ModeloIdNome, TemAtivo):
             return ""
 
         if letter == "D":
-            return process_texto_letra_d(self.texto_ata_letra_d)
+            return process_texto_letra_d(self.texto_ata_letra_d, self.habilita_aprovacao_com_ressalvas)
 
-        return fixed_text_texto_letra(letter, getattr(self, f'texto_ata_letra_{letter.lower()}', ''))
+        return fixed_text_texto_letra(
+            letter,
+            getattr(self, f'texto_ata_letra_{letter.lower()}', ''),
+            self.habilita_aprovacao_com_ressalvas
+        )
 
     def get_parameterized_text_introducao(self):
         return process_texto_introducao(self.texto_ata_introducao)

--- a/sme_ptrf_apps/core/services/lauda_pdf_service.py
+++ b/sme_ptrf_apps/core/services/lauda_pdf_service.py
@@ -54,10 +54,12 @@ def _montar_titulos_publicacao_lauda(lauda, parcial):
         else:
             titulo_sequencia_publicacao = f"Lauda referente à retificação {text_possessive_lower_document_consolidado_pc}"
     elif eh_parcial == "Parcial":
-        titulo_sequencia_publicacao = f"Lauda referente à {text_document_consolidado_pc.text_sequencial(
-            text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL,
-            sequencia_de_publicacao
-        )}"
+        public_type_param = text_document_consolidado_pc.PUBLICATION_TYPE_PARTIAL
+        text_sequencial = text_document_consolidado_pc.text_sequencial(
+            publication_type=public_type_param,
+            sequence_number=sequencia_de_publicacao
+        )
+        titulo_sequencia_publicacao = f"Lauda referente à {text_sequencial}"
     else:
         titulo_sequencia_publicacao = "Lauda final"
 

--- a/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
+++ b/sme_ptrf_apps/dre/services/ata_parecer_tecnico_service.py
@@ -207,6 +207,7 @@ def informacoes_execucao_financeira_unidades_ata_parecer_tecnico_consolidado_dre
         "motivo_retificacao": motivo_retificacao,
         "comissao_responsavel_pc": comissao_nome,
         "introducao": recurso.get_parameterized_text_introducao(),
+        "habilita_aprovacao_com_ressalvas": recurso.habilita_aprovacao_com_ressalvas,
         "letra_a": recurso.get_fixed_text_texto_letra("A"),
         "letra_b": recurso.get_fixed_text_texto_letra("B"),
         "letra_c": recurso.get_fixed_text_texto_letra("C"),

--- a/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata_parecer_tecnico/pdf.html
@@ -63,6 +63,7 @@
       {% include "./partials/talela-aprovadas.html" with dados=dados %}
   </article>
 
+  {% if dados.dados_texto_da_ata.habilita_aprovacao_com_ressalvas %}
   <article class="col-12 pl-0 titulo-tabelas mb-1 mt-4">
     {{ dados.dados_texto_da_ata.letra_b|safe }}
   </article>
@@ -71,6 +72,7 @@
     {# Incluindo tabela de Aprovadas com Ressalvas, passando dados como parametro #}
     {% include "./partials/tabela-aprovada-com-ressalvas.html" with dados=dados %}
   </article>
+  {% endif %}
 
   <article class="col-12 pl-0 titulo-tabelas mb-1 mt-4">
     {{ dados.dados_texto_da_ata.letra_c|safe }}

--- a/sme_ptrf_apps/utils/recurso_texto_ata.py
+++ b/sme_ptrf_apps/utils/recurso_texto_ata.py
@@ -20,26 +20,29 @@ def add_text_parameterized_text(parameterized_text):
     return "."
 
 
-def fixed_text_texto_letra(letter="A", parameterized_text=""):
+def fixed_text_texto_letra(letter="A", parameterized_text="", habilita_aprovacao_com_ressalva=False):
     text_letter = "a) <strong style='color: #297805;'>APROVAR</strong>"
 
     if letter == "B":
         text_letter = "b) <strong style='color: #297805;'>APROVAR COM RESSALVAS</strong>"
 
     if letter == "C":
-        text_letter = "c) <strong style='color: #b40c02;'>REJEITAR</strong>"
+        alt_letter = "c" if habilita_aprovacao_com_ressalva else "b"
+        text_letter = f"{alt_letter}) <strong style='color: #b40c02;'>REJEITAR</strong>"
 
     return mark_safe(
         f"<p style='display: inline;'>{text_letter} "
         f"{text_fixed_default_text_a_b_c()}{add_text_parameterized_text(parameterized_text)}</p>")
 
 
-def process_texto_letra_d(text):
+def process_texto_letra_d(text, habilita_aprovacao_com_ressalva=False):
     if not text:
         return ""
 
+    letter = "d" if habilita_aprovacao_com_ressalva else "c"
+
     return mark_safe(
-        f"<p style='display: inline;'>d) {text}</p>")
+        f"<p style='display: inline;'>{letter}) {text}</p>")
 
 
 def process_texto_introducao(text):


### PR DESCRIPTION
Este PR inclui:

- Condiciona exibição de PCs aprovadas de acordo com o campo habilita_aprovacao_com_ressalvas no modelo de Recurso;
- Em caso de campo desabilitado, oculta a exibição da seção de aprovadas com ressalvas e reordena as opções;
- Testes unitários validados.

- Correção de erro no momento de geração final do consolidado de PCs que impedia a geração dos documentos finais. (erro de f-string multilinha).

História: [AB#152693](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152693)
Tarefa: [AB#153123](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/153123)