### PR TITLE
feat(146314): Condiciona exibição de seção de devolução ao tesouro e reordena colunas no pdf do demonstrativo.

### DIFF
--- a/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
+++ b/sme_ptrf_apps/core/services/tipos_acerto_lancamento_service.py
@@ -103,3 +103,16 @@ class TipoAcertoLancamentoService:
     @classmethod
     def categorias(cls, choices):
         return TipoAcertoLancamentoCategorias(choices=choices).choices_json
+
+    @classmethod
+    def checa_se_existe_lancamento_devolucao_ao_tesouro(cls, periodo):
+        tipos_acertos_lancamentos = TipoAcertoLancamento.objects.filter(
+            ativo=True,
+            recurso=periodo.recurso,
+            categoria="DEVOLUCAO"
+        )
+
+        if not tipos_acertos_lancamentos.exists():
+            return False
+
+        return True

--- a/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
+++ b/sme_ptrf_apps/dre/services/dados_demo_execucao_fisico_financeira_service.py
@@ -11,8 +11,46 @@ from django.db.models import Max, Value, Count
 from django.db.models.functions import Coalesce
 
 from sme_ptrf_apps.dre.services.consolidado_dre_service import verifica_se_eh_relatorio_publicacoes_parciais, TextDocumentConsolidadoPC
+from sme_ptrf_apps.core.services.tipos_acerto_lancamento_service import TipoAcertoLancamentoService
 
 LOGGER = logging.getLogger(__name__)
+
+
+def retorna_indices_demo_execucao_fisico_financeira(existe_devolucao_ao_tesouro):
+    numero_base_bloco3 = 9 if existe_devolucao_ao_tesouro else 8
+    numero_base_bloco4 = 20 if existe_devolucao_ao_tesouro else 19
+
+    ordem_bloco3_execucao_fisica = {
+        "numeros_colunas": {
+            "ues_da_dre": numero_base_bloco3,
+            "ues_com_associacao": numero_base_bloco3 + 1,
+            "associacoes_regulares": numero_base_bloco3 + 2,
+            "aprovadas": numero_base_bloco3 + 3,
+            "aprovadas_com_ressalva": numero_base_bloco3 + 4,
+            "rejeitadas": numero_base_bloco3 + 5,
+            "em_analise": numero_base_bloco3 + 6,
+            "nao_apresentadas": numero_base_bloco3 + 7,
+            "ues_publicadas_anteriormente": numero_base_bloco3 + 8,
+            "total": numero_base_bloco3 + 9,
+            "ues_retificadas": numero_base_bloco3 + 10
+        }
+    }
+
+    ordem_bloco4_dados_fisico_financeiros = {
+        "numeros_colunas": {
+            "ordem": numero_base_bloco4,
+            "unidade": numero_base_bloco4 + 1,
+            "conta": numero_base_bloco4 + 2,
+            "reprogramado_do_periodo_anterior": numero_base_bloco4 + 3,
+            "transferido_pela_dre": numero_base_bloco4 + 4,
+            "outros_creditos": numero_base_bloco4 + 5,
+            "valor_total_disponivel": numero_base_bloco4 + 6,
+            "despesa_realizada": numero_base_bloco4 + 7,
+            "saldo_reprogramado_para_o_proximo_periodo": numero_base_bloco4 + 8,
+            "situacao_pc": numero_base_bloco4 + 9
+        }
+    }
+    return ordem_bloco3_execucao_fisica, ordem_bloco4_dados_fisico_financeiros
 
 
 def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, previa=False, apenas_nao_publicadas=False, eh_consolidado_de_publicacoes_parciais=False, consolidado_dre=None):
@@ -52,6 +90,16 @@ def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, 
                 assinatura_dre
         """
 
+        existe_devolucao_ao_tesouro = TipoAcertoLancamentoService. \
+            checa_se_existe_lancamento_devolucao_ao_tesouro(
+                periodo=periodo
+            )
+
+        (
+            ordem_bloco3_execucao_fisica,
+            ordem_bloco4_dados_fisico_financeiros
+        ) = retorna_indices_demo_execucao_fisico_financeira(existe_devolucao_ao_tesouro)
+
         dados_demonstrativo = {
             "text_document_consolidado_pc": text_document_consolidado_pc,
             "cabecalho": cabecalho,
@@ -63,7 +111,10 @@ def gerar_dados_demo_execucao_fisico_financeira(dre, periodo, usuario, parcial, 
             "dados_fisicos_financeiros": dados_fisicos_financeiros,
             "assinatura_dre": assinatura_dre,
             "versao_relatorio": "PARCIAL" if parcial else "FINAL",
-            "previa": previa
+            "previa": previa,
+            "existe_devolucao_ao_tesouro": existe_devolucao_ao_tesouro,
+            "ordem_bloco3_execucao_fisica": ordem_bloco3_execucao_fisica,
+            "ordem_bloco4_dados_fisico_financeiros": ordem_bloco4_dados_fisico_financeiros
         }
 
     finally:

--- a/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
+++ b/sme_ptrf_apps/dre/services/relatorio_consolidado_service.py
@@ -17,6 +17,7 @@ from .consolidado_dre_service import TextDocumentConsolidadoPC
 
 from ..services.dados_demo_execucao_fisico_financeira_service import gerar_dados_demo_execucao_fisico_financeira
 from .demo_execucao_fisico_financeiro_pdf_service import gerar_arquivo_demonstrativo_execucao_fisico_financeiro_pdf
+from ...core.services.tipos_acerto_lancamento_service import TipoAcertoLancamentoService
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +163,7 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
             else:
                 titulo_parcial = text_document_consolidado_pc.text_with_type_document(publication_type=text_document_consolidado_pc.PUBLICATION_TYPE_UNIQUE)
 
+    existe_lancamentos = TipoAcertoLancamentoService.checa_se_existe_lancamento_devolucao_ao_tesouro(periodo)
 
     dados = {
         "periodo_referencia": periodo.referencia if periodo.referencia else "",
@@ -169,6 +171,7 @@ def retorna_informacoes_execucao_financeira_todas_as_contas(dre, periodo, consol
         "periodo_data_fim_realizacao_despesas": periodo.data_fim_realizacao_despesas if periodo.data_fim_realizacao_despesas else "",
         "titulo_parcial": titulo_parcial,
         "eh_parcial": eh_parcial,
+        "existe_lancamentos_devolucao_ao_tesouro": existe_lancamentos
     }
 
     tipos_de_conta = TipoConta.objects.all()

--- a/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_relatorios_consolidados_dre/test_get_info_execucao_financeira_relatorio_consolidado_dre.py
@@ -385,6 +385,7 @@ def test_api_get_info_execucao_financeira_relatorio_consolidado_dre_parcial(
         'periodo_data_fim_realizacao_despesas': '2019-11-30',
         'periodo_data_inicio_realizacao_despesas': '2019-09-01',
         'periodo_referencia': '2019.2',
+        'existe_lancamentos_devolucao_ao_tesouro': False,
         'por_tipo_de_conta': [
             {
                 'consolidado_dre': None,
@@ -513,6 +514,7 @@ def test_api_get_info_execucao_financeira_relatorio_consolidado_dre_final(
         'periodo_data_fim_realizacao_despesas': '2019-11-30',
         'periodo_data_inicio_realizacao_despesas': '2019-09-01',
         'periodo_referencia': '2019.2',
+        'existe_lancamentos_devolucao_ao_tesouro': False,
         'por_tipo_de_conta': [
             {
                 'consolidado_dre': None,
@@ -641,6 +643,7 @@ def test_api_get_info_execucao_financeira_relatorio(
         'periodo_data_fim_realizacao_despesas': '2019-11-30',
         'periodo_data_inicio_realizacao_despesas': '2019-09-01',
         'periodo_referencia': '2019.2',
+        'existe_lancamentos_devolucao_ao_tesouro': False,
         'por_tipo_de_conta': [
             {
                 'consolidado_dre': None,

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisica.html
@@ -17,19 +17,18 @@
       </tr>
 
       <tr>
-        <th class="th-fundo-branco">09 - UEs da DRE</th>
-        <th class="th-fundo-branco">10 - UEs com Associação</th>
-        <th class="th-fundo-branco">11 - Associações regulares</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_da_dre }} - UEs da DRE</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_com_associacao }} - UEs com Associação</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.associacoes_regulares }} - Associações regulares</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.aprovadas }} - Aprovadas</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.aprovadas_com_ressalva }} - Aprovadas com ressalva</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.rejeitadas }} - Rejeitadas</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.em_analise }} - Em análise</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.nao_apresentadas }} - Não apresentadas</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_publicadas_anteriormente }} - UEs {{ dados.text_document_consolidado_pc.text_in_past_and_plural }} anteriormente</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.total }} - Total</th>
 
-        <th class="th-fundo-branco">12 - Aprovadas</th>
-        <th class="th-fundo-branco">13 - Aprovadas com ressalva</th>
-        <th class="th-fundo-branco">14 - Rejeitadas</th>
-        <th class="th-fundo-branco">15 - Em análise</th>
-        <th class="th-fundo-branco">16 - Não apresentadas</th>
-        <th class="th-fundo-branco">17 - UEs {{ dados.text_document_consolidado_pc.text_in_past_and_plural }} anteriormente</th>
-        <th class="th-fundo-branco">18 - Total</th>
-
-        <th class="th-fundo-branco">19 - UEs Retificadas</th>
+        <th class="th-fundo-branco">{{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_retificadas }} - UEs Retificadas</th>
       </tr>
 
   </thead>
@@ -62,12 +61,12 @@
             <span class="font-10 titulo pt-2 pb-2"><strong>Nota explicativa:</strong></span>
           </div>
           <div>
-            <span class="font-10 pt-2 pb-2">Coluna 18 - É a soma das colunas 12 a 17.</span>
+            <span class="font-10 pt-2 pb-2">Coluna {{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.total }} - É a soma das colunas {{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.aprovadas }} a {{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_publicadas_anteriormente }}.</span>
             <br/>
             {% if dados.execucao_fisica.eh_relatorio_consolidado_publicacoes_parciais %}
-              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_in }} parciais.</span>
+              <span class="font-10 pt-2">Coluna {{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_retificadas }} - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_in }} parciais.</span>
             {% else %}
-              <span class="font-10 pt-2">Coluna 19 - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_refer }}.</span>
+              <span class="font-10 pt-2">Coluna {{ dados.ordem_bloco3_execucao_fisica.numeros_colunas.ues_retificadas }} - Exibe a quantidade de UEs cuja a PC foi retificada {{ dados.text_document_consolidado_pc.text_refer }}.</span>
             {% endif %}
           </div>
         </div>

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisico-financeira.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-execucao-fisico-financeira.html
@@ -9,17 +9,21 @@
     </th>
   </tr>
   <tr>
-    <th style="width: 3%">20 - Ordem</th>
-    <th style="width: 15%">21 - Unidade</th>
-    <th style="width: 7%">22 - Conta</th>
-    <th colspan="2">23 - Reprogramado do período anterior</th>
-    <th colspan="2">24 - Transferido pela DRE</th>
-    <th colspan="2">25 - Outros créditos</th>
-    <th colspan="2">26 - Valor total disponível</th>
-    <th colspan="2">27 - Despesa realizada</th>
-    <th colspan="2">28 - Saldo reprogramado para<br/>o próximo período</th>
-    <th colspan="2">29 - Devolução ao Tesouro</th>
-    <th>30 - Situação da PC</th>
+    <th style="width: 3%">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.ordem }} - Ordem</th>
+    <th style="width: 15%">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.unidade }} - Unidade</th>
+    <th style="width: 7%">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.conta }} - Conta</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.reprogramado_do_periodo_anterior }} - Reprogramado do período anterior</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.transferido_pela_dre }} - Transferido pela DRE</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.outros_creditos }} - Outros créditos</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.valor_total_disponivel }} - Valor total disponível</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.despesa_realizada }} - Despesa realizada</th>
+    <th colspan="2">{{ dados.ordem_bloco4_dados_fisico_financeiros.numeros_colunas.saldo_reprogramado_para_o_proximo_periodo }} - Saldo reprogramado para<br/>o próximo período</th>
+    {% if dados.existe_devolucao_ao_tesouro %}
+      <th colspan="2">29 - Devolução ao Tesouro</th>
+      <th>30 - Situação da PC</th>
+    {% else %}
+      <th>28 - Situação da PC</th>
+    {% endif %}
   </tr>
   </thead>
 
@@ -73,9 +77,10 @@
         <td rowSpan="2" class="text-right">{{ conta.custeio.saldo_custeio }}</td>
 
         {% if forloop.counter == 1 %}
-          <td rowspan="{{ info.por_tipo_de_conta|length|retorna_quantidade_rowspan }}"><strong>T</strong></td>
-          <td class="text-right" rowspan="{{ info.por_tipo_de_conta|length|retorna_quantidade_rowspan }}"><strong>{{ conta.totais.devolucoes_ao_tesouro_no_periodo_total }}</strong></td>
-
+          {% if dados.existe_devolucao_ao_tesouro %}
+            <td rowspan="{{ info.por_tipo_de_conta|length|retorna_quantidade_rowspan }}"><strong>T</strong></td>
+            <td class="text-right" rowspan="{{ info.por_tipo_de_conta|length|retorna_quantidade_rowspan }}"><strong>{{ conta.totais.devolucoes_ao_tesouro_no_periodo_total }}</strong></td>
+          {% endif %}
 
           <td rowspan="{{ info.por_tipo_de_conta|length|retorna_quantidade_rowspan }}">{{ info.situacao_pc }}</td>
         {% endif %}

--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
@@ -42,7 +42,7 @@
         <th colSpan="2" style="width: 15%" class="th-fundo-branco">07 - Saldo reprogramado para o próximo período</th>
 
         {# Controlando o layout. Não devem ser exibidas as linhas de contas que tenham valores zerados em todas as colunas. #}
-        {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %}
+        {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 and dados.existe_devolucao_ao_tesouro %}
           <th rowspan="2" class="separacao-de-colunas-da-tabela"> </th>
 
           <th colSpan="3" class="th-fundo-branco">08 - Devolução ao Tesouro</th>
@@ -243,7 +243,9 @@
           <th colSpan="2" style="width: 15%" class="th-fundo-branco">07 - Saldo reprogramado para o próximo período</th>
           <th rowspan="2" class="separacao-de-colunas-da-tabela"> </th>
 
-          <th colSpan="3" class="th-fundo-branco">08 - Devolução ao Tesouro</th>
+          {% if dados.existe_devolucao_ao_tesouro %}
+            <th colSpan="3" class="th-fundo-branco">08 - Devolução ao Tesouro</th>
+          {% endif %}
         </tr>
       </thead>
 
@@ -278,8 +280,10 @@
           <td rowSpan="2" class="text-right">{{ valor.custeio.saldo_reprogramado_proximo_periodo_custeio }}</td>
           <td rowspan="7" class="separacao-de-colunas-da-tabela"> </td>
 
-          <td rowSpan="8" colspan="2" class="text-center" style="width: 2%"><strong>T</strong></td>
-          <td rowSpan="8" colspan="2" class="text-right"><strong>{{ valor.totais.devolucoes_ao_tesouro_no_periodo_total }}</strong></td>
+          {% if dados.existe_devolucao_ao_tesouro %}
+            <td rowSpan="8" colspan="2" class="text-center" style="width: 2%"><strong>T</strong></td>
+            <td rowSpan="8" colspan="2" class="text-right"><strong>{{ valor.totais.devolucoes_ao_tesouro_no_periodo_total }}</strong></td>
+          {% endif %}
         </tr>
         <tr></tr>
         <tr>


### PR DESCRIPTION
Este PR inclui:

- Função para verificar se existem tipos de acertos em lançamentos ATIVOS que possuem a categoria "Devolução ao tesouro" para um determinado período/recurso que retorna um boleano;
- O valor retornado por essa função é retornado na rota de informações da execução físico financeira, que é responsável por retornar os dados do demonstrativo;
- Em caso de existência de tipos acertos em lançamentos ATIVOS para o período especificado, as colunas do pdf do demonstrativo que mencionam "Devolução ao tesouro" são ocultadas e as demais colunas são reordenadas de modo a evitar inconsistências na numeração;
- Ajustes nos templates que geram o pdf do demonstrativo para reordenação dinâmica de colunas com base em novos campos passados por parâmetro para indicar a ordem a ser utilizada;
- Correção de testes unitários.

História: [AB#146314](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146314)
Tarefa: [AB#153134](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/153134)