### PR TITLE
feat(146314): Oculta bloco devolução ao tesouro na síntese da execução financeira do pdf do demonstrativo.

### DIFF
--- a/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
+++ b/sme_ptrf_apps/templates/pdf/demonstrativo_execucao_fisico_financeiro/partials/tabela-sintese-execucao-financeira.html
@@ -81,7 +81,7 @@
         <td rowSpan="2" class="text-right">{{ valor.custeio.saldo_reprogramado_proximo_periodo_custeio }}</td>
 
         {# Controlando o layout. Não devem ser exibidas as linhas de contas que tenham valores zerados em todas as colunas. #}
-        {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 %}
+        {% if dados.execucao_financeira.por_tipo_de_conta|length == 1 and dados.existe_devolucao_ao_tesouro %}
           <td rowspan="7" class="separacao-de-colunas-da-tabela"> </td>
 
           <td rowSpan="8" colspan="2" class="text-center" style="width: 2%"><strong>T</strong></td>


### PR DESCRIPTION
Este PR inclui:

- Oculta bloco de valores de devolução ao tesouro na síntese de execução financeira do pdf do demonstrativo físico financeiro.

<img width="1359" height="356" alt="image" src="https://github.com/user-attachments/assets/8d67720d-1b74-498b-bef0-736898c71b85" />


História: [AB#146314](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146314)
Tarefa: [AB#153134](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/153134)