### PR TITLE
Fix/153826 corrigir codigo para atualizar status rateio

### DIFF
--- a/sme_ptrf_apps/despesas/services/despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/despesa_service.py
@@ -113,10 +113,10 @@ class DespesaService:
     # =====================================================
     @classmethod
     @transaction.atomic
-    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None):        
+    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None):
 
         logger.info(f"Iniciando atualização de despesa: #{instance.id}")
-        
+
         # Desliga signal por questões de performance
         instance._skip_fornecedor_signal = True
 
@@ -146,7 +146,7 @@ class DespesaService:
             cls._atualizar_rateios(instance, rateios)
             cls._aplicar_motivos(instance, motivos, outros)
 
-            cls._processar_impostos_update(instance, despesas_impostos)            
+            cls._processar_impostos_update(instance, despesas_impostos)
 
             cls._finalizar_despesa(instance, rateios, limpar_prioridades_callback)
 
@@ -354,8 +354,14 @@ class DespesaService:
                             f"no rateio {rateio['uuid']}"
                         )
 
-                    RateioDespesa.objects.filter(uuid=rateio["uuid"]).update(**rateio)                    
+                    # Foi substituido o método update() para que seja executado o save() do model
+                    # Chamando o pre_save e o post_save do Rateio para recalcular o status do Rateio/Despesa
+                    for attr, value in rateio.items():
+                        setattr(rateio_para_atualizar, attr, value)
+
+                    rateio_para_atualizar.save()
                     keep.append(rateio_para_atualizar.uuid)
+
                 else:
                     logger.info(f"Rateio NÃO encontrado {rateio['uuid']} R${rateio['valor_rateio']}")
                     continue
@@ -378,7 +384,7 @@ class DespesaService:
             if despesa.nome_fornecedor != nome_fornecedor or despesa.cpf_cnpj_fornecedor != doc_fornecedor:
                 logger.info(f"Cria/Atualiza fornecedor: {doc_fornecedor}")
                 Fornecedor.atualiza_ou_cria(
-                    cpf_cnpj=despesa.cpf_cnpj_fornecedor, 
+                    cpf_cnpj=despesa.cpf_cnpj_fornecedor,
                     nome=despesa.nome_fornecedor
                 )
 
@@ -443,10 +449,10 @@ class DespesaService:
                 # Despesa de imposto herda o status de conciliação da despesa de origem
                 # caso esteja num contexto de PC devolvida para acertos
                 prestacao_conta = despesa.prestacao_conta
-               
+
                 if prestacao_conta and prestacao_conta.status == PrestacaoConta.STATUS_DEVOLVIDA:
-                  
-                    if despesa.conferido:                   
+
+                    if despesa.conferido:
                         periodo_conciliacao = (
                             despesa.rateios.all()
                             .order_by("periodo_conciliacao")
@@ -461,7 +467,7 @@ class DespesaService:
                             rateio["periodo_conciliacao_id"] = (
                                 periodo_conciliacao.periodo_conciliacao_id if periodo_conciliacao else None
                             )
-                        
+
                 else:
                     for rateio in rateios:
                         rateio["update_conferido"] = False

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
@@ -7,6 +7,7 @@ import pytest
 from rest_framework import serializers
 
 from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO, STATUS_INCOMPLETO
 from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CUSTEIO
 
 from sme_ptrf_apps.core.models import (
@@ -469,6 +470,57 @@ def test_update_custeio_para_capital_com_especificacao_capital_sucesso(
     assert rateio_atualizado.quantidade_itens_capital == 2
     assert rateio_atualizado.valor_item_capital == 50.00
     assert rateio_atualizado.numero_processo_incorporacao_capital == "2020/123456"
+
+
+def test_update_recalcula_status_de_rateio_incompleto_ao_preencher_campos_capital(
+    despesa_com_rateio_custeio,
+    associacao,
+    conta_associacao,
+    acao_associacao,
+    especificacao_capital,
+):
+    """
+    Regressão: rateio atualizado por QuerySet.update() mantinha status INCOMPLETO
+    mesmo após preencher todos os campos obrigatórios de CAPITAL.
+    """
+    despesa = despesa_com_rateio_custeio
+    rateio = despesa.rateios.first()
+
+    rateio.__class__.objects.filter(uuid=rateio.uuid).update(status=STATUS_INCOMPLETO)
+    despesa.atualiza_status()
+    rateio.refresh_from_db()
+    despesa.refresh_from_db()
+
+    assert rateio.status == STATUS_INCOMPLETO
+    assert despesa.status == STATUS_INCOMPLETO
+
+    validated_data = {
+        **_validated_data_base(despesa, associacao),
+        "rateios": [
+            {
+                "uuid": str(rateio.uuid),
+                "associacao": associacao,
+                "conta_associacao": conta_associacao,
+                "acao_associacao": acao_associacao,
+                "aplicacao_recurso": APLICACAO_CAPITAL,
+                "tipo_custeio": None,
+                "especificacao_material_servico": especificacao_capital,
+                "valor_rateio": 100.00,
+                "quantidade_itens_capital": 2,
+                "valor_item_capital": 50.00,
+                "numero_processo_incorporacao_capital": "2020/123456",
+            }
+        ],
+    }
+
+    result = DespesaService.update(despesa, validated_data)
+
+    rateio_atualizado = result.rateios.first()
+    rateio_atualizado.refresh_from_db()
+    despesa.refresh_from_db()
+
+    assert rateio_atualizado.status == STATUS_COMPLETO
+    assert despesa.status == STATUS_COMPLETO
 
 
 def test_update_custeio_para_capital_com_especificacao_de_custeio_deve_falhar(


### PR DESCRIPTION
Esse PR:

- Adiciona teste de atualização do status de rateio incompleto para completo 
- Corrige atualização do status de rateio incompleto para completo e de completo para completo no salvamento da Despesa

História: [AB#153167](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/153167) e Tarefa: [AB#153826](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/153826)