### PR TITLE
test(152193): ajusta teste unitário

### DIFF
--- a/sme_ptrf_apps/core/tests/conftest.py
+++ b/sme_ptrf_apps/core/tests/conftest.py
@@ -435,3 +435,39 @@ def associacao_teste_pendencia_envio_pc(unidade_pendencia_pc, usuario_notificave
     )
 
     return associacao
+
+
+@pytest.fixture
+def unidade_flagar_periodo_como_notificado(unidade_factory):
+    return unidade_factory.create(nome='Escola Flagar Período Como Notificado', codigo_eol='271170')
+
+
+@pytest.fixture
+def periodo_flagar_periodo_como_notificado(periodo_factory, recurso_explicito):
+    from datetime import date
+
+    return periodo_factory.create(
+        referencia='2026.1',
+        data_inicio_realizacao_despesas=date(2026, 1, 1),
+        data_fim_realizacao_despesas=date(2026, 6, 30),
+        data_prevista_repasse=date(2026, 1, 1),
+        data_inicio_prestacao_contas=date(2026, 7, 1),
+        data_fim_prestacao_contas=date(2026, 7, 15),
+    )
+
+
+@pytest.fixture
+def associacao_teste_flagar_periodo_como_notificado(unidade_flagar_periodo_como_notificado, usuario_notificavel,
+                                                    periodo_flagar_periodo_como_notificado, associacao_factory,
+                                                    periodo_inicial_associacao_factory):
+    usuario_notificavel.unidades.add(unidade_flagar_periodo_como_notificado)
+
+    associacao = associacao_factory.create(unidade=unidade_flagar_periodo_como_notificado,
+                                           periodo_inicial=periodo_flagar_periodo_como_notificado)
+
+    periodo_inicial_associacao_factory.create(
+        associacao=associacao,
+        periodo_inicial=periodo_flagar_periodo_como_notificado,
+    )
+
+    return associacao

--- a/sme_ptrf_apps/core/tests/tests_notificacoes_services/test_notificacoes_proximidade_periodo_pc_service.py
+++ b/sme_ptrf_apps/core/tests/tests_notificacoes_services/test_notificacoes_proximidade_periodo_pc_service.py
@@ -60,7 +60,7 @@ def test_deve_notificar_usuarios_no_dia(
 
 @freeze_time("2021-04-01")
 def test_deve_flagar_periodo_como_notificado(
-    associacao_a,
+    associacao_teste_flagar_periodo_como_notificado,
     usuario_notificavel,
     usuario_nao_notificavel,
     periodo_2020_4_pc_2021_01_01_a_2021_01_15,


### PR DESCRIPTION
Este PR inclui:

- Ajusta teste unitário 'test_deve_flagar_periodo_como_notificado' em test_notificacoes_proximidade_periodo_pc_service;

História: [AB#152092](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152092)
Tarefa: [AB#152193](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152193)