### PR TITLE
Feature/150755 altera exibicao texto lauda

### DIFF
--- a/sme_ptrf_apps/dre/api/serializers/consolidado_dre_serializer.py
+++ b/sme_ptrf_apps/dre/api/serializers/consolidado_dre_serializer.py
@@ -6,6 +6,7 @@ from .analise_consolidado_dre_serializer import AnaliseConsolidadoDreSerializer
 from ..serializers.relatorio_consolidado_dre_serializer import RelatorioConsolidadoDreSerializer
 from ..serializers.ata_parecer_tecnico_serializer import AtaParecerTecnicoLookUpSerializer
 from ...models import ConsolidadoDRE, AnaliseConsolidadoDre, AnaliseDocumentoConsolidadoDre
+from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
 
 
 class ConsolidadoDreSerializer(serializers.ModelSerializer):
@@ -86,6 +87,9 @@ class ConsolidadoDreDetalhamentoSerializer(serializers.ModelSerializer):
                 return False
 
     def get_botoes_avancar_e_retroceder(self, obj):
+        recurso = obj.periodo.recurso
+        text_action_female_single_in_past = TextDocumentConsolidadoPC(recurso.habilita_exibicao_de_lauda).text_action_female_single_in_past()
+
         obj_botoes = {
             "texto_botao_avancar": None,
             "habilita_botao_avancar": False,
@@ -111,7 +115,7 @@ class ConsolidadoDreDetalhamentoSerializer(serializers.ModelSerializer):
             obj_botoes = {
                 "texto_botao_avancar": 'Concluir',
                 "habilita_botao_avancar": pode_concluir,
-                "texto_botao_retroceder": "Voltar para Publicado no D.O.",
+                "texto_botao_retroceder": f"Voltar para {text_action_female_single_in_past}.",
                 "habilita_botao_retroceder": True,
             }
         elif obj.status_sme == obj.STATUS_SME_DEVOLVIDO:

--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -201,13 +201,15 @@ class TextDocumentConsolidadoPC:
         if self._is_enable_lauda:
             return "publicados" if is_positive else "não publicados"
 
-        return "enviados (externamente)" if is_positive else "gerado"
+        return "enviados (externamente)" if is_positive else "gerados e não enviados"
 
-    def text_action_female_single_in_past(self, is_positive=True):
+    def text_action_female_single_in_past(self, is_positive=True, is_plural=False):
+        letter_s = "s" if is_plural else ""
+
         if self._is_enable_lauda:
-            return "Publicada no D.O" if is_positive else "Não Publicada no D.O"
+            return f"Publicada{letter_s} no D.O" if is_positive else f"Não Publicada{letter_s} no D.O"
 
-        return "Enviada (externamente)" if is_positive else "Gerado"
+        return f"Enviado{letter_s} (externamente)" if is_positive else f"Gerado{letter_s} e não enviado{letter_s}"
 
 
 def criar_ata_e_atribuir_ao_consolidado_dre(dre=None, periodo=None, consolidado_dre=None, sequencia_de_publicacao=None,

--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -207,7 +207,7 @@ class TextDocumentConsolidadoPC:
         letter_s = "s" if is_plural else ""
 
         if self._is_enable_lauda:
-            return f"Publicada{letter_s} no D.O" if is_positive else f"Não Publicada{letter_s} no D.O"
+            return f"Publicado{letter_s} no D.O" if is_positive else f"Não Publicado{letter_s} no D.O"
 
         return f"Enviado{letter_s} (externamente)" if is_positive else f"Gerado{letter_s} e não enviado{letter_s}"
 

--- a/sme_ptrf_apps/dre/services/consolidado_dre_service.py
+++ b/sme_ptrf_apps/dre/services/consolidado_dre_service.py
@@ -7,13 +7,15 @@ from ..api.serializers.ata_parecer_tecnico_serializer import AtaParecerTecnicoLo
 from ..models import ConsolidadoDRE, AtaParecerTecnico, RelatorioConsolidadoDRE
 
 # Refatoração dre/tasks
-from ..tasks import gerar_previa_consolidado_dre_async, concluir_consolidado_dre_async, concluir_consolidado_de_publicacoes_parciais_async
+from ..tasks import gerar_previa_consolidado_dre_async, concluir_consolidado_dre_async, \
+    concluir_consolidado_de_publicacoes_parciais_async
 
 from ...core.models import Unidade, PrestacaoConta, Periodo, Associacao
 
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
 
 class TextDocumentConsolidadoPC:
     PUBLICACAO = "Publicação"
@@ -28,7 +30,6 @@ class TextDocumentConsolidadoPC:
     def __init__(self, is_enable_lauda):
         self._is_enable_lauda = is_enable_lauda
 
-
     def _get_quantity_test(_, quantity, quantity_name_singular=None, quantity_name_plural=None):
         if quantity == 1:
             name_obj = quantity_name_singular if quantity_name_singular else "PC"
@@ -42,13 +43,11 @@ class TextDocumentConsolidadoPC:
 
         return ""
 
-
     def get_tranform_publication_type(self, publication_type):
         if publication_type == self.PUBLICATION_TYPE_UNIQUE and not self._is_enable_lauda:
             return "Único"
 
         return publication_type
-
 
     def infinitive(self):
         if self._is_enable_lauda:
@@ -56,13 +55,11 @@ class TextDocumentConsolidadoPC:
 
         return "enviar externamente"
 
-
     def text_in_past_and_plural(self):
         if self._is_enable_lauda:
             return "publicadas"
 
         return "enviadas"
-
 
     def text_in_past_male_with_where(self):
         if self._is_enable_lauda:
@@ -70,13 +67,11 @@ class TextDocumentConsolidadoPC:
 
         return "enviado externamente"
 
-
     def text_in(self):
         if self._is_enable_lauda:
             return "nas publicações"
 
         return "nos relatórios"
-
 
     def text_with_refer(self):
         if self._is_enable_lauda:
@@ -84,20 +79,17 @@ class TextDocumentConsolidadoPC:
 
         return f"no referido {self.normal(case='lower')}"
 
-
     def text_complete_erro_mark_as_publicated_consolidado(self):
         if self._is_enable_lauda:
             return ", a data e a página de publicação"
 
         return " e a data do envio externo da documentação"
 
-
     def text_complete_erro_mark_as_no_publicated_consolidado(self):
         if self._is_enable_lauda:
             return "Não Publicado no Diário Oficial"
 
         return "Não Enviado Externamente no Diário Oficial"
-
 
     def normal(self, case=None):
         text_name = self.RELATORIO
@@ -113,7 +105,6 @@ class TextDocumentConsolidadoPC:
 
         return text_name
 
-
     def normal_plural(self, case=None):
         text_name = self.RELATORIOS
 
@@ -128,7 +119,6 @@ class TextDocumentConsolidadoPC:
 
         return text_name
 
-
     def possessive(self, case=None):
         possessive_type = "da" if self._is_enable_lauda else "do"
 
@@ -141,7 +131,6 @@ class TextDocumentConsolidadoPC:
             text_normal = text_normal.upper()
 
         return f'{possessive_type} {text_normal}'
-
 
     def possessive_plural(self, case=None):
         possessive_type = "das" if self._is_enable_lauda else "dos"
@@ -157,7 +146,6 @@ class TextDocumentConsolidadoPC:
 
         return text_concatenated
 
-
     def text_other(self, case=None):
         other_type = "outra" if self._is_enable_lauda else "outro"
 
@@ -169,41 +157,39 @@ class TextDocumentConsolidadoPC:
 
         return f'{other_type} {self.normal(case=case)}'
 
-
     def text_possessive_with_type_and_sequency(self, publication_type, sequency_number):
         text_document = self.possessive()
         text_sequency_number = f'#{sequency_number}' if sequency_number else ''
 
         return f'{text_document} {self.get_tranform_publication_type(publication_type)} {text_sequency_number}'
 
-
     def text_with_type_document(self, publication_type):
         text_document = self.normal()
 
         return f'{text_document} {self.get_tranform_publication_type(publication_type)}'
 
-
     def text_sequencial(self, publication_type, sequence_number):
         return f'{self.normal()} {self.get_tranform_publication_type(publication_type)} #{sequence_number}'
 
-
-    def text_sequencial_with_quantity(self, publication_type, sequency_number, quantity_unities, quantity_name_singular=None, quantity_name_plural=None):
-        return f'{self.text_sequencial(publication_type, sequency_number)} {self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)}'
-
+    def text_sequencial_with_quantity(self, publication_type, sequency_number, quantity_unities,
+                                      quantity_name_singular=None, quantity_name_plural=None):
+        quantity_test = self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)
+        return f'{self.text_sequencial(publication_type, sequency_number)} {quantity_test}'
 
     def text_with_quantity(self, publication_type, quantity, quantity_name_singular=None, quantity_name_plural=None):
-        return f'{self.text_with_type_document(publication_type)} {self._get_quantity_test(quantity, quantity_name_singular, quantity_name_plural)}'
+        quantity_test = self._get_quantity_test(quantity, quantity_name_singular, quantity_name_plural)
+        return f'{self.text_with_type_document(publication_type)} {quantity_test}'
 
-
-    def publication_name(self, publication_type, quantity_unities, publication_text, sequency_number, quantity_name_singular=None, quantity_name_plural=None):
+    def publication_name(self, publication_type, quantity_unities, publication_text, sequency_number,
+                         quantity_name_singular=None, quantity_name_plural=None):
         if publication_type == self.PUBLICATION_TYPE_PARTIAL:
             return self.text_sequencial_with_quantity(publication_type, sequency_number, quantity_unities)
 
         if publication_type == self.PUBLICATION_TYPE_RECTIFICATION:
-            return f'{publication_text} {self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)}'
+            quantity_test = self._get_quantity_test(quantity_unities, quantity_name_singular, quantity_name_plural)
+            return f'{publication_text} {quantity_test}'
 
         return self.text_with_quantity(publication_type, quantity_unities)
-
 
     def text_action(self):
         if self._is_enable_lauda:
@@ -211,10 +197,25 @@ class TextDocumentConsolidadoPC:
 
         return "Envio da Documentação"
 
-def criar_ata_e_atribuir_ao_consolidado_dre(dre=None, periodo=None, consolidado_dre=None, sequencia_de_publicacao=None, eh_retificacao=False):
+    def text_action_male_in_past(self, is_positive=True):
+        if self._is_enable_lauda:
+            return "publicados" if is_positive else "não publicados"
+
+        return "enviados (externamente)" if is_positive else "gerado"
+
+    def text_action_female_single_in_past(self, is_positive=True):
+        if self._is_enable_lauda:
+            return "Publicada no D.O" if is_positive else "Não Publicada no D.O"
+
+        return "Enviada (externamente)" if is_positive else "Gerado"
+
+
+def criar_ata_e_atribuir_ao_consolidado_dre(dre=None, periodo=None, consolidado_dre=None, sequencia_de_publicacao=None,
+                                            eh_retificacao=False):
     if eh_retificacao:
         ata = AtaParecerTecnico.criar_ou_retornar_ata_sem_consolidado_dre(dre=dre, periodo=periodo,
-                                                                          sequencia_de_publicacao=None, sequencia_de_retificacao=None)
+                                                                          sequencia_de_publicacao=None,
+                                                                          sequencia_de_retificacao=None)
     else:
         sequencia_de_publicacao_atual = sequencia_de_publicacao['sequencia_de_publicacao_atual']
         ata = AtaParecerTecnico.criar_ou_retornar_ata_sem_consolidado_dre(dre=dre, periodo=periodo,
@@ -1298,12 +1299,16 @@ class AcompanhamentoDeRelatoriosConsolidados:
         return self.__versao_relatorio
 
     @staticmethod
-    def retorna_titulo_por_status(chave):
+    def retorna_titulo_por_status(chave, habilita_exibicao_de_lauda=False):
+        text_action_male_in_past_positive = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)\
+            .text_action_male_in_past()
+        text_action_male_in_past_negative = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)\
+            .text_action_male_in_past(is_positive=False)
 
         titulos_por_status = {
             'DRES_SEM_RELATORIOS_GERADOS': "DREs sem relatório gerado",
-            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: "Relatórios não publicados",
-            ConsolidadoDRE.STATUS_SME_PUBLICADO: "Relatórios publicados",
+            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: f"Relatórios {text_action_male_in_past_negative}",
+            ConsolidadoDRE.STATUS_SME_PUBLICADO: f"Relatórios {text_action_male_in_past_positive}",
             ConsolidadoDRE.STATUS_SME_EM_ANALISE: "Relatórios em análise",
             ConsolidadoDRE.STATUS_SME_DEVOLVIDO: "Relatórios devolvidos para acertos",
             ConsolidadoDRE.STATUS_SME_ANALISADO: "Relatórios analisados",
@@ -1359,11 +1364,15 @@ class ListagemPorStatusComFiltros(AcompanhamentoDeRelatoriosConsolidados):
 
     @staticmethod
     def retorna_titulo_por_status(chave, habilita_exibicao_de_lauda=False):
+        text_action_female_single_in_past_positive = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)\
+            .text_action_female_single_in_past()
+        text_action_female_single_in_past_negative = TextDocumentConsolidadoPC(habilita_exibicao_de_lauda)\
+            .text_action_female_single_in_past(is_positive=False)
 
         titulos_por_status = {
             'DRES_SEM_RELATORIOS_GERADOS': "Não gerado",
-            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: "Não publicada no D.O." if habilita_exibicao_de_lauda else "Não publicada externamente",
-            ConsolidadoDRE.STATUS_SME_PUBLICADO: "Publicada no D.O." if habilita_exibicao_de_lauda else "Publicada externamente",
+            ConsolidadoDRE.STATUS_SME_NAO_PUBLICADO: text_action_female_single_in_past_negative,
+            ConsolidadoDRE.STATUS_SME_PUBLICADO: text_action_female_single_in_past_positive,
             ConsolidadoDRE.STATUS_SME_EM_ANALISE: "Em análise",
             ConsolidadoDRE.STATUS_SME_DEVOLVIDO: "Devolvida para acertos",
             ConsolidadoDRE.STATUS_SME_ANALISADO: "Relatórios analisados",
@@ -1436,7 +1445,8 @@ class ListagemPorStatusComFiltros(AcompanhamentoDeRelatoriosConsolidados):
                         "total_unidades_no_relatorio": total_unidades_no_relatorio,
                         "data_recebimento": self.formata_data(consolidado.data_de_inicio_da_analise) if consolidado.data_de_inicio_da_analise else None,
                         "status_sme": consolidado.status_sme,
-                        "status_sme_label": self.retorna_titulo_por_status(consolidado.status_sme, habilita_exibicao_de_lauda),
+                        "status_sme_label": self.retorna_titulo_por_status(consolidado.status_sme,
+                                                                           habilita_exibicao_de_lauda),
                         "pode_visualizar": True,
                         "uuid_consolidado_dre": f"{consolidado.uuid}",
                         "uuid_dre": f"{dre.uuid}",
@@ -1487,6 +1497,9 @@ class Dashboard(AcompanhamentoDeRelatoriosConsolidados):
 
         qtde_relatorios_com_status = 0
 
+        recurso = self.periodo.recurso
+        habilita_exibicao_de_lauda = recurso.habilita_exibicao_de_lauda
+
         for chave, valor in status_sme_choice.items():
             qtde_relatorios = ConsolidadoDRE.objects.filter(
                 periodo=self.periodo,
@@ -1497,7 +1510,7 @@ class Dashboard(AcompanhamentoDeRelatoriosConsolidados):
             qtde_relatorios_com_status += qtde_relatorios
 
             obj = {
-                "titulo": self.retorna_titulo_por_status(chave),
+                "titulo": self.retorna_titulo_por_status(chave, habilita_exibicao_de_lauda),
                 "quantidade_de_relatorios": qtde_relatorios,
                 "status": chave
             }

--- a/sme_ptrf_apps/dre/services/dados_relatorio_devolucao_acertos_sme_service.py
+++ b/sme_ptrf_apps/dre/services/dados_relatorio_devolucao_acertos_sme_service.py
@@ -26,12 +26,18 @@ class DadosRelatorioDevolucaoAcertosSme:
 
 
     def __info_cabecalho(self):
+        from sme_ptrf_apps.dre.services.consolidado_dre_service import TextDocumentConsolidadoPC
+
+        recurso = self.consolidado_dre.periodo.recurso
+        texto_normal = TextDocumentConsolidadoPC(recurso.habilita_exibicao_de_lauda).normal()
+
         info_cabecalho = {
-            "recurso": self.consolidado_dre.periodo.recurso.nome,
+            "recurso": recurso.nome,
             'periodo_referencia': self.consolidado_dre.periodo.referencia,
             'data_inicio_periodo': self.consolidado_dre.periodo.data_inicio_realizacao_despesas,
             'data_fim_periodo': self.consolidado_dre.periodo.data_fim_realizacao_despesas,
-            'tipo_relatorio': self.consolidado_dre.referencia
+            'tipo_relatorio': self.consolidado_dre.referencia,
+            'tipo_documento': texto_normal
         }
 
         return info_cabecalho

--- a/sme_ptrf_apps/dre/tests/tests_services/tests_acompanhamento_de_relatorios_consolidados_sme/test_listagem_de_relatorios_consolidados_sme_com_filtros.py
+++ b/sme_ptrf_apps/dre/tests/tests_services/tests_acompanhamento_de_relatorios_consolidados_sme/test_listagem_de_relatorios_consolidados_sme_com_filtros.py
@@ -323,7 +323,7 @@ def test_teste_listagem_com_filtros_sem_filtros_retificacao(
             'data_recebimento': None,
             'pode_visualizar': True,
             'status_sme': 'NAO_PUBLICADO',
-            'status_sme_label': 'Não publicada no D.O.',
+            'status_sme_label': 'Não Publicada no D.O',
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_retificacao_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
         },
@@ -333,7 +333,7 @@ def test_teste_listagem_com_filtros_sem_filtros_retificacao(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_retificado.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -423,7 +423,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_04.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -459,7 +459,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_03.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -470,7 +470,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O.",
+            "status_sme_label": "Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -481,7 +481,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -562,7 +562,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_03.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -573,7 +573,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O.",
+            "status_sme_label": "Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -584,7 +584,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -616,7 +616,7 @@ def test_teste_listagem_com_filtros__filtro_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O.",
+            "status_sme_label": "Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -647,7 +647,7 @@ def test_teste_listagem_com_filtros__sem_filtros(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não publicada no D.O.",
+            "status_sme_label": "Não Publicada no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"

--- a/sme_ptrf_apps/dre/tests/tests_services/tests_acompanhamento_de_relatorios_consolidados_sme/test_listagem_de_relatorios_consolidados_sme_com_filtros.py
+++ b/sme_ptrf_apps/dre/tests/tests_services/tests_acompanhamento_de_relatorios_consolidados_sme/test_listagem_de_relatorios_consolidados_sme_com_filtros.py
@@ -323,7 +323,7 @@ def test_teste_listagem_com_filtros_sem_filtros_retificacao(
             'data_recebimento': None,
             'pode_visualizar': True,
             'status_sme': 'NAO_PUBLICADO',
-            'status_sme_label': 'Não Publicada no D.O',
+            'status_sme_label': 'Não Publicado no D.O',
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_retificacao_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
         },
@@ -333,7 +333,7 @@ def test_teste_listagem_com_filtros_sem_filtros_retificacao(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_retificado.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -423,7 +423,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_04.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -459,7 +459,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_03.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -470,7 +470,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O",
+            "status_sme_label": "Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -481,7 +481,7 @@ def test_teste_listagem_com_filtros__filtro_nao_gerado_publicado_e_nao_publicado
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -562,7 +562,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_03.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -573,7 +573,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O",
+            "status_sme_label": "Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -584,7 +584,7 @@ def test_teste_listagem_com_filtros__filtro_publicado_e_nao_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -616,7 +616,7 @@ def test_teste_listagem_com_filtros__filtro_publicado(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "PUBLICADO",
-            "status_sme_label": "Publicada no D.O",
+            "status_sme_label": "Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_02.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"
@@ -647,7 +647,7 @@ def test_teste_listagem_com_filtros__sem_filtros(
             "total_unidades_no_relatorio": 1,
             "data_recebimento": None,
             "status_sme": "NAO_PUBLICADO",
-            "status_sme_label": "Não Publicada no D.O",
+            "status_sme_label": "Não Publicado no D.O",
             "pode_visualizar": True,
             "uuid_consolidado_dre": f"{consolidado_teste_listagem_com_filtros_01.uuid}",
             "uuid_dre": f"{dre_teste_listagem_com_filtros_01.uuid}"

--- a/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_status_prestacoes_conta/conftest.py
+++ b/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_status_prestacoes_conta/conftest.py
@@ -96,6 +96,10 @@ def ambiente():
 def queryset_ordered(prestacao_conta_aprovada_com_ressalva, prestacao_conta_reprovada):
     return PrestacaoConta.objects.all().order_by('criado_em')
 
+@pytest.fixture
+def queryset_ordered_status_pc(prestacao_conta_aprovada_com_ressalva, prestacao_conta_reprovada):
+    return PrestacaoConta.objects.all().order_by('criado_em')
+
 
 @pytest.fixture
 def queryset_ordered_dre_sem_pcs(prestacao_conta_aprovada_com_ressalva, prestacao_conta_reprovada, dre_ipiranga):

--- a/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_status_prestacoes_conta/test_exportacoes_status_prestacoes_conta.py
+++ b/sme_ptrf_apps/sme/tests/tests_services/tests_exportacoes_status_prestacoes_conta/test_exportacoes_status_prestacoes_conta.py
@@ -21,9 +21,9 @@ resultado_pcs_nao_apresentadas = [
     ['123456', 'Escola Teste', 'Outra', 'DRE teste', '2020.1', 'NAO_APRESENTADA']]
 
 
-def test_dados_esperados_csv(queryset_ordered):
+def test_dados_esperados_csv(queryset_ordered_status_pc):
     dados = ExportacoesStatusPrestacoesContaService(
-        queryset=queryset_ordered
+        queryset=queryset_ordered_status_pc
     ).monta_dados()
 
     assert dados == resultado_esperado

--- a/sme_ptrf_apps/static/css/pdf-relatorio-devolucao-acertos-sme.css
+++ b/sme_ptrf_apps/static/css/pdf-relatorio-devolucao-acertos-sme.css
@@ -19,17 +19,20 @@
   src: url(../fonts/Roboto-Italic.ttf);
 }
 
-@page {
+@page :first {
   size: A4;
-  margin: 3cm -2mm 2cm -2mm;
-  padding: 0;
+  padding: 1cm 0 1cm 0;
+  margin: 3cm 1cm 1cm 3cm;
+  @top-center {
+    content: element(cabecalho);
+  }
 
   @bottom-right {
     color: #000;
     content: counter(page) "/" counter(pages);
-    font-size: 9pt;
+    font-size: 8pt;
     padding: 0 1cm;
-    margin: 1cm 0;
+    margin: -2mm -9mm 0 0;
     font-weight: bold;
   }
 
@@ -40,30 +43,28 @@
   @bottom-left {
     color: #000;
     content: element(data-geracao);
-    font-size: 9pt;
-    padding: 0 1cm;
-    margin: 0;
     font-style: normal;
     font-family: Roboto;
+    font-size: 9pt;
+    margin: 0 0 0 -2cm;
   }
+}
+
+@page {
+  size: A4;
+  padding: 1cm 0 1cm 0;
+  margin: 2cm 1cm 1cm 3cm;
 
   @top-center {
     content: element(heading);
   }
-}
-
-@page :first {
-  size: A4;
-  margin: -2mm;
-  margin-bottom: 2cm;
-  padding: 0;
 
   @bottom-right {
     color: #000;
     content: counter(page) "/" counter(pages);
-    font-size: 9pt;
+    font-size: 8pt;
     padding: 0 1cm;
-    margin: 1cm 0;
+    margin: -2mm -9mm 0 0;
     font-weight: bold;
   }
 
@@ -74,15 +75,10 @@
   @bottom-left {
     color: #000;
     content: element(data-geracao);
-    font-size: 9pt;
-    padding: 0 1cm;
-    margin: 0;
     font-style: normal;
     font-family: Roboto;
-  }
-
-  @top-center {
-    content: none;
+    font-size: 9pt;
+    margin: 0 0 0 -2cm;
   }
 }
 
@@ -105,12 +101,20 @@ body {
   font-style: normal;
 }
 
-html body section#cabecalho,
-header {
+#cabecalho {
+  position: running(cabecalho);
   background: #eeeeee;
-  margin: 0 0 0 -2cm;
-  padding: 0 2.5cm 0cm 2.5cm;
-  width: 100%;
+  width: 215mm;
+  padding: 1cm 1cm 0.5cm 0.5cm;
+  margin: 0;
+}
+
+header {
+  position: running(heading);
+  background: #eeeeee;
+  width: 215mm;
+  padding: 1cm 1cm 0.5cm 0.5cm;
+  margin: 0;
 }
 
 html body section#cabecalho .titulo,
@@ -125,13 +129,6 @@ html body section#cabecalho .subtitulo,
 html body header .subtitulo {
   font-family: Roboto, serif;
   font-style: normal;
-}
-
-header {
-  position: running(heading);
-  width: 215mm;
-  margin: 1cm 0.5cm 5.5cm 1cm;
-  padding: 5cm 0 0 0;
 }
 
 .font-18 {
@@ -184,24 +181,11 @@ header {
 }
 
 .conteudo {
-  margin: 0 1cm;
   width: 74%;
+  margin-left: -2.2cm; /* ajusta um pouco para compensar o aumento da largura */
+  margin-right: 0;
   font-family: Roboto, serif;
   font-style: normal;
-}
-
-#data-geracao-rodape {
-  position: running(data-geracao);
-  font-style: normal;
-  font-family: Roboto;
-}
-
-.titulo-bloco-sme {
-  color: #000000 !important;
-}
-
-.itens-bloco-sme {
-  color: #000000 !important;
 }
 
 html body .conteudo .tabela-resumo-por-acao {
@@ -211,10 +195,6 @@ html body .conteudo .tabela-resumo-por-acao {
 
 html body .conteudo .tabela-quebra-palavra {
   table-layout: fixed;
-}
-
-.nao-quebra-linha {
-  break-inside: avoid !important;
 }
 
 html body .conteudo .tabela-resumo-por-acao thead th,
@@ -236,16 +216,6 @@ html body .conteudo .tabela-resumo-por-acao thead th.fundo-th-cinza {
   color: #000000 !important;
 }
 
-html
-  body
-  .conteudo
-  .tabela-resumo-por-acao
-  thead
-  td.fundo-td-cinza-mais-escuro {
-  background-color: #eeeeee !important;
-  color: #000000 !important;
-}
-
 html body .conteudo .tabela-resumo-por-acao thead th.align-top {
   vertical-align: top;
 }
@@ -258,12 +228,8 @@ html body .conteudo .tabela-resumo-por-acao tbody td.sem-borda {
   border: none !important;
 }
 
-html body .conteudo .tabela-resumo-por-acao tbody td.fundo-cinza-sme {
+html body .conteudo .tabela-resumo-por-acao tbody td.fundo-cinza {
   background-color: #eeeeee !important;
-}
-
-html body .conteudo .tabela-resumo-por-acao tbody td.fundo-cinza-mais-claro {
-  background-color: #f5f6f8 !important;
 }
 
 html body .conteudo .tabela-resumo-por-acao tbody td {
@@ -272,6 +238,42 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
   word-break: normal !important;
   overflow-wrap: break-word !important;
   white-space: normal !important;
+}
+
+.titulo-conta {
+  font-weight: bold;
+  color: #2b7d83;
+}
+
+.item {
+  color: #2b7d83;
+}
+
+#data-geracao-rodape {
+  position: running(data-geracao);
+  font-style: normal;
+}
+
+.text-saldo-reprogramado {
+  color: #2b7d83 !important;
+}
+
+.titulo-bloco {
+  color: #2b7d83 !important;
+}
+
+/* checkbox */
+.checkbox-pdf {
+  margin-left: 40%;
+  text-align: center;
+  display: flex;
+  flex: 1;
+  max-width: 14px;
+  justify-content: center;
+  margin-bottom: 10px;
+  color: #ffffff;
+  background-color: #d8d8d8;
+  font-weight: 700;
 }
 
 .container-watermark {
@@ -294,4 +296,9 @@ html body .conteudo .tabela-resumo-por-acao tbody td {
   transform: translate(-50%, -50%);
   opacity: 0.5;
   z-index: 99;
+}
+
+.nao-quebra-linha {
+  break-after: avoid !important;
+  break-inside: avoid !important;
 }

--- a/sme_ptrf_apps/templates/pdf/relatorio_devolucao_acertos_sme/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/relatorio_devolucao_acertos_sme/pdf.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
   <link href="{{ base_static_url }}/css/pdf-relatorio-devolucao-acertos-sme.css" rel="stylesheet">
-  <title>Relatório de acertos</title>
+  <title>Relatório de acertos - {{ dados.info_cabecalho.recurso }}</title>
 </head>
 <body>
   {% if dados.previa == True %}
@@ -20,27 +20,25 @@
   {% endif %}
   {# ************************* Cabecalho das páginas *************************  #}
 
-
   <header>
-    <div class="d-flex p-2 mb-0 bd-highlight mt-1">
-
-      <div class="col-8 mt-1">
+    <div class="d-flex bd-highlight">
+      <div class="col-8">
         <p class="subtitulo font-12 mb-0">Análise SME</p>
-        <p class="font-12 mb-0">Relatório de devolução para acertos da DRE</p>
+        <p class="font-12">Relatório de devolução para acertos da DRE</p>
       </div>
+      <div class="col-4 d-flex align-items-center justify-content-end">
+          <div class="borda-box-cabecalho-right px-3">
+            <p class="font-10 mb-0">Período de Realização:</p>
+            <p class="subtitulo font-10 mb-0 pb-0">
+              {{ dados.info_cabecalho.periodo_referencia }} -
+              {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até
+              {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}
+            </p>
+          </div>
 
-      <div class="col-4 mt-1 justify-content-end">
-
-        <div class="pl-2 borda-box-cabecalho-right">
-          <p class="font-10 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-10 mb-0 pb-0">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
-        </div>
-
-        <span class="font-10 pb-0 mb-0"><strong class="pr-1">Publicação:</strong>{{ dados.info_cabecalho.tipo_relatorio }}</span>
+          <p class="font-10 pb-0 mb-0"><strong class="pr-1">{{ dados.info_cabecalho.tipo_documento }}:</strong>{{ dados.info_cabecalho.tipo_relatorio }}</p>
       </div>
-
     </div>
-
   </header>
 
   {# ************************* Fim Cabecalho das páginas *************************  #}
@@ -53,38 +51,36 @@
   {# ************************* Fim Rodape ************************* #}
 
   <section id="cabecalho" class="mt-2">
-    <div class="d-flex pt-2 pl-2 pr-2 pb-0 bd-highlight">
-      <div class="col-4">
+    <div class="d-flex p-2 bd-highlight">
+      <div class="col-4 d-flex align-items-center border-rigth-logo">
         <img src="{{ base_static_url }}/images/logo_PrefSP_sem_fundo_horizontal_colorida.svg" alt="logo">
       </div>
-      <div class="col-8 pr-3 mr-0 mt-2 d-flex align-items-center justify-content-end">
-        <p class="titulo font-14">Programa de Transferências de Recursos Financeiros - PTRF</p>
+      <div class="col-8 d-flex align-items-center justify-content-end">
+        <p class="titulo font-16">{{ dados.info_cabecalho.recurso }}</p>
       </div>
     </div>
-
     <hr class="divisao"/>
-
-    <div class="d-flex p-2 mb-0 bd-highlight mt-1">
-
-      <div class="col-8 mt-1">
+    <div class="d-flex bd-highlight">
+      <div class="col-8">
         <p class="subtitulo font-12 mb-0">Análise SME</p>
-        <p class="font-12 mb-0">Relatório de devolução para acertos da DRE</p>
+        <p class="font-12">Relatório de devolução para acertos da DRE</p>
       </div>
+      <div class="col-4">
+          <div class="borda-box-cabecalho-right px-3">
+            <p class="font-10 mb-0">Período de Realização:</p>
+            <p class="subtitulo font-10 mb-0 pb-0">
+              {{ dados.info_cabecalho.periodo_referencia }} -
+              {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até
+              {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}
+            </p>
+          </div>
 
-      <div class="col-4 mt-1 justify-content-end">
-        <div class="pl-2 borda-box-cabecalho-right">
-          <p class="font-10 mb-0">Período de Realização:</p>
-          <p class="subtitulo font-10 mb-0 pb-0">{{ dados.info_cabecalho.periodo_referencia }} -  {{ dados.info_cabecalho.data_inicio_periodo|date:'d/m/Y' }} até {{ dados.info_cabecalho.data_fim_periodo|date:'d/m/Y' }}</p>
-        </div>
-
-        <span class="font-10 pb-0 mb-0"><strong class="pr-1">Publicação:</strong>{{ dados.info_cabecalho.tipo_relatorio }}</span>
-
+          <p class="font-10 pb-0 mb-0"><strong class="pr-1">{{ dados.info_cabecalho.tipo_documento }}:</strong>{{ dados.info_cabecalho.tipo_relatorio }}</p>
       </div>
-
     </div>
   </section>
 
-  <section class="conteudo mt-4">
+  <section class="conteudo">
     {% comment %} Bloco identificação DRE {% endcomment %}
     {% include "./partials/bloco-identificacao-dre.html" with dados=dados %}
 


### PR DESCRIPTION
Este PR inclui:

- Troca de texto "Publicação" para "Relatório" ou "Envio (Externamente)" em fluxo de consolidado na visão SME;
- Correção da exibição do cabeçalho do pdf de "Relatório de Devolução de Acertos" exportado na visão SME;
- Exibe o nome do recurso e o tipo de documento no pdf "Relatório de Devolução de Acertos" de acordo com recurso selecionado;
- Ajusta testes unitários;

História: [AB#150755](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150755)
Tarefa: [AB#150873](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150873)