### PR TITLE
fix(154332): Remove Requisição de rota de usuário logado devido a inconsistencias de dados quando usuário é autenticado, conflitando com as unidade vinculadas do usuário.

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.44.0"
+__version__ = "9.44.1"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/paa/paa_querysets/paa_queryset.py
+++ b/sme_ptrf_apps/paa/paa_querysets/paa_queryset.py
@@ -34,6 +34,10 @@ class PaaQuerySet(models.QuerySet):
         Returns:
             PaaQuerySet com os campos de status de geração anotados.
         """
+        if 'status_andamento' in self.query.annotations:
+            # Queryset já anotado evita reanotação desnecessária
+            return self
+
         from sme_ptrf_apps.paa.models.documento_paa import DocumentoPaa
         from sme_ptrf_apps.paa.models.ata_paa import AtaPaa
 

--- a/sme_ptrf_apps/paa/services/prioridades_impactadas_receitas_previstas_service.py
+++ b/sme_ptrf_apps/paa/services/prioridades_impactadas_receitas_previstas_service.py
@@ -52,6 +52,10 @@ class PrioridadesPaaImpactadasBaseService(ABC):
         self.receita_prevista = receita_prevista
         self.acao_receita = self.get_acao_receita()
         self.recurso = self.get_recurso()
+        # Cache de ResumoPrioridadesService por paa_id: evita recriar o service (e recalcular o resumo
+        # completo do PAA, custoso) a cada prioridade verificada em `_verifica_saldo`, já que todas as
+        # prioridades avaliadas num mesmo loop pertencem ao mesmo PAA.
+        self._resumo_service_cache = {}
 
     @abstractmethod
     def get_acao_receita(self):
@@ -331,7 +335,13 @@ class PrioridadesPaaImpactadasBaseService(ABC):
 
     def _verifica_saldo(self, prioridade, valor_total):
         # Validar no service de Resumo de Prioridades
-        resumo = ResumoPrioridadesService(prioridade.paa)
+        # Reaproveita a instância (e o resumo memoizado nela) entre prioridades do mesmo PAA,
+        # em vez de recriar o service (e recalcular todo o resumo) a cada iteração do loop.
+        resumo = self._resumo_service_cache.get(prioridade.paa_id)
+        if resumo is None:
+            resumo = ResumoPrioridadesService(prioridade.paa)
+            self._resumo_service_cache[prioridade.paa_id] = resumo
+
         # # considera apenas a diferença entre o valor atual da receita e o novo valor
         # valor_total = valor_custeio_atual - valor_custeio_edicao
         SIMULA_PRIORIDADE_SEM_VALOR = 0

--- a/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
+++ b/sme_ptrf_apps/paa/services/resumo_prioridades_service.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from rest_framework import serializers
 from sme_ptrf_apps.paa.enums import RecursoOpcoesEnum, TipoAplicacaoOpcoesEnum
 from sme_ptrf_apps.paa.api.serializers.receita_prevista_paa_serializer import ReceitaPrevistaPaaSerializer
@@ -20,6 +20,7 @@ class ValidacaoSaldoIndisponivel(serializers.ValidationError):
 class ResumoPrioridadesService:
     def __init__(self, paa):
         self.paa = paa
+        self._resumo_prioridades_cache = None
 
     def calcula_saldos(self, key, receitas, despesas) -> dict:
         """
@@ -127,14 +128,14 @@ class ResumoPrioridadesService:
 
                 return (saldo_congelado or saldo_atual) + previsao_valor
 
-            def get_valor_custeio(acao_associacao_data) -> Decimal:
+            def get_valor_custeio(acao_associacao_data, receitas_previstas_paa) -> Decimal:
                 """
                     Retorna o cálculo de valor de custeio em uma acao_associacao_data.
                     Procura nas receitas previstas em Acao Associacao, caso nao tenha, pega do saldo atual.
                     :param acao_associacao_data: Dado de uma Acao Associacao serializada
+                    :param receitas_previstas_paa: Receita prevista da ação, já obtida (evita reconsultar)
                     :return: Decimal com o valor de custeio
                 """
-                receitas_previstas_paa = get_receita_prevista_da_acao_associacao(acao_associacao_data)
                 saldos = acao_associacao_data.get('saldos', {})
 
                 previsao_valor = Decimal(receitas_previstas_paa.get('previsao_valor_custeio', None) or 0)
@@ -145,14 +146,14 @@ class ResumoPrioridadesService:
 
                 return valor
 
-            def get_valor_capital(acao_associacao_data) -> Decimal:
+            def get_valor_capital(acao_associacao_data, receitas_previstas_paa) -> Decimal:
                 """
                     Retorna o cálculo de valor de capital em uma acao_associacao_data.
                     Procura nas receitas previstas em Acao Associacao, caso nao tenha, pega do saldo atual.
                     :param acao_associacao_data: Dado de uma Acao Associacao
+                    :param receitas_previstas_paa: Receita prevista da ação, já obtida (evita reconsultar)
                     :return: Decimal com o valor de capital
                 """
-                receitas_previstas_paa = get_receita_prevista_da_acao_associacao(acao_associacao_data)
                 saldos = acao_associacao_data.get('saldos', {})
 
                 previsao_valor = Decimal(receitas_previstas_paa.get('previsao_valor_capital', None) or 0)
@@ -163,14 +164,14 @@ class ResumoPrioridadesService:
 
                 return valor
 
-            def get_valor_livre(acao_associacao_data) -> Decimal:
+            def get_valor_livre(acao_associacao_data, receitas_previstas_paa) -> Decimal:
                 """
                     Retorna o cálculo de valor de livre em uma acao_associacao_data.
                     Procura nas receitas previstas em Acao Associacao, caso nao tenha, pega do saldo atual.
                     :param acao_associacao_data: Dado de uma Acao Associacao
+                    :param receitas_previstas_paa: Receita prevista da ação, já obtida (evita reconsultar)
                     :return: Decimal com o valor de livre
                 """
-                receitas_previstas_paa = get_receita_prevista_da_acao_associacao(acao_associacao_data)
                 saldos = acao_associacao_data.get('saldos', {})
 
                 previsao_valor = Decimal(receitas_previstas_paa.get('previsao_valor_livre', None) or 0)
@@ -182,13 +183,17 @@ class ResumoPrioridadesService:
 
                 return valor
 
+            # Busca a receita prevista da ação uma única vez e reaproveita nos 3 cálculos abaixo
+            # (antes: 1 query + 1 serialização por chamada x 3 chamadas por ação, redundantes entre si)
+            receitas_previstas_paa = get_receita_prevista_da_acao_associacao(item)
+
             # Retorna um Node 3 de Receita
             return {
                 'key': item.get('uuid') + '_' + 'receita',
                 "recurso": LABEL_RECEITAS_PREVISTAS,
-                "custeio": get_valor_custeio(item),
-                "capital": get_valor_capital(item),
-                "livre_aplicacao": get_valor_livre(item),
+                "custeio": get_valor_custeio(item, receitas_previstas_paa),
+                "capital": get_valor_capital(item, receitas_previstas_paa),
+                "livre_aplicacao": get_valor_livre(item, receitas_previstas_paa),
             }
 
         def calcula_despesas(item) -> dict:
@@ -203,21 +208,16 @@ class ResumoPrioridadesService:
                 necessários para utilização em tabela no frontend com expand de 3 níveis
             """
 
-            # Valores relacionados às "Prioridades do PAA" de uma ação associação e tipo CUSTEIO
-            despesa_custeio = prioridades_ptrf_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name,
+            # Valores relacionados às "Prioridades do PAA" de uma ação associação, CUSTEIO e CAPITAL
+            # numa única query (antes: 2 queries de aggregate separadas)
+            despesas_agregadas = prioridades_ptrf_qs.filter(
                 acao_associacao__uuid=item.get('uuid')
             ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
-
-            # Valores relacionados às "Prioridades do PAA" de uma ação associação e tipo CAPITAL
-            despesa_capital = prioridades_ptrf_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name,
-                acao_associacao__uuid=item.get('uuid')
-            ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
+                total_custeio=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name)),
+                total_capital=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name)),
+            )
+            despesa_custeio = despesas_agregadas.get('total_custeio') or 0
+            despesa_capital = despesas_agregadas.get('total_capital') or 0
 
             return {
                 'key': item.get('uuid') + '_' + 'despesa',
@@ -322,21 +322,16 @@ class ResumoPrioridadesService:
                 :return: Dicionário com a estrutura do Node 3 de "Despesas previstas".
             """
 
-            # Valores relacionados às "Prioridades do PAA" de uma ação PDDE e tipo CUSTEIO
-            despesa_custeio = prioridades_pdde_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name,
+            # Valores relacionados às "Prioridades do PAA" de uma ação PDDE, CUSTEIO e CAPITAL
+            # numa única query (antes: 2 queries de aggregate separadas)
+            despesas_agregadas = prioridades_pdde_qs.filter(
                 acao_pdde__uuid=item.get('uuid')
             ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
-
-            # Valores relacionados às "Prioridades do PAA" de uma ação PDDE e tipo CAPITAL
-            despesa_capital = prioridades_pdde_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name,
-                acao_pdde__uuid=item.get('uuid')
-            ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
+                total_custeio=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name)),
+                total_capital=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name)),
+            )
+            despesa_custeio = despesas_agregadas.get('total_custeio') or 0
+            despesa_capital = despesas_agregadas.get('total_capital') or 0
 
             return {
                 'key': item.get('uuid') + '_' + 'despesa',
@@ -502,21 +497,16 @@ class ResumoPrioridadesService:
                 :return: Dicionário com a estrutura do Node 3 de "Despesas previstas".
             """
 
-            despesa_custeio = prioridades_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name,
+            # CUSTEIO e CAPITAL numa única query (antes: 2 queries de aggregate separadas)
+            despesas_agregadas = prioridades_qs.filter(
                 acao_pdde__isnull=True,
                 acao_associacao__isnull=True,
             ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
-
-            despesa_capital = prioridades_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name,
-                acao_pdde__isnull=True,
-                acao_associacao__isnull=True,
-            ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
+                total_custeio=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name)),
+                total_capital=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name)),
+            )
+            despesa_custeio = despesas_agregadas.get('total_custeio') or 0
+            despesa_capital = despesas_agregadas.get('total_capital') or 0
 
             return {
                 'key': item.get('uuid') + '_' + 'despesa',
@@ -535,23 +525,17 @@ class ResumoPrioridadesService:
                 :return: Dicionário com a estrutura do Node 3 de "Despesas previstas".
             """
 
-            despesa_custeio = prioridades_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name,
+            # CUSTEIO e CAPITAL numa única query (antes: 2 queries de aggregate separadas)
+            despesas_agregadas = prioridades_qs.filter(
                 acao_pdde__isnull=True,
                 acao_associacao__isnull=True,
                 outro_recurso__uuid=item.get('uuid')
             ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
-
-            despesa_capital = prioridades_qs.filter(
-                tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name,
-                acao_pdde__isnull=True,
-                acao_associacao__isnull=True,
-                outro_recurso__uuid=item.get('uuid')
-            ).aggregate(
-                total=Sum('valor_total')
-            ).get('total') or 0
+                total_custeio=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CUSTEIO.name)),
+                total_capital=Sum('valor_total', filter=Q(tipo_aplicacao=TipoAplicacaoOpcoesEnum.CAPITAL.name)),
+            )
+            despesa_custeio = despesas_agregadas.get('total_custeio') or 0
+            despesa_capital = despesas_agregadas.get('total_capital') or 0
 
             return {
                 'key': item.get('uuid') + '_' + 'despesa',
@@ -631,7 +615,15 @@ class ResumoPrioridadesService:
             - children: lista de nodes filhos (receitas, despesas e saldos)
 
             Retorna uma lista com os dados de cada tipo de recurso.
+
+            O resultado é cacheado na instância (memoização): como os dados não mudam durante o ciclo
+            de vida da instância (mesmo request/transação), chamadas subsequentes evitam recalcular e
+            reconsultar toda a árvore de PTRF/PDDE/Outros Recursos do PAA (custoso: dezenas de queries).
+            Usado, por exemplo, por `validar_valor_prioridade`, que pode ser chamado várias vezes em
+            sequência para o mesmo PAA (ex: validação de saldo de várias prioridades impactadas).
         """
+        if self._resumo_prioridades_cache is not None:
+            return self._resumo_prioridades_cache
 
         # Mapa de dados para cada tipo de recurso
         tipo_recurso_map = {
@@ -643,6 +635,7 @@ class ResumoPrioridadesService:
         # Retorna a lista de dados para cada tipo de recurso
         dados = list(tipo_recurso_map.values())
 
+        self._resumo_prioridades_cache = dados
         return dados
 
     def recursos_totalmente_utilizados(self) -> bool:

--- a/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_paa_queryset.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from sme_ptrf_apps.paa.models import Paa, DocumentoPaa, AtaPaa
 from sme_ptrf_apps.paa.enums import PaaStatusEnum, PaaStatusAndamentoEnum
@@ -10,6 +11,57 @@ pytestmark = pytest.mark.django_db
 def _qs():
     """Retorna um queryset de Paa usando o PaaQuerySet."""
     return PaaQuerySet(model=Paa, using=Paa.objects.db)
+
+
+class TestAnnotateStatusGeracaoIdempotente:
+    def test_segunda_chamada_nao_reconstroi_as_anotacoes(self, paa_factory, periodo_paa_factory, associacao):
+        """
+        `paas_em_elaboracao`, `paas_gerados*`, `paas_em_retificacao` e `filter_por_status_geracao`
+        chamam `annotate_status_geracao()` sobre um queryset que, vindo de `Paa.objects` (via
+        `PaaManager`), já foi anotado. Sem a guarda de idempotência, isso reconstrói os 6 `Exists`
+        e as ~24 condições `Case/When` uma segunda vez, à toa, em toda chamada.
+
+        Este teste chama `annotate_status_geracao()` duas vezes seguidas e garante que `_make_when`
+        (usado para montar cada condição `Case/When`) só é invocado na primeira chamada.
+        """
+        periodo = periodo_paa_factory.create()
+        paa_factory.create(periodo_paa=periodo, associacao=associacao, status=PaaStatusEnum.EM_ELABORACAO.name)
+
+        with patch.object(PaaQuerySet, '_make_when', wraps=PaaQuerySet._make_when) as mock_make_when:
+            qs_anotado_1x = _qs().annotate_status_geracao()
+            chamadas_apos_1a_anotacao = mock_make_when.call_count
+            assert chamadas_apos_1a_anotacao > 0
+
+            qs_anotado_2x = qs_anotado_1x.annotate_status_geracao()
+            chamadas_apos_2a_anotacao = mock_make_when.call_count
+
+        # A segunda chamada não deve ter adicionado nenhuma invocação nova de _make_when
+        assert chamadas_apos_2a_anotacao == chamadas_apos_1a_anotacao
+        # E o resultado funcional continua correto
+        assert qs_anotado_2x.first().status_andamento == PaaStatusAndamentoEnum.EM_ELABORACAO.name
+
+    def test_paas_em_elaboracao_chamado_sobre_queryset_ja_anotado_nao_duplica(
+        self, paa_factory, periodo_paa_factory, associacao
+    ):
+        """
+        Reproduz o padrão real: `Paa.objects` (já anotado pelo manager) + `.paas_em_elaboracao()`.
+        O custo de montar as anotações deve ser o mesmo de uma única chamada a
+        `annotate_status_geracao()` — não o dobro.
+        """
+        periodo = periodo_paa_factory.create()
+        paa = paa_factory.create(periodo_paa=periodo, associacao=associacao, status=PaaStatusEnum.EM_ELABORACAO.name)
+
+        with patch.object(PaaQuerySet, '_make_when', wraps=PaaQuerySet._make_when) as mock_make_when:
+            _qs().filter(pk=paa.pk).annotate_status_geracao()
+            custo_de_uma_chamada = mock_make_when.call_count
+
+        with patch.object(PaaQuerySet, '_make_when', wraps=PaaQuerySet._make_when) as mock_make_when:
+            resultado = Paa.objects.filter(pk=paa.pk).paas_em_elaboracao()
+            custo_via_manager_mais_helper = mock_make_when.call_count
+
+        # O manager já anota; paas_em_elaboracao() não deve custar o dobro por reanotar de novo
+        assert custo_via_manager_mais_helper == custo_de_uma_chamada
+        assert resultado.first().status_andamento == PaaStatusAndamentoEnum.EM_ELABORACAO.name
 
 
 class TestAnnotateStatusGeracao:

--- a/sme_ptrf_apps/paa/tests/services/test_prioridades_impactadas_receitas_previstas_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_prioridades_impactadas_receitas_previstas_service.py
@@ -1324,6 +1324,72 @@ class TestValidacaoSaldo:
     @patch('sme_ptrf_apps.paa.services.prioridades_impactadas_receitas_previstas_service.ResumoPrioridadesService')
     @patch('sme_ptrf_apps.paa.models.Paa')
     @patch('sme_ptrf_apps.paa.services.prioridades_impactadas_receitas_previstas_service.PrioridadePaa.objects')
+    def test_verifica_saldo_reaproveita_resumo_service_entre_prioridades_do_mesmo_paa(
+        self,
+        mock_queryset,
+        mock_paa_class,
+        mock_resumo_service,
+        receita_prevista_ptrf_data,
+        mock_acao_associacao,
+        mock_paa
+    ):
+        """
+        Cenário real que motivou a otimização: uma receita prevista com N prioridades vinculadas
+        (mesmo PAA) tendo o valor de custeio reduzido. Antes da correção, `ResumoPrioridadesService`
+        era instanciado (e o resumo completo do PAA recalculado, ~103 queries em produção) uma vez
+        POR PRIORIDADE. Como todas as prioridades verificadas num mesmo loop pertencem ao mesmo PAA,
+        o service deve ser instanciado apenas 1 vez e reaproveitado (cache por paa_id) — ganho de
+        (N - 1) x custo_completo_do_resumo, ou seja (N - 1) x ~103 queries evitadas no caso observado.
+        """
+        instance = Mock(spec=ReceitaPrevistaPaa)
+        instance.acao_associacao = mock_acao_associacao
+        instance.paa = mock_paa
+        instance.previsao_valor_custeio = Decimal('2000.00')
+        instance.previsao_valor_capital = Decimal('2000.00')
+        instance.previsao_valor_livre = Decimal('500.00')
+
+        # Redução de custeio para disparar a verificação de saldo nas prioridades de CUSTEIO
+        receita_prevista_ptrf_data['previsao_valor_custeio'] = '1500.00'
+
+        # N prioridades de CUSTEIO, todas do mesmo PAA (cenário real: 13 prioridades vinculadas)
+        total_prioridades = 5
+        mock_prioridades = []
+        for i in range(total_prioridades):
+            mock_prioridade = Mock()
+            mock_prioridade.uuid = f'prioridade-uuid-{i}'
+            mock_prioridade.tipo_aplicacao = TipoAplicacaoOpcoesEnum.CUSTEIO.name
+            mock_prioridade.paa = mock_paa
+            mock_prioridade.paa_id = mock_paa.uuid
+            mock_prioridades.append(mock_prioridade)
+
+        mock_qs = Mock(spec=models.QuerySet)
+        mock_queryset.filter.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.exists.return_value = True
+        mock_qs.__iter__ = Mock(return_value=iter(mock_prioridades))
+
+        mock_paa_qs = Mock()
+        mock_paa_class.objects.filter.return_value = mock_paa_qs
+        mock_paa_qs.paas_em_elaboracao.return_value = Mock()
+
+        mock_resumo_instance = Mock()
+        mock_resumo_service.return_value = mock_resumo_instance
+
+        service = PrioridadesPaaImpactadasReceitasPrevistasPTRFService(
+            receita_prevista_ptrf_data,
+            instance
+        )
+
+        service._buscar_prioridades_impactadas()
+
+        # As N prioridades foram de fato verificadas...
+        assert mock_resumo_instance.validar_valor_prioridade.call_count == total_prioridades
+        # ...mas o service (e o cálculo caro do resumo que ele encapsula) foi criado uma única vez
+        mock_resumo_service.assert_called_once_with(mock_paa)
+
+    @patch('sme_ptrf_apps.paa.services.prioridades_impactadas_receitas_previstas_service.ResumoPrioridadesService')
+    @patch('sme_ptrf_apps.paa.models.Paa')
+    @patch('sme_ptrf_apps.paa.services.prioridades_impactadas_receitas_previstas_service.PrioridadePaa.objects')
     def test_buscar_prioridades_com_reducao_capital(
         self,
         mock_queryset,

--- a/sme_ptrf_apps/paa/tests/services/test_resumo_prioridades.py
+++ b/sme_ptrf_apps/paa/tests/services/test_resumo_prioridades.py
@@ -127,6 +127,38 @@ def test_resumo_prioridades(mock_recursos, mock_pdde, mock_ptrf, resumo_recursos
 
 
 @pytest.mark.django_db
+@patch.object(ResumoPrioridadesService, "calcula_node_ptrf")
+@patch.object(ResumoPrioridadesService, "calcula_node_pdde")
+@patch.object(ResumoPrioridadesService, "calcula_node_outros_recursos")
+def test_resumo_prioridades_e_memoizado_entre_chamadas(mock_recursos, mock_pdde, mock_ptrf, resumo_recursos_paa):
+    """
+    Garante a memoização de `resumo_prioridades()`: em produção, cada uma dessas 3 funções
+    (calcula_node_ptrf/pdde/outros_recursos) dispara dezenas de queries para montar a árvore completa
+    do PAA. `validar_valor_prioridade` chama `resumo_prioridades()` uma vez por prioridade verificada
+    (ex: 13 prioridades impactadas por uma mesma receita prevista); sem cache, isso recalcula a árvore
+    do zero em cada chamada (~103 queries x 13 em um caso real observado).
+
+    Chamar `resumo_prioridades()` múltiplas vezes na mesma instância deve reaproveitar o resultado da
+    1ª chamada: as 3 funções de cálculo devem ser executadas apenas 1 vez, não numa por chamada.
+    """
+    mock_ptrf.return_value = {"key": "PTRF"}
+    mock_pdde.return_value = {"key": "PDDE"}
+    mock_recursos.return_value = {"key": "OUTRO_RECURSO"}
+
+    service = ResumoPrioridadesService(paa=resumo_recursos_paa)
+
+    primeira_chamada = service.resumo_prioridades()
+    segunda_chamada = service.resumo_prioridades()
+    terceira_chamada = service.resumo_prioridades()
+
+    assert primeira_chamada == segunda_chamada == terceira_chamada
+    # Ganho: 2 recomputações completas evitadas (calculadas 1x em vez de 3x)
+    mock_ptrf.assert_called_once()
+    mock_pdde.assert_called_once()
+    mock_recursos.assert_called_once()
+
+
+@pytest.mark.django_db
 @patch.object(ResumoPrioridadesService, "resumo_prioridades")
 def test_recursos_totalmente_utilizados_quando_sem_saldo(mock_resumo, resumo_recursos_paa):
     """Deve retornar True quando não há saldo de recursos."""

--- a/sme_ptrf_apps/users/api/views/login.py
+++ b/sme_ptrf_apps/users/api/views/login.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -310,82 +309,20 @@ class MeView(APIView):
     """
     GET api/me/
 
-    Retorna dados atualizados do usuário autenticado: permissões, visões, unidades e
-    feature flags. Usado pelo frontend no reload da página para sincronizar o
-    localStorage com o estado atual do banco.
+    retorna sempre {} (200 OK, só exige autenticação).
 
-    Herda de APIView (não de TokenObtainPairView), portanto usa o
-    DEFAULT_AUTHENTICATION_CLASSES do settings (JWTAuthentication) sem sobrescritas.
+    Classe disponível para obtenção de dados customizados.
+
+    Em desuso após a inviabilidade de atualizar unidades, permissões e features flags
+    devido ao acoplamento atual no fluxo de Login, em relação às integrações e verificações
+    de unidades do usuário. O fluxo do Service de Gestão de Usuário não é apenas de leitura,
+    mas esse fluxo aplica alterações nos relacionamento de usuários e unidades.
+    Devido a isso, se houver qualquer instabilidade em uma das integrações, pode refletir com falsos
+    negativos (considerando um exemplo em que ocorra alguma falha na requisição de unidades, e, falsamente retornaria
+    como Unidade inexistente no usuário), entre inúmeros outros pontos...
     """
 
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        user = request.user
-        flags = get_waffle_flag_model()
-        novo_suporte_unidades = flags.objects.filter(name='novo-suporte-unidades', everyone=True).exists()
-        suporte = request.query_params.get('suporte', 'false').lower() == 'true'
-
-        try:
-            gestao_usuario = GestaoUsuarioService(usuario=user)
-
-            if novo_suporte_unidades:
-                login_service = LoginUsuarioService(usuario=user, gestao_usuario=gestao_usuario, suporte=suporte)
-            else:
-                login_service = LoginUsuarioService(usuario=user, gestao_usuario=gestao_usuario)
-
-            unidades = login_service.unidades_que_usuario_tem_acesso
-
-            if not unidades:
-                return Response(
-                    {'detail': 'Você não possui mais acesso ao sistema.'},
-                    status=status.HTTP_403_FORBIDDEN
-                )
-
-            associacao = Associacao.objects.filter(unidade__uuid=unidades[0]['uuid']).first()
-            associacao_dict = {
-                'uuid': str(associacao.uuid),
-                'nome': associacao.nome,
-                'nome_escola': associacao.unidade.nome,
-                'tipo_escola': associacao.unidade.tipo_unidade,
-            } if associacao else {'uuid': '', 'nome': '', 'nome_escola': '', 'tipo_escola': ''}
-
-            visoes = list(user.visoes.values_list('nome', flat=True))
-            if novo_suporte_unidades and suporte and 'SME' in visoes:
-                visoes.remove('SME')
-
-            return Response({
-                'login': user.username,
-                'nome': user.name,
-                'email': user.email,
-                'visoes': visoes,
-                'unidades': unidades,
-                'associacao': associacao_dict,
-                'permissoes': self._get_permissoes(user, flags, suporte, novo_suporte_unidades),
-                'feature_flags': self._get_feature_flags(user, request),
-            }, status=status.HTTP_200_OK)
-
-        except Exception as e:
-            logger.exception('Erro ao carregar dados do usuário autenticado: %s', e)
-            return Response(
-                {'detail': f'Erro ao carregar dados do usuário: {e}'},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
-
-    def _get_permissoes(self, user, flags, suporte, novo_suporte_unidades):
-        perms = []
-        if novo_suporte_unidades:
-            groups = user.groups.filter(grupo__suporte=True) if suporte else user.groups.filter(grupo__suporte=False)
-        else:
-            groups = user.groups.all()
-        for group in groups:
-            for permission in group.permissions.all():
-                perms.append(permission.codename)
-        return perms
-
-    def _get_feature_flags(self, user, request):
-        request_com_user = HttpRequest()
-        request_com_user.META = request.META
-        request_com_user.user = user
-        Flag = get_waffle_flag_model()
-        return [flag.name for flag in Flag.get_all() if flag.is_active(request_com_user)]
+        return Response({}, status=status.HTTP_200_OK)

--- a/sme_ptrf_apps/users/tests/test_me_view/test_api_me_view.py
+++ b/sme_ptrf_apps/users/tests/test_me_view/test_api_me_view.py
@@ -1,28 +1,11 @@
 import pytest
 
-from unittest.mock import patch
-
 from rest_framework import status
 from rest_framework.test import APIClient
-from waffle.testutils import override_flag
 
 pytestmark = pytest.mark.django_db
 
 ME_URL = '/api/me'
-
-
-def mock_login_usuario_service(unidades):
-    """Substitui GestaoUsuarioService/LoginUsuarioService por dublês, evitando
-    reconstruir toda a infraestrutura de acesso (já coberta em test_user_v2)
-    e mantendo o teste focado no comportamento da própria MeView."""
-    gestao_patch = patch('sme_ptrf_apps.users.api.views.login.GestaoUsuarioService')
-    login_service_patch = patch('sme_ptrf_apps.users.api.views.login.LoginUsuarioService')
-    mock_gestao = gestao_patch.start()  # noqa
-    mock_login_service_cls = login_service_patch.start()
-    mock_login_service_cls.return_value.unidades_que_usuario_tem_acesso = unidades
-    mock_login_service_cls.return_value.unidades_que_perdeu_acesso = []
-    mock_login_service_cls.return_value.mensagem_perca_acesso = None
-    return gestao_patch, login_service_patch
 
 
 def test_me_view_sem_autenticacao_retorna_401():
@@ -33,191 +16,15 @@ def test_me_view_sem_autenticacao_retorna_401():
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_me_view_retorna_dados_do_usuario_autenticado(me_client, me_user, unidades_com_acesso):
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
+def test_me_view_autenticado_retorna_dict_vazio(me_client):
+    """MeView está desativada temporariamente (ver docstring da view): não recalcula
+    mais nada, só confirma que o usuário está autenticado e devolve {}.
+
+    Isso evita reintroduzir o incidente de perda de acesso a unidades causado por
+    valida_unidades_do_usuario() (chamado indiretamente via GestaoUsuarioService/
+    LoginUsuarioService) rodando a cada reload de página em vez de só no login.
+    """
+    response = me_client.get(ME_URL)
 
     assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert data['login'] == me_user.username
-    assert data['nome'] == me_user.name
-    assert data['email'] == me_user.email
-    assert data['visoes'] == ['UE']
-    assert data['unidades'] == unidades_com_acesso
-    assert data['permissoes'] == ['view_tipodevolucaoaotesouro']
-    assert 'feature_flags' in data
-    assert 'associacao' in data
-
-
-def test_me_view_sem_acesso_a_nenhuma_unidade_retorna_403(me_client):
-    gestao_patch, login_service_patch = mock_login_usuario_service([])
-    try:
-        response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert 'detail' in response.json()
-
-
-def test_me_view_erro_interno_retorna_500(me_client):
-    with patch(
-        'sme_ptrf_apps.users.api.views.login.GestaoUsuarioService',
-        side_effect=Exception('Falha ao consultar usuário'),
-    ):
-        response = me_client.get(ME_URL)
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert 'Falha ao consultar usuário' in response.json()['detail']
-
-
-def test_me_view_monta_associacao_quando_existe_para_a_unidade(me_client, unidade, associacao_unidade_a):
-    unidades = [{
-        'uuid': str(unidade.uuid),
-        'nome': unidade.nome,
-        'tipo_unidade': unidade.tipo_unidade,
-        'associacao': {'uuid': '', 'nome': ''},
-        'acesso_de_suporte': False,
-        'notificar_devolucao_por_recurso': {},
-    }]
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades)
-    try:
-        response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert response.status_code == status.HTTP_200_OK
-    associacao_dict = response.json()['associacao']
-    assert associacao_dict == {
-        'uuid': str(associacao_unidade_a.uuid),
-        'nome': associacao_unidade_a.nome,
-        'nome_escola': unidade.nome,
-        'tipo_escola': unidade.tipo_unidade,
-    }
-
-
-def test_me_view_associacao_vazia_quando_nao_ha_associacao_para_a_unidade(me_client, unidades_com_acesso):
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()['associacao'] == {'uuid': '', 'nome': '', 'nome_escola': '', 'tipo_escola': ''}
-
-
-def test_me_view_permissoes_flag_desativada_retorna_permissoes_de_todos_os_grupos(
-    me_client, me_user, grupo_suporte, unidades_com_acesso
-):
-    me_user.groups.add(grupo_suporte)
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('novo-suporte-unidades', active=False):
-            response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    permissoes = response.json()['permissoes']
-    assert sorted(permissoes) == ['view_tipodevolucaoaotesouro', 'view_unidade']
-
-
-def test_me_view_permissoes_flag_ativa_sem_suporte_retorna_apenas_grupos_normais(
-    me_client, me_user, grupo_suporte, unidades_com_acesso
-):
-    me_user.groups.add(grupo_suporte)
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('novo-suporte-unidades', active=True):
-            response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert response.json()['permissoes'] == ['view_tipodevolucaoaotesouro']
-
-
-def test_me_view_permissoes_flag_ativa_com_suporte_retorna_apenas_grupos_de_suporte(
-    me_client, me_user, grupo_suporte, unidades_com_acesso
-):
-    me_user.groups.add(grupo_suporte)
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('novo-suporte-unidades', active=True):
-            response = me_client.get(f'{ME_URL}?suporte=true')
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert response.json()['permissoes'] == ['view_unidade']
-
-
-def test_me_view_remove_visao_sme_quando_flag_ativa_e_suporte_true(
-    me_client, me_user, visao_sme, unidades_com_acesso
-):
-    me_user.visoes.add(visao_sme)
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('novo-suporte-unidades', active=True):
-            response = me_client.get(f'{ME_URL}?suporte=true')
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert 'SME' not in response.json()['visoes']
-    assert 'UE' in response.json()['visoes']
-
-
-def test_me_view_mantem_visao_sme_quando_suporte_true_mas_flag_desativada(
-    me_client, me_user, visao_sme, unidades_com_acesso
-):
-    me_user.visoes.add(visao_sme)
-
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('novo-suporte-unidades', active=False):
-            response = me_client.get(f'{ME_URL}?suporte=true')
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert 'SME' in response.json()['visoes']
-
-
-def test_me_view_repassa_suporte_para_login_usuario_service(me_client, unidades_com_acesso):
-    with patch('sme_ptrf_apps.users.api.views.login.GestaoUsuarioService'), \
-         patch('sme_ptrf_apps.users.api.views.login.LoginUsuarioService') as mock_login_service_cls:
-        mock_login_service_cls.return_value.unidades_que_usuario_tem_acesso = unidades_com_acesso
-        mock_login_service_cls.return_value.unidades_que_perdeu_acesso = []
-        mock_login_service_cls.return_value.mensagem_perca_acesso = None
-
-        with override_flag('novo-suporte-unidades', active=True):
-            me_client.get(f'{ME_URL}?suporte=true')
-
-        _, kwargs = mock_login_service_cls.call_args
-        assert kwargs['suporte'] is True
-
-
-def test_me_view_feature_flags_retorna_flags_ativas_para_todos(me_client, unidades_com_acesso):
-    gestao_patch, login_service_patch = mock_login_usuario_service(unidades_com_acesso)
-    try:
-        with override_flag('flag-de-teste-me-view', active=True):
-            response = me_client.get(ME_URL)
-    finally:
-        gestao_patch.stop()
-        login_service_patch.stop()
-
-    assert 'flag-de-teste-me-view' in response.json()['feature_flags']
+    assert response.json() == {}


### PR DESCRIPTION

Esse PR:

- 154332 - [SIG-Escola] Login: perda de acesso as unidades disponíveis
  - Remove Requisição de rota /me devido a inconsistencias de dados quando usuário é autenticado, conflitando com as unidade vinculadas do usuário. Agora a rota /me é requisitada apenas quando o usuário não possui unidades vinculadas, evitando perda de acesso as unidades disponíveis.

- [PERFORM - PAA] Adiciona cache de objeto no resumo de prioridades quando uma receita prevista tem seu valor alterado(principalmente, quando reduzido) e dispara validações de saldos de prioridades.
Considerando que pra cada prioridade, atualmente, é carregado todo o resumo de prioridades. Agora, passa a carregar apenas a primeira vez e reutilizar o objeto em cache, reduzindo quantidade de requisições no banco de dados.
Este ajuste segue em Hotfix, pois a atualização deve refletir imediatamente no ambiente de treinamento.

História [AB#154332](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/154332)

