### PR TITLE
feature(152458): Alterações na verificação de professor grêmio, exibição de atividades na ata e melhorias nos documentos

### DIFF
--- a/sme_ptrf_apps/core/models/acao.py
+++ b/sme_ptrf_apps/core/models/acao.py
@@ -6,6 +6,12 @@ from auditlog.registry import auditlog
 
 
 class Acao(ModeloIdNome):
+    class Nome(models.TextChoices):
+        ORCAMENTO_GREMIO_ESTUDANTIL = (
+            "Orçamento Grêmio Estudantil",
+            "Orçamento Grêmio Estudantil",
+        )
+
     history = AuditlogHistoryField()
     posicao_nas_pesquisas = models.CharField(
         'posição nas pesquisas',

--- a/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
@@ -16,17 +16,18 @@ _FORMATO_DATA = "%d/%m/%Y"
 
 
 def _filtrar_itens_atividades_retificadas(items: list[dict]) -> tuple[list[dict], bool]:
-    """Retorna apenas os itens marcados como retificados e um flag de presença.
+    """Retorna todos os itens retificados ou não e um flag de presença.
 
     Args:
         items: Lista de itens que contêm a chave ``retificado``.
 
     Returns:
-        Tupla ``(items_retificados, tem_retificado)`` onde ``items_retificados``
-        é a lista filtrada e ``tem_retificado`` indica se há ao menos um item.
+        Tupla ``(items, bool(tem_retificado))`` onde ``items``
+        é a lista completa e ``tem_retificado`` indica se há ao menos um item.
     """
+
     items_retificados = [item for item in items if item.get('retificado')]
-    return items_retificados, bool(items_retificados)
+    return items, bool(items_retificados)
 
 
 def _aplicar_filtro_retificacao_no_grupo(prioridades: list[dict], key: str) -> bool:
@@ -243,8 +244,8 @@ def presentes_ata_paa(ata_paa: AtaPaa):
         presentes_ata_membros_list.append(presente_dict)
 
     presentes_ata_nao_membros = ParticipanteAtaPaa.objects.filter(
-        ata_paa=ata_paa, membro=False, conselho_fiscal=False
-    ).order_by('nome').values('uuid', 'nome', 'cargo', 'presente', 'professor_gremio')
+        ata_paa=ata_paa, membro=False, conselho_fiscal=False,
+    ).exclude(identificacao="").order_by('nome').values('uuid', 'nome', 'cargo', 'presente', 'professor_gremio')
 
     presentes_na_ata = {
         "presentes_ata_membros": presentes_ata_membros_list,

--- a/sme_ptrf_apps/paa/services/ata_paa_service.py
+++ b/sme_ptrf_apps/paa/services/ata_paa_service.py
@@ -5,8 +5,7 @@ from sme_ptrf_apps.paa.models import AtaPaa, LogReplicaPaa
 from sme_ptrf_apps.paa.models.documento_paa import obter_documento_final_por_retificacao
 from sme_ptrf_apps.paa.services.ata_paa_dados_service import gerar_dados_ata_paa
 from sme_ptrf_apps.paa.services.ata_paa_pdf_service import gerar_arquivo_ata_paa_pdf
-from sme_ptrf_apps.despesas.models import RateioDespesa
-from sme_ptrf_apps.core.models import Parametros
+from sme_ptrf_apps.core.models import Parametros, Acao
 from sme_ptrf_apps.paa.services.paa_service import PaaService
 
 LOGGER = logging.getLogger(__name__)
@@ -241,27 +240,18 @@ def verifica_precisa_professor_gremio(ata_paa: AtaPaa) -> bool:
     if not ata_paa.paa.periodo_paa:
         return False
 
-    periodo_paa = ata_paa.paa.periodo_paa
     associacao = ata_paa.paa.associacao
 
     acao_gremio = associacao.acoes.filter(
-        acao__nome__icontains='Orçamento Grêmio Estudantil',
+        acao__nome__icontains=Acao.Nome.ORCAMENTO_GREMIO_ESTUDANTIL,
         status='ATIVA'
     ).first()
 
     if not acao_gremio:
         return False
 
-    rateios_query = RateioDespesa.completos.filter(
-        acao_associacao=acao_gremio,
-        associacao=associacao
-    ).filter(
-        despesa__data_transacao__gte=periodo_paa.data_inicial
+    receita_prevista_query = ata_paa.paa.receitaprevistapaa_set.filter(
+        acao_associacao__acao=acao_gremio.acao,
     )
 
-    if periodo_paa.data_final:
-        rateios_query = rateios_query.filter(
-            despesa__data_transacao__lte=periodo_paa.data_final
-        )
-
-    return rateios_query.exists()
+    return receita_prevista_query.exists()

--- a/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_model.py
+++ b/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_model.py
@@ -1,8 +1,6 @@
 import pytest
-from datetime import timedelta
 
 from sme_ptrf_apps.paa.models import AtaPaa, Paa
-from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO
 from sme_ptrf_apps.paa.services.ata_paa_service import unidade_precisa_professor_gremio
 
 pytestmark = pytest.mark.django_db
@@ -211,14 +209,24 @@ def test_unidade_precisa_professor_gremio_sem_configuracao(parametros):
     assert unidade_precisa_professor_gremio('EMEF') is False
 
 
-def test_precisa_professor_gremio_com_tipo_configurado_sem_despesas(ata_paa, parametros):
-    """Testa se precisa_professor_gremio retorna False quando tipo está configurado mas não há despesas"""
+def test_precisa_professor_gremio_com_tipo_configurado_sem_receitas_previstas(ata_paa, parametros, acao_factory,
+                                                                               acao_associacao_factory,
+                                                                               receita_prevista_paa_factory):
+    """Testa se precisa_professor_gremio retorna False quando tipo está configurado mas não há receitas previstas"""
     parametros.tipos_unidades_professor_gremio = ['EMEF']
     parametros.save()
 
-    ata_paa.paa.associacao.unidade.tipo_unidade = 'EMEF'
+    ata_paa.paa.associacao.unidade.tipo_unidade = 'CIEJA'
     ata_paa.paa.associacao.unidade.save()
 
+    acao_gremio = acao_factory.create(nome='Orçamento Grêmio Estudantil')
+    acao_associacao_gremio = acao_associacao_factory.create(
+        associacao=ata_paa.paa.associacao,
+        acao=acao_gremio,
+        status='ATIVA'
+    )
+
+    receita_prevista_paa_factory.create(paa=ata_paa.paa, acao_associacao=acao_associacao_gremio)
     assert ata_paa.precisa_professor_gremio is False
 
 
@@ -287,16 +295,16 @@ def test_completa_ata_aprovada_sem_professor_gremio_quando_precisa(
     assert ata_paa.completa is True
 
 
-def test_precisa_professor_gremio_com_despesas_completas_gremio_no_periodo(
-        ata_paa, parametros, acao_factory, acao_associacao_factory, despesa_factory, rateio_despesa_factory):
+def test_precisa_professor_gremio_com_receitas_previstas_gremio_no_periodo(
+        ata_paa, parametros, acao_factory, acao_associacao_factory, receita_prevista_paa_factory):
     """
-        Testa se precisa_professor_gremio retorna True quando há despesas completas com rateio de
+        Testa se precisa_professor_gremio retorna True quando há receitas previstas com
         ação 'Orçamento Grêmio Estudantil' no período do PAA
     """
-    parametros.tipos_unidades_professor_gremio = ['EMEF']
+    parametros.tipos_unidades_professor_gremio = ['CIEJA']
     parametros.save()
 
-    ata_paa.paa.associacao.unidade.tipo_unidade = 'EMEF'
+    ata_paa.paa.associacao.unidade.tipo_unidade = 'CIEJA'
     ata_paa.paa.associacao.unidade.save()
 
     # Cria ação "Orçamento Grêmio Estudantil"
@@ -307,37 +315,23 @@ def test_precisa_professor_gremio_com_despesas_completas_gremio_no_periodo(
         status='ATIVA'
     )
 
-    # Cria despesa completa no período do PAA
-    periodo_paa = ata_paa.paa.periodo_paa
-    despesa = despesa_factory.create(
-        associacao=ata_paa.paa.associacao,
-        data_transacao=periodo_paa.data_inicial + timedelta(days=1),
-        status=STATUS_COMPLETO
-    )
-
-    # Cria rateio completo com a ação do grêmio
-    rateio_despesa_factory.create(
-        despesa=despesa,
-        associacao=ata_paa.paa.associacao,
-        acao_associacao=acao_associacao_gremio
-    )
+    receita_prevista_paa_factory.create(paa=ata_paa.paa, acao_associacao=acao_associacao_gremio)
 
     assert ata_paa.precisa_professor_gremio is True
 
 
-def test_precisa_professor_gremio_sem_despesas_completas_gremio_no_periodo(
+def test_precisa_professor_gremio_sem_receitas_previstas_gremio_no_periodo(
         ata_paa, parametros, acao_factory, acao_associacao_factory):
     """
-        Testa se precisa_professor_gremio retorna False quando não há despesas completas com rateio de
+        Testa se precisa_professor_gremio retorna False quando não há receitas previstas com
         ação 'Orçamento Grêmio Estudantil' no período do PAA
     """
-    parametros.tipos_unidades_professor_gremio = ['EMEF']
+    parametros.tipos_unidades_professor_gremio = ['CIEJA']
     parametros.save()
 
-    ata_paa.paa.associacao.unidade.tipo_unidade = 'EMEF'
+    ata_paa.paa.associacao.unidade.tipo_unidade = 'CIEJA'
     ata_paa.paa.associacao.unidade.save()
 
-    # Cria ação "Orçamento Grêmio Estudantil" mas sem despesas completas no período
     acao_gremio = acao_factory.create(nome='Orçamento Grêmio Estudantil')
     acao_associacao_factory.create(
         associacao=ata_paa.paa.associacao,
@@ -345,7 +339,6 @@ def test_precisa_professor_gremio_sem_despesas_completas_gremio_no_periodo(
         status='ATIVA'
     )
 
-    # Não cria despesas completas no período do PAA
     assert ata_paa.precisa_professor_gremio is False
 
 
@@ -358,42 +351,4 @@ def test_precisa_professor_gremio_sem_acao_gremio(ata_paa, parametros):
     ata_paa.paa.associacao.unidade.save()
 
     # Não cria ação "Orçamento Grêmio Estudantil"
-    assert ata_paa.precisa_professor_gremio is False
-
-
-def test_precisa_professor_gremio_com_despesas_fora_do_periodo(
-        ata_paa, parametros, acao_factory, acao_associacao_factory, despesa_factory, rateio_despesa_factory):
-    """
-        Testa se precisa_professor_gremio retorna False quando há despesas completas com rateio de
-        ação 'Orçamento Grêmio Estudantil' mas fora do período do PAA
-    """
-    parametros.tipos_unidades_professor_gremio = ['EMEF']
-    parametros.save()
-
-    ata_paa.paa.associacao.unidade.tipo_unidade = 'EMEF'
-    ata_paa.paa.associacao.unidade.save()
-
-    # Cria ação "Orçamento Grêmio Estudantil"
-    acao_gremio = acao_factory.create(nome='Orçamento Grêmio Estudantil')
-    acao_associacao_gremio = acao_associacao_factory.create(
-        associacao=ata_paa.paa.associacao,
-        acao=acao_gremio,
-        status='ATIVA'
-    )
-
-    # Cria despesa completa FORA do período do PAA (antes do período)
-    periodo_paa = ata_paa.paa.periodo_paa
-    despesa = despesa_factory.create(
-        associacao=ata_paa.paa.associacao,
-        data_transacao=periodo_paa.data_inicial - timedelta(days=10),
-        status=STATUS_COMPLETO
-    )
-
-    # Cria rateio completo com a ação do grêmio
-    rateio_despesa_factory.create(
-        despesa=despesa,
-        associacao=ata_paa.paa.associacao,
-        acao_associacao=acao_associacao_gremio
-    )
-
     assert ata_paa.precisa_professor_gremio is False

--- a/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_serializer.py
+++ b/sme_ptrf_apps/paa/tests/ata_paa/test_ata_paa_serializer.py
@@ -41,13 +41,14 @@ def test_serializer(ata_paa):
 
 
 def test_serializer_precisa_professor_gremio_true(
-        ata_paa, parametros, acao_factory, acao_associacao_factory, despesa_factory, rateio_despesa_factory):
+        ata_paa, parametros, acao_factory, acao_associacao_factory,
+        receita_prevista_paa_factory):
     """Testa se serializer retorna precisa_professor_gremio=True quando unidade precisa e há
-      despesas completas com ação grêmio no período"""
-    parametros.tipos_unidades_professor_gremio = ['EMEF']
+      receitas previstas com ação grêmio no período"""
+    parametros.tipos_unidades_professor_gremio = ['CIEJA']
     parametros.save()
 
-    ata_paa.paa.associacao.unidade.tipo_unidade = 'EMEF'
+    ata_paa.paa.associacao.unidade.tipo_unidade = 'CIEJA'
     ata_paa.paa.associacao.unidade.save()
 
     # Cria ação "Orçamento Grêmio Estudantil"
@@ -58,20 +59,7 @@ def test_serializer_precisa_professor_gremio_true(
         status='ATIVA'
     )
 
-    # Cria despesa completa no período do PAA
-    periodo_paa = ata_paa.paa.periodo_paa
-    despesa = despesa_factory.create(
-        associacao=ata_paa.paa.associacao,
-        data_transacao=periodo_paa.data_inicial + timedelta(days=1),
-        status=STATUS_COMPLETO
-    )
-
-    # Cria rateio completo com a ação do grêmio
-    rateio_despesa_factory.create(
-        despesa=despesa,
-        associacao=ata_paa.paa.associacao,
-        acao_associacao=acao_associacao_gremio
-    )
+    receita_prevista_paa_factory.create(paa=ata_paa.paa, acao_associacao=acao_associacao_gremio)
 
     serializer = AtaPaaSerializer(ata_paa)
     assert serializer.data['precisa_professor_gremio'] is True

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
@@ -210,8 +210,7 @@ class TestFiltrarItensRetificados:
 
         resultado, _ = _filtrar_itens_atividades_retificadas(items)
 
-        assert len(resultado) == 2
-        assert all(i['retificado'] for i in resultado)
+        assert len(resultado) == 3
 
     def test_flag_true_quando_ha_retificado(self):
         items = [{'retificado': True}, {'retificado': False}]

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_service.py
@@ -15,7 +15,6 @@ from sme_ptrf_apps.paa.services.ata_paa_service import (
     validar_geracao_ata_paa,
 )
 from sme_ptrf_apps.paa.services.validacao_edicao_ata_paa_service import validar_edicao_ata_paa
-from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO
 
 pytestmark = pytest.mark.django_db
 
@@ -82,8 +81,8 @@ def test_verifica_precisa_professor_gremio_sem_tipo_configurado(ata_paa, paramet
     assert verifica_precisa_professor_gremio(ata_paa) is False
 
 
-def test_verifica_precisa_professor_gremio_com_tipo_configurado_sem_despesas(ata_paa, parametros):
-    """Testa se verifica_precisa_professor_gremio retorna False quando tipo está configurado mas não há despesas"""
+def test_verifica_precisa_professor_gremio_com_tipo_configurado_sem_receita_prevista(ata_paa, parametros):
+    """Testa se verifica_precisa_professor_gremio retorna False quando tipo está configurado mas não há receitas previstas"""
     tipo_unidade = ata_paa.paa.associacao.unidade.tipo_unidade
     parametros.tipos_unidades_professor_gremio = [tipo_unidade]
     parametros.save()
@@ -91,38 +90,25 @@ def test_verifica_precisa_professor_gremio_com_tipo_configurado_sem_despesas(ata
     assert verifica_precisa_professor_gremio(ata_paa) is False
 
 
-def test_verifica_precisa_professor_gremio_com_despesas_completas_gremio_no_periodo(
-    ata_paa, parametros, acao_factory, acao_associacao_factory, despesa_factory, rateio_despesa_factory
+def test_verifica_precisa_professor_gremio_receita_prevista_gremio(
+    ata_paa, parametros, acao_factory, acao_associacao_factory, receita_prevista_paa_factory
 ):
-    """Testa se verifica_precisa_professor_gremio retorna True quando há despesas completas com
+    """Testa se verifica_precisa_professor_gremio retorna True quando há receita previstas com
         ação grêmio no período"""
     tipo_unidade = ata_paa.paa.associacao.unidade.tipo_unidade
     parametros.tipos_unidades_professor_gremio = [tipo_unidade]
     parametros.save()
 
-    # Cria ação "Orçamento Grêmio Estudantil"
+
     acao_gremio = acao_factory.create(nome='Orçamento Grêmio Estudantil')
+
     acao_associacao_gremio = acao_associacao_factory.create(
         associacao=ata_paa.paa.associacao,
         acao=acao_gremio,
         status='ATIVA'
     )
 
-    # Cria despesa completa no período do PAA
-    periodo_paa = ata_paa.paa.periodo_paa
-    despesa = despesa_factory.create(
-        associacao=ata_paa.paa.associacao,
-        data_transacao=periodo_paa.data_inicial + timedelta(days=1),
-        status=STATUS_COMPLETO
-    )
-
-    # Cria rateio completo com a ação do grêmio
-    rateio_despesa_factory.create(
-        despesa=despesa,
-        associacao=ata_paa.paa.associacao,
-        acao_associacao=acao_associacao_gremio
-    )
-
+    receita_prevista_paa_factory.create(paa=ata_paa.paa, acao_associacao=acao_associacao_gremio)
     assert verifica_precisa_professor_gremio(ata_paa) is True
 
 
@@ -131,40 +117,6 @@ def test_verifica_precisa_professor_gremio_sem_acao_gremio(ata_paa, parametros):
     tipo_unidade = ata_paa.paa.associacao.unidade.tipo_unidade
     parametros.tipos_unidades_professor_gremio = [tipo_unidade]
     parametros.save()
-
-    assert verifica_precisa_professor_gremio(ata_paa) is False
-
-
-def test_verifica_precisa_professor_gremio_com_despesas_fora_do_periodo(
-    ata_paa, parametros, acao_factory, acao_associacao_factory, despesa_factory, rateio_despesa_factory
-):
-    """Testa se verifica_precisa_professor_gremio retorna False quando há despesas fora do período"""
-    tipo_unidade = ata_paa.paa.associacao.unidade.tipo_unidade
-    parametros.tipos_unidades_professor_gremio = [tipo_unidade]
-    parametros.save()
-
-    # Cria ação "Orçamento Grêmio Estudantil"
-    acao_gremio = acao_factory.create(nome='Orçamento Grêmio Estudantil')
-    acao_associacao_gremio = acao_associacao_factory.create(
-        associacao=ata_paa.paa.associacao,
-        acao=acao_gremio,
-        status='ATIVA'
-    )
-
-    # Cria despesa completa FORA do período do PAA (antes do período)
-    periodo_paa = ata_paa.paa.periodo_paa
-    despesa = despesa_factory.create(
-        associacao=ata_paa.paa.associacao,
-        data_transacao=periodo_paa.data_inicial - timedelta(days=1),
-        status=STATUS_COMPLETO
-    )
-
-    # Cria rateio completo com a ação do grêmio
-    rateio_despesa_factory.create(
-        despesa=despesa,
-        associacao=ata_paa.paa.associacao,
-        acao_associacao=acao_associacao_gremio
-    )
 
     assert verifica_precisa_professor_gremio(ata_paa) is False
 

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-lista-presenca.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-lista-presenca.html
@@ -41,7 +41,7 @@
             </tr>
           </thead>
           {% for info in dados.presentes_na_ata.presentes_ata_nao_membros %}
-            {% if not info.professor_gremio or info.identificacao %}
+            {% if info.professor_gremio or info.identificacao %}
             <tbody>
             <tr>
               <td>

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
@@ -1,18 +1,12 @@
 {# Bloco X - Manifestações #}
+{% if dados.dados_texto_da_ata.comentarios %}
 <section class="row mt-4">
   <article class="col mb-3 border p-0">
     <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0"><strong>Manifestações</strong></p>
     <div class="col-12">
-      {% if dados.dados_texto_da_ata.comentarios %}
       <p class="font-12 texto-justificado pt-2 pb-2 mb-0">
         {{ dados.dados_texto_da_ata.comentarios|linebreaks }}
       </p>
-      {% else %}
-      <p class="font-12 texto-justificado pt-2 pb-2 mb-0">
-        Não houve manifestações.
-      </p>
-      {% endif %}
-
       {% if dados.dados_da_ata.parecer_conselho == "APROVADA" %}
       <p class="font-12 texto-justificado pb-2 mb-0">
         Os presentes manifestaram que estão de acordo com o PAA apresentado. Sem ressalvas.
@@ -34,4 +28,4 @@
     </div>
   </article>
 </section>
-
+{% endif %}


### PR DESCRIPTION

Esse PR:

- Altera verificação de professor grêmio para ser por receita prevista.
- Apresenta todas as atividades na ata quando uma for alterada.
- Omiti a seção manifestações do documento da ata do paa, quando o campo comentários não estiver preenchido.
- Melhora a exibição do campo de não membros nos documento de elaboração e retificação.

História: [AB#152458](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152458)


