### PR TITLE
feat(151566): Oculta menus fique de olho desnecessários do admin.

### DIFF
--- a/sme_ptrf_apps/core/admin.py
+++ b/sme_ptrf_apps/core/admin.py
@@ -88,7 +88,7 @@ from django.db.models import Count
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 
-admin.site.register(ParametroFiqueDeOlhoPc)
+# admin.site.register(ParametroFiqueDeOlhoPc)
 admin.site.register(ModeloCarga)
 admin.site.register(MotivoRejeicaoEncerramentoContaAssociacao)
 

--- a/sme_ptrf_apps/dre/admin.py
+++ b/sme_ptrf_apps/dre/admin.py
@@ -21,7 +21,7 @@ from .models import (
 )
 from .forms import ComissaoAdminForm
 
-admin.site.register(ParametroFiqueDeOlhoRelDre)
+# admin.site.register(ParametroFiqueDeOlhoRelDre)
 admin.site.register(MotivoAprovacaoRessalva)
 admin.site.register(MotivoReprovacao)
 


### PR DESCRIPTION
Este PR inclui:

- Oculta menus de textos fique de olho desnecessários no painel Admin;
- Validação de testes unitários;

**Obs:** Não foi necessário criar filtro por recurso e tipo de texto na viewset do novo modelo FiqueDeOlho, pois o mesmo já estava implementado.

História: [AB#151566](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151566)
Tarefa: [AB#152026](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152026)