### PR TITLE
fix(153524): corrige exibição e alinhamento da Ata do PAA

### DIFF
--- a/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/services/ata_paa_dados_service.py
@@ -146,7 +146,13 @@ def gerar_dados_ata_paa(ata_paa: AtaPaa, usuario=None) -> dict[str, Any]:
                 _filtrar_itens_atividades_retificadas(atividades_estatutarias)
             )
 
-        numeros_blocos = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+        dados = {
+            "prioridades": prioridades,
+            "atividades_estatutarias": atividades_estatutarias,
+            "manifestacoes": dados_texto_ata.get("manifestacoes", ""),
+        }
+
+        numeros_blocos = calcular_numeros_blocos(dados, is_retificacao)
 
         dados_ata = {
             "cabecalho": cabecalho,
@@ -175,11 +181,15 @@ def gerar_dados_ata_paa(ata_paa: AtaPaa, usuario=None) -> dict[str, Any]:
         raise
 
 
-def calcular_numeros_blocos(prioridades, atividades_estatutarias):
+def calcular_numeros_blocos(dados, is_retificacao):
     """
     Calcula os números dos blocos dinamicamente baseado nos blocos que existem.
     Similar à função nome_blocos do relatório de acertos.
     """
+    prioridades = dados.get('prioridades', [])
+    atividades_estatutarias = dados.get('atividades_estatutarias', [])
+    manifestacoes = dados.get('manifestacoes', "")
+
     numeros = {}
     numero_bloco = 2  # Começa em 2 porque Bloco 1 e 2 são fixos
 
@@ -217,11 +227,20 @@ def calcular_numeros_blocos(prioridades, atividades_estatutarias):
         numero_bloco += 1
         numeros['atividades_estatutarias'] = numero_bloco
 
-    # Bloco de Manifestações (sempre após Atividades Estatutárias)
-    numero_bloco += 1
-    numeros['manifestacoes'] = numero_bloco
+    if is_retificacao:
+        # Bloco de Justificativa da Retificação (sempre após Atividades Estatutárias)
+        numero_bloco += 1
+        numeros['justificativa_retificacao'] = numero_bloco
 
-    # Bloco de Lista de Presença (sempre após Manifestações)
+    if manifestacoes:
+        # Bloco de Manifestações (sempre após Atividades Estatutárias ou Justificativa da Retificação)
+        numero_bloco += 1
+        numeros['manifestacoes'] = numero_bloco
+
+    numero_bloco += 1
+    numeros['parecer_conselho'] = numero_bloco
+
+    # Bloco de Lista de Presença (sempre após Parecer do Conselho)
     numero_bloco += 1
     numeros['lista_presenca'] = numero_bloco
 
@@ -412,6 +431,7 @@ def dados_texto_ata_paa(ata_paa: AtaPaa, usuario=None):
         "comentarios": ata_paa.comentarios,
         "parecer_conselho": ata_paa.parecer_conselho,
         "justificativa": ata_paa.justificativa if ata_paa.justificativa else "",
+        "justificativa_retificacao": ata_paa.justificativa_retificacao if ata_paa.justificativa_retificacao else "",
         "usuario": usuario.username if usuario else "",
         "hora_reuniao": ata_paa.hora_reuniao.strftime('%H:%M') if ata_paa.hora_reuniao else "00:00",
         "hora_reuniao_formatada": formatar_hora_ata(ata_paa.hora_reuniao) if ata_paa.hora_reuniao else "00h00",

--- a/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
+++ b/sme_ptrf_apps/paa/tests/services/test_ata_paa_dados_service.py
@@ -59,15 +59,49 @@ def test_calcular_numeros_blocos_com_todos_blocos():
         {'titulo': 'Prioridades Recursos próprios', 'items': [{'id': 3}]},
     ]
     atividades_estatutarias = [{'id': 1}]
+    is_retificacao = True
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
 
-    resultado = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
 
     assert resultado['ptrf'] == 3
     assert resultado['pdde'] == 4
     assert resultado['recursos_proprios'] == 5
     assert resultado['atividades_estatutarias'] == 6
+    assert resultado['justificativa_retificacao'] == 7
+    assert resultado['manifestacoes'] == 8
+    assert resultado['parecer_conselho'] == 9
+    assert resultado['lista_presenca'] == 10
+
+
+def test_calcular_numeros_blocos_com_todos_blocos_sem_retificacao():
+    prioridades = [
+        {'titulo': 'Prioridades PTRF', 'items': [{'id': 1}]},
+        {'titulo': 'Prioridades PDDE', 'items': [{'id': 2}]},
+        {'titulo': 'Prioridades Recursos próprios', 'items': [{'id': 3}]},
+    ]
+    atividades_estatutarias = [{'id': 1}]
+    is_retificacao = False
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert resultado['ptrf'] == 3
+    assert resultado['pdde'] == 4
+    assert resultado['recursos_proprios'] == 5
+    assert resultado['atividades_estatutarias'] == 6
+    assert 'justificativa_retificacao' not in resultado
     assert resultado['manifestacoes'] == 7
-    assert resultado['lista_presenca'] == 8
+    assert resultado['parecer_conselho'] == 8
+    assert resultado['lista_presenca'] == 9
 
 
 def test_calcular_numeros_blocos_sem_ptrf():
@@ -75,27 +109,87 @@ def test_calcular_numeros_blocos_sem_ptrf():
         {'titulo': 'Prioridades PDDE', 'items': [{'id': 1}]},
     ]
     atividades_estatutarias = []
+    is_retificacao = True
 
-    resultado = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
 
     assert 'ptrf' not in resultado
     assert resultado['pdde'] == 3
+    assert resultado['justificativa_retificacao'] == 4
+    assert resultado['manifestacoes'] == 5
+    assert resultado['parecer_conselho'] == 6
+    assert resultado['lista_presenca'] == 7
+
+
+def test_calcular_numeros_blocos_sem_ptrf_sem_retificacao():
+    prioridades = [
+        {'titulo': 'Prioridades PDDE', 'items': [{'id': 1}]},
+    ]
+    atividades_estatutarias = []
+    is_retificacao = False
+
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert 'ptrf' not in resultado
+    assert resultado['pdde'] == 3
+    assert 'justificativa_retificacao' not in resultado
     assert resultado['manifestacoes'] == 4
-    assert resultado['lista_presenca'] == 5
+    assert resultado['parecer_conselho'] == 5
+    assert resultado['lista_presenca'] == 6
 
 
 def test_calcular_numeros_blocos_sem_prioridades():
     prioridades = []
     atividades_estatutarias = [{'id': 1}]
+    is_retificacao = True
 
-    resultado = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
 
     assert 'ptrf' not in resultado
     assert 'pdde' not in resultado
     assert 'recursos_proprios' not in resultado
     assert resultado['atividades_estatutarias'] == 3
+    assert resultado['justificativa_retificacao'] == 4
+    assert resultado['manifestacoes'] == 5
+    assert resultado['parecer_conselho'] == 6
+    assert resultado['lista_presenca'] == 7
+
+
+def test_calcular_numeros_blocos_sem_prioridades_sem_retificacao():
+    prioridades = []
+    atividades_estatutarias = [{'id': 1}]
+    is_retificacao = False
+
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert 'ptrf' not in resultado
+    assert 'pdde' not in resultado
+    assert 'recursos_proprios' not in resultado
+    assert resultado['atividades_estatutarias'] == 3
+    assert 'justificativa_retificacao' not in resultado
     assert resultado['manifestacoes'] == 4
-    assert resultado['lista_presenca'] == 5
+    assert resultado['parecer_conselho'] == 5
+    assert resultado['lista_presenca'] == 6
 
 
 def test_calcular_numeros_blocos_prioridades_vazias():
@@ -104,22 +198,82 @@ def test_calcular_numeros_blocos_prioridades_vazias():
         {'titulo': 'Prioridades PDDE', 'items': []},
     ]
     atividades_estatutarias = []
+    is_retificacao = True
 
-    resultado = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
 
     assert 'ptrf' not in resultado
     assert 'pdde' not in resultado
+    assert resultado['justificativa_retificacao'] == 3
+    assert resultado['manifestacoes'] == 4
+    assert resultado['parecer_conselho'] == 5
+    assert resultado['lista_presenca'] == 6
+
+
+def test_calcular_numeros_blocos_prioridades_vazias_sem_retificacao():
+    prioridades = [
+        {'titulo': 'Prioridades PTRF', 'items': []},
+        {'titulo': 'Prioridades PDDE', 'items': []},
+    ]
+    atividades_estatutarias = []
+    is_retificacao = False
+
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert 'ptrf' not in resultado
+    assert 'pdde' not in resultado
+    assert 'justificativa_retificacao' not in resultado
     assert resultado['manifestacoes'] == 3
-    assert resultado['lista_presenca'] == 4
+    assert resultado['parecer_conselho'] == 4
+    assert resultado['lista_presenca'] == 5
 
 
 def test_calcular_numeros_blocos_apenas_fixos():
     prioridades = []
     atividades_estatutarias = []
 
-    resultado = calcular_numeros_blocos(prioridades, atividades_estatutarias)
+    is_retificacao = True
 
-    assert resultado['manifestacoes'] == 3
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+        "manifestacoes": "informação testes sobre manifestação",
+    }
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert resultado['justificativa_retificacao'] == 3
+    assert resultado['manifestacoes'] == 4
+    assert resultado['parecer_conselho'] == 5
+    assert resultado['lista_presenca'] == 6
+
+
+def test_calcular_numeros_blocos_apenas_fixos_sem_retificacao():
+    prioridades = []
+    atividades_estatutarias = []
+
+    is_retificacao = False
+
+    dados = {
+        "prioridades": prioridades,
+        "atividades_estatutarias": atividades_estatutarias,
+    }
+
+    resultado = calcular_numeros_blocos(dados, is_retificacao)
+
+    assert 'justificativa_retificacao' not in resultado
+    assert 'manifestacoes' not in resultado
+    assert resultado['parecer_conselho'] == 3
     assert resultado['lista_presenca'] == 4
 
 
@@ -276,7 +430,8 @@ def test_gerar_dados_ata_paa_inclui_numeros_blocos(
 
     assert 'numeros_blocos' in resultado
     assert resultado['numeros_blocos']['ptrf'] == 3
-    assert resultado['numeros_blocos']['manifestacoes'] == 5
+    assert resultado['numeros_blocos']['parecer_conselho'] == 5
+    assert resultado['numeros_blocos']['lista_presenca'] == 6
 
 
 @patch("sme_ptrf_apps.paa.services.ata_paa_dados_service.criar_titulo_introducao", autospec=True)

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-atividades-estatutarias.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-atividades-estatutarias.html
@@ -2,33 +2,35 @@
 {% if dados.atividades_estatutarias|length > 0 %}
 <section class="row mt-4">
   <article class="col mb-3 border p-0">
-    <p class="font-12 texto-justificado pb-2 mb-0">
-        Foi apresentado o seguinte cronograma para as atividades de {{dados.dados_texto_da_ata.datas_limite_periodo_por_extenso}}
-    </p>
-    <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0">
-      <strong>Atividades estatutárias</strong>
-      {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
-    </p>
-    <table class="table tabela-atividades tabela-zebra">
-      <thead>
-        <tr class="tr-titulo">
-          <th scope="col" style="width: 20%">Tipo de Atividades</th>
-          <th scope="col" style="width: 15%">Data</th>
-          <th scope="col" style="width: 45%">Atividades Estatutárias Previstas</th>
-          <th scope="col" style="width: 20%">Mês/Ano</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for atividade in dados.atividades_estatutarias %}
-        <tr>
-          <td>{{ atividade.tipo_atividade }}</td>
-          <td>{{ atividade.data }}</td>
-          <td>{{ atividade.atividades_previstas }}</td>
-          <td>{{ atividade.mes_ano }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="col-12">
+      <p class="font-12 texto-justificado pb-2 mb-0">
+          Foi apresentado o seguinte cronograma para as atividades de {{dados.dados_texto_da_ata.datas_limite_periodo_por_extenso}}
+      </p>
+      <p class="font-14 pt-1 pb-1 border-bottom mb-0">
+        <strong>Atividades estatutárias</strong>
+        {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
+      </p>
+      <table class="table tabela-atividades tabela-zebra">
+        <thead>
+          <tr class="tr-titulo">
+            <th scope="col" style="width: 20%">Tipo de Atividades</th>
+            <th scope="col" style="width: 15%">Data</th>
+            <th scope="col" style="width: 45%">Atividades Estatutárias Previstas</th>
+            <th scope="col" style="width: 20%">Mês/Ano</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for atividade in dados.atividades_estatutarias %}
+          <tr>
+            <td>{{ atividade.tipo_atividade }}</td>
+            <td>{{ atividade.data }}</td>
+            <td>{{ atividade.atividades_previstas }}</td>
+            <td>{{ atividade.mes_ano }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </article>
 </section>
 {% endif %}

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-justificativa_retificacao.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-justificativa_retificacao.html
@@ -1,0 +1,11 @@
+{# Bloco X - Justificativa da Retificação #}
+<section class="row mt-4">
+  <article class="col-12 mb-3 border p-0">
+    <div class="col-12">
+      <p class="font-14 pt-1 pb-1 border-bottom mb-0"><strong>Justificativa da Retificação</strong></p>
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        {{ dados.dados_texto_da_ata.justificativa_retificacao }}
+      </p>
+    </div>
+  </article>
+</section>

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-lista-presenca.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-lista-presenca.html
@@ -2,37 +2,10 @@
 {% if dados.presentes_na_ata.presentes_ata_membros|length > 0 or dados.presentes_na_ata.presentes_ata_nao_membros|length > 0 %}
 <section class="row mt-4">
   <article class="col mb-3 border p-0">
-    <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0"><strong>Lista de presença</strong></p>
-    <div class="p-2">
-      <p class="font-12 mt-3 mb-2 titulo-membros-conselho-fiscal">Membros da Diretoria Executiva e do Conselho Fiscal</p>
-      <table class="table table-bordered tabela-assinaturas">
-        <thead>
-          <tr>
-            <th scope="col">Nome e cargo</th>
-            <th scope="col" style="width: 150px;">Assinatura</th>
-          </tr>
-        </thead>
-        {% for info in dados.presentes_na_ata.presentes_ata_membros %}
-          {% if not info.professor_gremio or info.identificacao %}
-          <tbody>
-          <tr>
-            <td>
-              <p class='mb-0'><strong>{{ info.nome }}</strong></p>
-              <p class='mb-0'>{% if info.professor_gremio %}{{ info.cargo }} - Professor do Grêmio{% else %}{{ info.cargo }}{% endif %}</p>
-            </td>
-            {% if info.presente %}
-              <td style="width: 150px;"></td>
-            {% else %}
-              <td style="width: 150px;">Ausente</td>
-            {% endif %}
-          </tr>
-          </tbody>
-          {% endif %}
-        {% endfor %}
-      </table>
-
-      {% if dados.presentes_na_ata.presentes_ata_nao_membros|length > 0 %}
-        <p class="font-12 mt-4 mb-2 titulo-membros-conselho-fiscal">DEMAIS PRESENTES</p>
+    <div class="col-12">
+      <p class="font-14 pt-1 pb-1 border-bottom mb-0"><strong>Lista de presença</strong></p>
+      <div class="py-2">
+        <p class="font-12 mt-3 mb-2 titulo-membros-conselho-fiscal">Membros da Diretoria Executiva e do Conselho Fiscal</p>
         <table class="table table-bordered tabela-assinaturas">
           <thead>
             <tr>
@@ -40,21 +13,50 @@
               <th scope="col" style="width: 150px;">Assinatura</th>
             </tr>
           </thead>
-          {% for info in dados.presentes_na_ata.presentes_ata_nao_membros %}
-            {% if info.professor_gremio or info.identificacao %}
+          {% for info in dados.presentes_na_ata.presentes_ata_membros %}
+            {% if not info.professor_gremio or info.identificacao %}
             <tbody>
             <tr>
               <td>
                 <p class='mb-0'><strong>{{ info.nome }}</strong></p>
                 <p class='mb-0'>{% if info.professor_gremio %}{{ info.cargo }} - Professor do Grêmio{% else %}{{ info.cargo }}{% endif %}</p>
               </td>
-              <td style="width: 150px;"></td>
+              {% if info.presente %}
+                <td style="width: 150px;"></td>
+              {% else %}
+                <td style="width: 150px;">Ausente</td>
+              {% endif %}
             </tr>
             </tbody>
             {% endif %}
           {% endfor %}
         </table>
-      {% endif %}
+
+        {% if dados.presentes_na_ata.presentes_ata_nao_membros|length > 0 %}
+          <p class="font-12 mt-4 mb-2 titulo-membros-conselho-fiscal">DEMAIS PRESENTES</p>
+          <table class="table table-bordered tabela-assinaturas">
+            <thead>
+              <tr>
+                <th scope="col">Nome e cargo</th>
+                <th scope="col" style="width: 150px;">Assinatura</th>
+              </tr>
+            </thead>
+            {% for info in dados.presentes_na_ata.presentes_ata_nao_membros %}
+              {% if info.professor_gremio or info.identificacao %}
+              <tbody>
+              <tr>
+                <td>
+                  <p class='mb-0'><strong>{{ info.nome }}</strong></p>
+                  <p class='mb-0'>{% if info.professor_gremio %}{{ info.cargo }} - Professor do Grêmio{% else %}{{ info.cargo }}{% endif %}</p>
+                </td>
+                <td style="width: 150px;"></td>
+              </tr>
+              </tbody>
+              {% endif %}
+            {% endfor %}
+          </table>
+        {% endif %}
+      </div>
     </div>
   </article>
 </section>

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-manifestacoes.html
@@ -1,29 +1,11 @@
 {# Bloco X - Manifestações #}
 {% if dados.dados_texto_da_ata.comentarios %}
 <section class="row mt-4">
-  <article class="col mb-3 border p-0">
-    <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0"><strong>Manifestações</strong></p>
+  <article class="col-12 mb-3 border p-0">
     <div class="col-12">
-      <p class="font-12 texto-justificado pt-2 pb-2 mb-0">
+      <p class="font-14 pt-1 pb-1 border-bottom mb-0"><strong>Manifestações</strong></p>
+      <p class="font-12 texto-justificado pb-2 mb-0">
         {{ dados.dados_texto_da_ata.comentarios|linebreaks }}
-      </p>
-      {% if dados.dados_da_ata.parecer_conselho == "APROVADA" %}
-      <p class="font-12 texto-justificado pb-2 mb-0">
-        Os presentes manifestaram que estão de acordo com o PAA apresentado. Sem ressalvas.
-      </p>
-      <p class="font-12 texto-justificado pb-2 mb-0">
-        <strong>Diante ao exposto, o Plano Anual de Atividades foi aprovado. Os presentes concordaram com o PAA apresentado.</strong>
-      </p>
-      {% elif dados.dados_da_ata.parecer_conselho == "REJEITADA" %}
-      <p class="font-12 texto-justificado pb-2 mb-0">
-        <strong>Diante ao exposto, o Plano Anual de Atividades foi reprovado. Os presentes não concordaram com o PAA apresentado.</strong>
-        {% if dados.dados_texto_da_ata.justificativa %}
-        {{ dados.dados_texto_da_ata.justificativa|linebreaks }}
-        {% endif %}
-      </p>
-      {% endif %}
-      <p class="font-12 texto-justificado pb-2 mb-0">
-        Esgotados os assuntos, o (a) senhor (a) presidente ofereceu a palavra a quem dela desejasse fazer uso e, como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual eu, {{ dados.dados_da_ata.secretario_reuniao }} lavrei a presente ata, que vai por mim assinada.
       </p>
     </div>
   </article>

--- a/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-parecer-conselho.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/partials/bloco-parecer-conselho.html
@@ -1,0 +1,27 @@
+{# Bloco X - Manifestações #}
+{% if dados.dados_texto_da_ata.parecer_conselho %}
+<section class="row mt-4">
+  <article class="col-12 mb-3 border p-0">
+    <div class="col-12">
+      {% if dados.dados_da_ata.parecer_conselho == "APROVADA" %}
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        Os presentes manifestaram que estão de acordo com o PAA apresentado. Sem ressalvas.
+      </p>
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        <strong>Diante ao exposto, o Plano Anual de Atividades foi aprovado. Os presentes concordaram com o PAA apresentado.</strong>
+      </p>
+      {% elif dados.dados_da_ata.parecer_conselho == "REJEITADA" %}
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        <strong>Diante ao exposto, o Plano Anual de Atividades foi reprovado. Os presentes não concordaram com o PAA apresentado.</strong>
+        {% if dados.dados_texto_da_ata.justificativa %}
+        {{ dados.dados_texto_da_ata.justificativa|linebreaks }}
+        {% endif %}
+      </p>
+      {% endif %}
+      <p class="font-12 texto-justificado pb-2 mb-0">
+        Esgotados os assuntos, o (a) senhor (a) presidente ofereceu a palavra a quem dela desejasse fazer uso e, como não houve manifestação, agradeceu a presença de todos e considerou encerrada a reunião, a qual eu, {{ dados.dados_da_ata.secretario_reuniao }} lavrei a presente ata, que vai por mim assinada.
+      </p>
+    </div>
+  </article>
+</section>
+{% endif %}

--- a/sme_ptrf_apps/templates/pdf/ata_paa/pdf.html
+++ b/sme_ptrf_apps/templates/pdf/ata_paa/pdf.html
@@ -89,11 +89,13 @@
       {% if not dados.is_retificacao or dados.retificado_prioridades_ptrf %}
         <section class="row mt-4">
           <article class="col mb-3 border p-0">
-            <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0">
-              <strong>{{ grupo.titulo }}</strong>
-              {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
-            </p>
-            {% include "./partials/tabela-prioridades.html" %}
+            <div class="col-12">
+              <p class="font-14 pt-1 pb-1 border-bottom mb-0">
+                <strong>{{ grupo.titulo }}</strong>
+                {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
+              </p>
+              {% include "./partials/tabela-prioridades.html" %}
+            </div>
           </article>
         </section>
       {% endif %}
@@ -106,11 +108,13 @@
       {% if not dados.is_retificacao or dados.retificado_prioridades_pdde %}
         <section class="row mt-4">
           <article class="col mb-3 border p-0">
-            <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0">
+            <div class="col-12">
+            <p class="font-14 pt-1 pb-1 border-bottom mb-0">
               <strong>{{ grupo.titulo }}</strong>
               {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
             </p>
             {% include "./partials/tabela-prioridades.html" %}
+            </div>
           </article>
         </section>
       {% endif %}
@@ -123,11 +127,13 @@
       {% if not dados.is_retificacao or dados.retificado_prioridades_outros %}
         <section class="row mt-4">
           <article class="col mb-3 border p-0">
-            <p class="font-14 pt-1 pb-1 pl-2 border-bottom mb-0">
-              <strong>{{ grupo.titulo }}</strong>
-              {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
-            </p>
-            {% include "./partials/tabela-prioridades.html" %}
+            <div class="col-12">
+              <p class="font-14 pt-1 pb-1 border-bottom mb-0">
+                <strong>{{ grupo.titulo }}</strong>
+                {% if dados.is_retificacao and dados.etiqueta_retificacao %}<span class="tag-retificacao">{{ dados.etiqueta_retificacao }}</span>{% endif %}
+              </p>
+              {% include "./partials/tabela-prioridades.html" %}
+            </div>
           </article>
         </section>
       {% endif %}
@@ -139,8 +145,16 @@
     {% include "./partials/bloco-atividades-estatutarias.html" with numero_bloco=dados.numeros_blocos.atividades_estatutarias %}
   {% endif %}
 
+  {# Bloco Justificativa da retificação #}
+  {% if dados.is_retificacao and dados.dados_texto_da_ata.justificativa_retificacao %}
+    {% include "./partials/bloco-justificativa_retificacao.html" with numero_bloco=dados.numeros_blocos.justificativa_retificacao %}
+  {% endif %}
+
   {# Bloco de Manifestações #}
   {% include "./partials/bloco-manifestacoes.html" with numero_bloco=dados.numeros_blocos.manifestacoes %}
+
+  {# Bloco de Parecer do Conselho #}
+  {% include "./partials/bloco-parecer-conselho.html" with numero_bloco=dados.numeros_blocos.parecer_conselho %}
 
   {# Bloco de Lista de Presença #}
   {% include "./partials/bloco-lista-presenca.html" with numero_bloco=dados.numeros_blocos.lista_presenca %}


### PR DESCRIPTION

Esse PR:

- Adiciona justificativa da retificação na ata do PAA
- Corrige alinhamento da ata do PAA
- Separa parecer do conselho em bloco separado de manifestações na ata do PAA
- Corrige exibição de manifestações na ata do PAA

História: [AB#153524](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/153524)

