### PR TITLE
Feature/154063 separa associacao recurso parametrizacao

### DIFF
--- a/sme_ptrf_apps/core/api/serializers/__init__.py
+++ b/sme_ptrf_apps/core/api/serializers/__init__.py
@@ -68,3 +68,4 @@ from .motivo_rejeicao_encerramento_conta_associacao_serializer import (
 from .prestacao_conta_reprovada_nao_apresentacao_serializer import PrestacaoContaReprovadaNaoApresentacaoSerializer
 from .acao_serializer import AcaoSerializer
 from .fique_de_olho_serializer import FiqueDeOlhoSerializer
+from .periodo_inicial_associacao_serializer import SimplePeriodoInicialAssociacaoSerializer

--- a/sme_ptrf_apps/core/api/serializers/associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/associacao_serializer.py
@@ -2,9 +2,11 @@ from rest_framework import serializers
 from sme_ptrf_apps.core.api.serializers.recurso_serializer import RecursoSerializer
 from sme_ptrf_apps.utils.update_instance_from_dict import update_instance_from_dict
 from ...api.serializers.unidade_serializer import (UnidadeInfoAtaSerializer, UnidadeLookUpSerializer,
-                                                   UnidadeListEmAssociacoesSerializer, UnidadeSerializer, UnidadeCreateSerializer)
+                                                   UnidadeListEmAssociacoesSerializer, UnidadeSerializer,
+                                                   UnidadeCreateSerializer)
 from ...api.serializers.periodo_serializer import PeriodoLookUpSerializer
-from ...models import Associacao, Unidade, Periodo
+from ...api.serializers.periodo_inicial_associacao_serializer import SimplePeriodoInicialAssociacaoSerializer
+from ...models import Associacao, Unidade, Periodo, PeriodoInicialAssociacao
 
 
 class AssociacaoSerializer(serializers.ModelSerializer):
@@ -52,12 +54,17 @@ class AssociacaoCreateSerializer(serializers.ModelSerializer):
         allow_empty=True,
     )
 
+    periodos_iniciais = serializers.ListField(
+        child=SimplePeriodoInicialAssociacaoSerializer(), required=True, write_only=True
+    )
+
     class Meta:
         model = Associacao
         fields = '__all__'
 
     def create(self, validated_data):
         unidade = validated_data.pop('unidade')
+        periodos_iniciais = validated_data.pop('periodos_iniciais', [])
         observacao = ""
 
         if "unidade__observacao" in validated_data:
@@ -66,13 +73,15 @@ class AssociacaoCreateSerializer(serializers.ModelSerializer):
         if not unidade.get('nome_dre'):
             raise serializers.ValidationError({"nome_dre": ["EOL informado não possui DRE."]})
 
-        
         associacao = Associacao.objects.create(**validated_data)
         unidade['observacao'] = observacao
-        
+
         unidade_object = UnidadeCreateSerializer().create(unidade)
         associacao.unidade = unidade_object
         associacao.save()
+
+        for periodo_inicial in periodos_iniciais:
+            associacao.periodos_iniciais.create(**periodo_inicial)
 
         return associacao
 
@@ -92,12 +101,16 @@ class AssociacaoUpdateSerializer(serializers.ModelSerializer):
         allow_null=True,
         allow_empty=True,
     )
+    periodos_iniciais = serializers.ListField(
+        child=SimplePeriodoInicialAssociacaoSerializer(), required=True, write_only=True
+    )
 
     class Meta:
         model = Associacao
         fields = '__all__'
 
     def update(self, instance, validated_data):
+        periodos_iniciais = validated_data.pop('periodos_iniciais', [])
         observacao = ""
 
         if validated_data.get("unidade__observacao"):
@@ -106,10 +119,39 @@ class AssociacaoUpdateSerializer(serializers.ModelSerializer):
         instance.unidade.observacao = observacao
         instance.unidade.save()
 
-        update_instance_from_dict(instance, validated_data)
+        if instance.pode_editar_dados_associacao_encerrada:
+            update_instance_from_dict(instance, validated_data)
+
         instance.save()
 
+        if instance.pode_editar_dados_associacao_encerrada and \
+                instance.pode_editar_periodo_inicial['pode_editar_periodo_inicial'] and \
+                len(periodos_iniciais) > 0:
+            periodos_iniciais_list = []
+
+            for periodo_inicial in periodos_iniciais:
+                uuid = periodo_inicial.pop('uuid', None)
+
+                periodo_inicial_obj = None
+
+                if uuid:
+                    periodo_inicial_obj = instance.periodos_iniciais.filter(uuid=uuid).first()
+                    if periodo_inicial_obj:
+                        update_instance_from_dict(periodo_inicial_obj, periodo_inicial)
+                        periodo_inicial_obj.save()
+                else:
+                    periodo_inicial_obj = instance.periodos_iniciais.create(**periodo_inicial)
+
+                periodos_iniciais_list.append(periodo_inicial_obj)
+
+            periodos_iniciais_a_remover = PeriodoInicialAssociacao.objects.exclude(
+                id__in=[d.id for d in periodos_iniciais_list]
+            ).filter(associacao=instance)
+
+            periodos_iniciais_a_remover.delete()
+
         return instance
+
 
 class AssociacaoInfoAtaSerializer(serializers.ModelSerializer):
     unidade = UnidadeInfoAtaSerializer(many=False)
@@ -128,6 +170,7 @@ class AssociacaoListSerializer(serializers.ModelSerializer):
     unidade = UnidadeListEmAssociacoesSerializer(many=False)
     encerrada = serializers.SerializerMethodField('get_encerrada')
     status_valores_reprogramados = serializers.SerializerMethodField('get_status_valores_reprogramados')
+    recursos = serializers.SerializerMethodField('get_recursos_da_associacao', required=False)
 
     informacoes = serializers.SerializerMethodField(method_name='get_informacoes', required=False)
 
@@ -142,6 +185,14 @@ class AssociacaoListSerializer(serializers.ModelSerializer):
         recurso = getattr(request, "recurso", None) if request else None
         return obj.get_status_valores_reprogramados(recurso=recurso)
 
+    def get_recursos_da_associacao(self, obj):
+        recursos = ""
+
+        for periodo_inicial in obj.periodos_iniciais.all():
+            recursos += f"{periodo_inicial.recurso.nome};"
+
+        return recursos
+
     class Meta:
         model = Associacao
         fields = [
@@ -154,14 +205,15 @@ class AssociacaoListSerializer(serializers.ModelSerializer):
             'tooltip_encerramento_conta',
             'unidade',
             'encerrada',
-            'informacoes'
+            'informacoes',
+            'recursos'
         ]
 
 
 class AssociacaoCompletoSerializer(serializers.ModelSerializer):
     unidade = UnidadeSerializer(many=False)
     periodo_inicial = PeriodoLookUpSerializer()
-
+    periodos_iniciais = SimplePeriodoInicialAssociacaoSerializer(many=True, read_only=True)
     data_de_encerramento = serializers.SerializerMethodField('get_data_de_encerramento')
     recursos_da_associacao = serializers.SerializerMethodField('get_recursos_da_associacao')
 
@@ -172,14 +224,14 @@ class AssociacaoCompletoSerializer(serializers.ModelSerializer):
             "pode_editar_dados_associacao_encerrada": obj.pode_editar_dados_associacao_encerrada
         }
         return response
-    
+
     def get_recursos_da_associacao(self, obj):
         recursos = set()
         for periodo_inicial in obj.periodos_iniciais.all():
             recursos.add(periodo_inicial.recurso)
- 
+
         response = RecursoSerializer(recursos, many=True).data
- 
+
         return response
 
     class Meta:
@@ -198,5 +250,6 @@ class AssociacaoCompletoSerializer(serializers.ModelSerializer):
             'data_de_encerramento',
             'id',
             'pode_editar_periodo_inicial',
-            'recursos_da_associacao'
+            'recursos_da_associacao',
+            'periodos_iniciais'
         ]

--- a/sme_ptrf_apps/core/api/serializers/periodo_inicial_associacao_serializer.py
+++ b/sme_ptrf_apps/core/api/serializers/periodo_inicial_associacao_serializer.py
@@ -1,0 +1,52 @@
+from rest_framework import serializers
+from sme_ptrf_apps.core.models import Periodo, PeriodoInicialAssociacao, Recurso
+from sme_ptrf_apps.core.api.serializers.periodo_serializer import PeriodoSerializer
+
+
+class SimplePeriodoInicialAssociacaoSerializer(serializers.ModelSerializer):
+    uuid = serializers.CharField(allow_blank=True, required=False)
+
+    periodo_inicial = serializers.SlugRelatedField(
+        slug_field='uuid',
+        required=False,
+        queryset=Periodo.objects.all(),
+    )
+
+    recurso = serializers.SlugRelatedField(
+        slug_field='uuid',
+        required=False,
+        queryset=Recurso.objects.all(),
+    )
+
+    status_valores_reprogramados = serializers.ChoiceField(
+        choices=PeriodoInicialAssociacao.STATUS_VALORES_REPROGRAMADOS_CHOICES,
+        required=False,
+    )
+
+    periodos_disponiveis = serializers.SerializerMethodField('get_periodos_disponiveis')
+
+    def get_periodos_disponiveis(self, obj):
+        periodos_disponiveis = Periodo.objects.filter(recurso=obj.recurso)
+
+        return PeriodoSerializer(periodos_disponiveis, many=True).data
+
+    class Meta:
+        model = PeriodoInicialAssociacao
+        fields = (
+            'uuid',
+            'periodo_inicial',
+            'recurso',
+            'status_valores_reprogramados',
+            'periodos_disponiveis',
+        )
+
+    def validate(self, attrs):
+        periodo_inicial = attrs.get('periodo_inicial')
+        recurso = attrs.get('recurso')
+
+        if periodo_inicial and recurso and periodo_inicial.recurso_id != recurso.id:
+            raise serializers.ValidationError({
+                'periodo_inicial': 'Período deve pertencer ao recurso selecionado.'
+            })
+
+        return attrs

--- a/sme_ptrf_apps/core/api/views/associacoes_viewset.py
+++ b/sme_ptrf_apps/core/api/views/associacoes_viewset.py
@@ -35,7 +35,7 @@ from ....dre.services import (
     atualiza_itens_verificacao,
 )
 from ...models import Associacao, ContaAssociacao, Periodo, PrestacaoConta, Unidade, Ata, AnalisePrestacaoConta, \
-    FechamentoPeriodo, Recurso
+    FechamentoPeriodo, Recurso, PeriodoInicialAssociacao
 from ...services import (
     atualiza_dados_unidade,
     gerar_planilha,
@@ -105,12 +105,16 @@ class AssociacoesViewSet(ModelViewSet):
 
         try:
             self.perform_destroy(obj)
-        except ProtectedError:
-            content = {
-                'erro': 'ProtectedError',
-                'mensagem': 'Não é possível excluir essa associação porque ela já possui movimentação (despesas, receitas, etc.)'
-            }
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+        except ProtectedError as e:
+            obj_protected = list(e.protected_objects)[0]
+            isnot_periodo_inicial_associacao = not isinstance(obj_protected, PeriodoInicialAssociacao)
+
+            if len(e.protected_objects) > 1 or isnot_periodo_inicial_associacao:
+                content = {
+                    'erro': 'ProtectedError',
+                    'mensagem': 'Não é possível excluir essa associação porque ela já possui movimentação (despesas, receitas, etc.)'
+                }
+                return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -703,6 +707,33 @@ class AssociacoesViewSet(ModelViewSet):
         result = consulta_unidade(codigo_eol)
         status_code = status.HTTP_400_BAD_REQUEST if 'erro' in result.keys() else status.HTTP_200_OK
         return Response(result, status=status_code)
+
+    @action(detail=False, methods=['get'], url_path='verifica-cnpj-existente',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def verifica_cnpj_existente(self, request):
+        cnpj = self.request.query_params.get('cnpj')
+        associacao = Associacao.objects.filter(cnpj=cnpj).first()
+        result = None
+
+        if associacao:
+            result = {
+                'erro': 'cnpj_existente',
+                'mensagem': f"O CNPJ {cnpj} já está cadastrado na base."
+            }
+
+        status_code = status.HTTP_409_CONFLICT if result else status.HTTP_200_OK
+        return Response(result, status=status_code)
+
+    @action(detail=False, methods=['get'], url_path='opcoes-status-valores-reprogramados',
+            permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])
+    def opcoes_status_valores_reprogramados(self, request):
+        result = [
+            {'key': key, 'value': value}
+            for key, value
+            in PeriodoInicialAssociacao.STATUS_VALORES_REPROGRAMADOS_CHOICES
+        ]
+
+        return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=True, url_path='status-presidente', methods=['get'],
             permission_classes=[IsAuthenticated & PermissaoAPITodosComLeituraOuGravacao])

--- a/sme_ptrf_apps/core/api/views/parametrizacoes_associacoes.py
+++ b/sme_ptrf_apps/core/api/views/parametrizacoes_associacoes.py
@@ -4,7 +4,7 @@ from sme_ptrf_apps.users.permissoes import (
     PermissaoApiUe,
 )
 
-from sme_ptrf_apps.core.models import Associacao
+from sme_ptrf_apps.core.models import Associacao, Recurso
 from django_filters import rest_framework as filters
 from django.db.models import Q
 from rest_framework.filters import SearchFilter
@@ -31,6 +31,13 @@ class ParametrizacoesAssociacoesViewSet(mixins.ListModelMixin, GenericViewSet):
 
     def get_queryset(self):
         qs = Associacao.objects.all().order_by('unidade__tipo_unidade', 'unidade__nome')
+
+        recurso_uuid = self.request.query_params.get('recurso_uuid')
+        if recurso_uuid is not None and recurso_uuid != "":
+            recurso = Recurso.objects.filter(uuid=recurso_uuid).first()
+
+            if recurso:
+                qs = qs.filter(Q(periodos_iniciais__recurso=recurso))
 
         uuid_dre = self.request.query_params.get('unidade__dre__uuid')
         if uuid_dre is not None and uuid_dre != "":

--- a/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes/test_acoes_list_associacoes_nao_vinculadas.py
@@ -35,7 +35,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas(jwt_authenticated_client_a,
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         }
     ]
 
@@ -73,7 +74,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_encerradas_e_nao_encerradas(j
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
         {
             'uuid': f'{associacao_eco_delta_000088.uuid}',
@@ -90,7 +92,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_encerradas_e_nao_encerradas(j
                 'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000088.cnpj
+            'cnpj': associacao_eco_delta_000088.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -126,7 +129,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_somente_nao_encerradas(jwt_au
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -162,7 +166,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_somente_encerradas(jwt_authen
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -197,7 +202,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome(jwt_authenticated_cl
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -233,7 +239,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_encerradas_e_nao_e
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
         {
             'uuid': f'{associacao_eco_delta_000088.uuid}',
@@ -250,7 +257,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_encerradas_e_nao_e
                 'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000088.cnpj
+            'cnpj': associacao_eco_delta_000088.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -286,7 +294,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_somente_nao_encerr
                 'nome_com_tipo': associacao_eco_delta_000087.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000087.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000087.cnpj
+            'cnpj': associacao_eco_delta_000087.cnpj,
+            'recursos': '',
         },
     ]
 
@@ -322,7 +331,8 @@ def test_api_acoes_list_associacoes_nao_vinculadas_por_nome_e_somente_encerradas
                 'nome_com_tipo': associacao_eco_delta_000088.unidade.nome_com_tipo,
                 'nome_dre': associacao_eco_delta_000088.unidade.nome_dre
             },
-            'cnpj': associacao_eco_delta_000088.cnpj
+            'cnpj': associacao_eco_delta_000088.cnpj,
+            'recursos': '',
         },
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acao_associacao_retrieve.py
@@ -41,7 +41,8 @@ def test_retrieve_acao_associacao(
                 'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                 'nome_dre': acao_associacao.associacao.unidade.nome_dre
             },
-            'cnpj': acao_associacao.associacao.cnpj
+            'cnpj': acao_associacao.associacao.cnpj,
+            'recursos': '',
         },
         'data_de_encerramento_associacao': None,
         'tooltip_associacao_encerrada': None,

--- a/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
+++ b/sme_ptrf_apps/core/tests/tests_api_acoes_associacoes/test_acoes_associacoes_list.py
@@ -47,7 +47,8 @@ def test_api_list_acoes_associacoes_todas(
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -113,7 +114,8 @@ def test_api_list_associacoes_pelo_nome_associacao(jwt_authenticated_client_a,
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -178,7 +180,8 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a,
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -242,7 +245,8 @@ def test_api_list_associacoes_pelo_eol_escola(jwt_authenticated_client_a,
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -308,7 +312,8 @@ def test_api_list_associacoes_por_acao(jwt_authenticated_client_a,
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -375,7 +380,8 @@ def test_api_list_associacoes_por_status(jwt_authenticated_client_a,
                         'nome_com_tipo': acao_associacao.associacao.unidade.nome_com_tipo,
                         'nome_dre': acao_associacao.associacao.unidade.nome_dre
                     },
-                    'cnpj': acao_associacao.associacao.cnpj
+                    'cnpj': acao_associacao.associacao.cnpj,
+                    'recursos': '',
                 },
                 'data_de_encerramento_associacao': None,
                 'tooltip_associacao_encerrada': None,
@@ -437,7 +443,8 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
                     'nome_com_tipo': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_com_tipo,
                     'nome_dre': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_dre
                 },
-                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj
+                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj,
+                'recursos': '',
             },
             'data_de_encerramento_associacao': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),  # noqa
             'tooltip_associacao_encerrada': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
@@ -482,7 +489,8 @@ def test_api_list_associacoes_por_associacoes_encerradas_e_nao_encerradas(jwt_au
                     'nome_com_tipo': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_com_tipo,
                     'nome_dre': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_dre
                 },
-                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj
+                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj,
+                'recursos': '',
             },
             'data_de_encerramento_associacao': None,
             'tooltip_associacao_encerrada': None,
@@ -543,7 +551,8 @@ def test_api_list_associacoes_por_associacoes_somente_encerradas(jwt_authenticat
                     'nome_com_tipo': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_com_tipo,
                     'nome_dre': acao_associacao_charli_bingo_000086_x.associacao.unidade.nome_dre
                 },
-                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj
+                'cnpj': acao_associacao_charli_bingo_000086_x.associacao.cnpj,
+                'recursos': '',
             },
             'data_de_encerramento_associacao': acao_associacao_charli_bingo_000086_x.associacao.data_de_encerramento.strftime("%Y-%m-%d"),  # noqa
             'tooltip_associacao_encerrada': acao_associacao_charli_bingo_000086_x.associacao.tooltip_data_encerramento,
@@ -604,7 +613,8 @@ def test_api_list_associacoes_por_associacoes_somente_nao_encerradas(jwt_authent
                     'nome_com_tipo': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_com_tipo,
                     'nome_dre': acao_associacao_charli_bravo_000086_x.associacao.unidade.nome_dre
                 },
-                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj
+                'cnpj': acao_associacao_charli_bravo_000086_x.associacao.cnpj,
+                'recursos': '',
             },
             'data_de_encerramento_associacao': None,
             'tooltip_associacao_encerrada': None,

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes.py
@@ -80,6 +80,7 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
+            'recursos': '',
         },
         {
             'uuid': f'{associacao_pinheiros_emef_mendes_dre_2.uuid}',
@@ -97,6 +98,7 @@ def test_api_list_associacoes_todas(jwt_authenticated_client_a, associacao_valen
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_pinheiros_emef_mendes_dre_2.tags_de_informacao,
+            'recursos': '',
         },
     ]
 
@@ -128,7 +130,7 @@ def test_api_list_associacoes_de_uma_dre(jwt_authenticated_client_a, associacao_
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
-
+            'recursos': '',
         },
     ]
 
@@ -158,6 +160,7 @@ def test_api_list_associacoes_pelo_nome_associacao_ignorando_acentos(jwt_authent
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
+            'recursos': '',
         },
     ]
 
@@ -187,6 +190,7 @@ def test_api_list_associacoes_pelo_nome_escola(jwt_authenticated_client_a, assoc
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
+            'recursos': '',
         },
     ]
 
@@ -216,6 +220,7 @@ def test_api_list_associacoes_pelo_tipo_unidade(jwt_authenticated_client_a, asso
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
+            'recursos': '',
         },
     ]
 
@@ -245,6 +250,7 @@ def test_api_list_associacoes_pelo_codigo_eol(jwt_authenticated_client_a, associ
             'tooltip_encerramento_conta': None,
             'encerrada': False,
             'informacoes': associacao_valenca_ceu_vassouras_dre_1.tags_de_informacao,
+            'recursos': '',
         },
     ]
 
@@ -278,6 +284,7 @@ def test_api_list_associacoes_filtro_somente_encerradas(
             'tooltip_encerramento_conta': None,
             'encerrada': True,
             'informacoes': associacao_encerrada_2020_1.tags_de_informacao,
+            'recursos': '',
         },
         {
             'uuid': f'{associacao_encerrada_2020_2.uuid}',
@@ -295,6 +302,7 @@ def test_api_list_associacoes_filtro_somente_encerradas(
             'tooltip_encerramento_conta': None,
             'encerrada': True,
             'informacoes': associacao_encerrada_2020_2.tags_de_informacao,
+            'recursos': '',
         },
     ]
 

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes_status_regularidade_ano.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_list_associacoes_status_regularidade_ano.py
@@ -116,6 +116,7 @@ def test_api_list_status_associacoes_dre_1(
                     'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
                 },
                 'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
+                'recursos': '',
             },
             'status_regularidade': 'REGULAR',
             'motivo': '',
@@ -158,6 +159,7 @@ def test_api_list_status_associacoes_pelo_nome_associacao_ignorando_acentos(
                     'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
                 },
                 'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
+                'recursos': '',
             },
             'status_regularidade': 'REGULAR',
             'motivo': ''
@@ -199,6 +201,7 @@ def test_api_list_status_associacoes_pelo_nome_escola(
                     'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
                 },
                 'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
+                'recursos': '',
             },
             'status_regularidade': 'REGULAR',
             'motivo': ''
@@ -223,7 +226,6 @@ def test_api_list_status_associacoes_pelo_tipo_unidade(
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
     result = json.loads(response.content)
 
-
     result_esperado = [
         {
             'associacao': {
@@ -242,6 +244,7 @@ def test_api_list_status_associacoes_pelo_tipo_unidade(
                     'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
                 },
                 'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
+                'recursos': '',
             },
             'status_regularidade': 'REGULAR',
             'motivo': ''
@@ -265,7 +268,6 @@ def test_api_list_status_associacoes_pelo_status(
     response = jwt_authenticated_client_a.get(url, content_type='application/json')
     result = json.loads(response.content)
 
-
     result_esperado = [
         {
             'associacao': {
@@ -284,6 +286,7 @@ def test_api_list_status_associacoes_pelo_status(
                     'nome_dre': associacao_valenca_ceu_vassouras_dre_1.unidade.nome_dre
                 },
                 'cnpj': associacao_valenca_ceu_vassouras_dre_1.cnpj,
+                'recursos': '',
             },
             'status_regularidade': 'REGULAR',
             'motivo': ''

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_post_associacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_post_associacao.py
@@ -29,10 +29,15 @@ def test_api_post_associacao(jwt_authenticated_client_a, periodo_anterior):
             'bairro': 'Ferreira',
             'cep': '05524160',
             'nome_dre': 'DRE Existente 1'
-        }
+        },
+        'periodos_iniciais': [{
+            'periodo_inicial': str(periodo_anterior.uuid),
+            'recurso': str(periodo_anterior.recurso.uuid),
+            'status_valores_reprogramados': 'VALORES_CORRETOS'
+        }]
     }
     response = jwt_authenticated_client_a.post(f'/api/associacoes/', data=json.dumps(payload),
-                          content_type='application/json')
+                                               content_type='application/json')
 
     registro_alterado = Associacao.objects.first()
 
@@ -65,7 +70,13 @@ def test_api_post_associacao_deve_gerar_erro_data_de_encerramento_maior_que_peri
                 'bairro': 'Ferreira',
                 'cep': '05524160',
                 'nome_dre': 'DRE Existente 2'
-            }
+            },
+            'periodos_iniciais': [{
+                'uuid': '',
+                'periodo_inicial': str(periodo_anterior.uuid),
+                'recurso': str(periodo_anterior.recurso.uuid),
+                'status_valores_reprogramados': 'VALORES_CORRETOS'
+            }]
         }
         response = jwt_authenticated_client_a.post(f'/api/associacoes/', data=json.dumps(payload),
                                                    content_type='application/json')
@@ -99,7 +110,13 @@ def test_api_post_associacao_deve_gerar_erro_data_de_encerramento_maior_que_data
                 'bairro': 'Ferreira',
                 'cep': '05524160',
                 'nome_dre': 'DRE Existente 3'
-            }
+            },
+            "periodos_iniciais": [{
+                'uuid': '',
+                'periodo_inicial': str(periodo_anterior.uuid),
+                'recurso': str(periodo_anterior.recurso.uuid),
+                'status_valores_reprogramados': 'VALORES_CORRETOS'
+            }]
         }
         response = jwt_authenticated_client_a.post(f'/api/associacoes/', data=json.dumps(payload),
                                                    content_type='application/json')
@@ -133,7 +150,13 @@ def test_api_post_associacao_deve_gerar_erro_cnpj_invalido(
             'bairro': 'Ferreira',
             'cep': '05524160',
             'nome_dre': 'DRE Existente 4'
-        }
+        },
+        "periodos_iniciais": [{
+            'uuid': '',
+            'periodo_inicial': str(periodo_anterior.uuid),
+            'recurso': str(periodo_anterior.recurso.uuid),
+            'status_valores_reprogramados': 'VALORES_CORRETOS'
+        }]
     }
     response = jwt_authenticated_client_a.post(f'/api/associacoes/', data=json.dumps(payload),
                                                content_type='application/json')

--- a/sme_ptrf_apps/core/tests/tests_api_associacoes/test_update_associacao.py
+++ b/sme_ptrf_apps/core/tests/tests_api_associacoes/test_update_associacao.py
@@ -13,10 +13,16 @@ pytestmark = pytest.mark.django_db
 def test_api_update_associacao(jwt_authenticated_client_a, associacao):
     payload = {
         "nome": "Nome alterado",
-        "processo_regularidade": "123456"
+        "processo_regularidade": "123456",
+        "periodos_iniciais": [{
+            'uuid': '12345678-1234-1234-1234-123456789012',
+            'periodo': str(associacao.periodo_inicial.uuid),
+            'recurso': str(associacao.periodo_inicial.recurso.uuid),
+            'valores_reprogramados': 'VALORES_CORRETOS'
+        }],
     }
     response = jwt_authenticated_client_a.put(f'/api/associacoes/{associacao.uuid}/', data=json.dumps(payload),
-                          content_type='application/json')
+                                              content_type='application/json')
 
     registro_alterado = Associacao.objects.get(uuid=associacao.uuid)
 
@@ -36,6 +42,12 @@ def test_api_update_associacao_deve_gerar_erro_data_de_encerramento_maior_que_pe
             "processo_regularidade": "123456",
             "periodo_inicial": str(periodo_anterior.uuid),
             "data_de_encerramento": "2019-08-29",
+            "periodos_iniciais": [{
+                'uuid': '12345678-1234-1234-1234-123456789012',
+                'periodo': str(periodo_anterior.uuid),
+                'recurso': str(periodo_anterior.recurso.uuid),
+                'valores_reprogramados': 'VALORES_CORRETOS'
+            }],
         }
         response = jwt_authenticated_client_a.put(f'/api/associacoes/{associacao.uuid}/', data=json.dumps(payload),
                               content_type='application/json')
@@ -57,6 +69,12 @@ def test_api_update_associacao_deve_gerar_erro_data_de_encerramento_maior_que_da
             "processo_regularidade": "123456",
             "periodo_inicial": str(periodo_anterior.uuid),
             "data_de_encerramento": "2023-04-19",
+            "periodos_iniciais": [{
+                'uuid': '12345678-1234-1234-1234-123456789012',
+                'periodo': str(periodo_anterior.uuid),
+                'recurso': str(periodo_anterior.recurso.uuid),
+                'valores_reprogramados': 'VALORES_CORRETOS'
+            }],
         }
         response = jwt_authenticated_client_a.put(f'/api/associacoes/{associacao.uuid}/', data=json.dumps(payload),
                               content_type='application/json')
@@ -71,6 +89,12 @@ def test_api_update_associacao_erro_cnpj_invalido(jwt_authenticated_client_a, as
         "nome": "Nome alterado",
         "processo_regularidade": "123456",
         "cnpj": '52.302.275/0001-82',
+        "periodos_iniciais": [{
+            'uuid': '12345678-1234-1234-1234-123456789012',
+            'periodo': str(associacao.periodo_inicial.uuid),
+            'recurso': str(associacao.periodo_inicial.recurso.uuid),
+            'valores_reprogramados': 'VALORES_CORRETOS'
+        }],
     }
     response = jwt_authenticated_client_a.put(f'/api/associacoes/{associacao.uuid}/', data=json.dumps(payload),
                           content_type='application/json')

--- a/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_serializer.py
+++ b/sme_ptrf_apps/core/tests/tests_associacao/test_associacao_serializer.py
@@ -77,7 +77,8 @@ def test_associacao_create_serializer_sem_nome_dre():
             'cep': '01001000',
             'tipo_unidade': 'EMEF',
             'observacao': 'Unidade gerada para teste',
-        }
+        },
+        'periodos_iniciais': []
     })
 
     assert serializer.is_valid(), serializer.errors

--- a/sme_ptrf_apps/dre/tests/tests_api_valores_reprogramados_dre/test_valores_reprogramados_filtros.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_valores_reprogramados_dre/test_valores_reprogramados_filtros.py
@@ -25,6 +25,7 @@ def test_api_valores_reprogramados_filtro_nome_unidade(
     resultado_esperado = [
         {
             'associacao': {
+                'recursos': '',
                 'cnpj': associacao_2.cnpj,
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
@@ -83,6 +84,7 @@ def test_api_valores_reprogramados_filtro_nome_associacao(
     resultado_esperado = [
         {
             'associacao': {
+                'recursos': '',
                 'cnpj': associacao_2.cnpj,
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
@@ -141,6 +143,7 @@ def test_api_valores_reprogramados_filtro_codigo_eol(
     resultado_esperado = [
         {
             'associacao': {
+                'recursos': '',
                 'cnpj': associacao_2.cnpj,
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,
@@ -199,6 +202,7 @@ def test_api_valores_reprogramados_filtro_tipo_unidade(
     resultado_esperado = [
         {
             'associacao': {
+                'recursos': '',
                 'cnpj': associacao_2.cnpj,
                 'nome': associacao_2.nome,
                 'data_de_encerramento': None,


### PR DESCRIPTION
Este PR inclui:

- Atualiza serializer de associação para devolver e tratar campo de períodos iniciais associação;
- Cria novos endpoints de 'verificar cnpj existe' e  'devolver opcoes status valores reprogramados' são endpoints utilizados na tela de formulário de associação em parametrizações > associações;
- Trata os períodos iniciais associação na criação e atualização da associação;
- Ajusta testes unitários;

História: [AB#141035](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/141035)
Tarefa: [AB#154063](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/154063)