### PR TITLE
hotfix(153925): ajusta estratégia de cálculo de saldo em conta e ações

### DIFF
--- a/sme_ptrf_apps/__init__.py
+++ b/sme_ptrf_apps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "9.44.1"
+__version__ = "9.44.2"
 
 __version_info__ = tuple(
     [

--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -314,7 +314,7 @@ def info_acao_associacao_no_periodo(
             info['receitas_devolucao_no_periodo_custeio'] += fechamento_periodo.total_receitas_devolucao_custeio
             info['repasses_no_periodo_custeio'] += fechamento_periodo.total_repasses_custeio
             info['despesas_no_periodo_custeio'] += fechamento_periodo.total_despesas_custeio
-            info['saldo_atual_custeio'] += fechamento_periodo.saldo_reprogramado_custeio
+
             info['receitas_nao_conciliadas_custeio'] += fechamento_periodo.total_receitas_nao_conciliadas_custeio
             info['despesas_nao_conciliadas_custeio'] += fechamento_periodo.total_despesas_nao_conciliadas_custeio
             info['despesas_conciliadas_custeio'] += (fechamento_periodo.total_despesas_custeio -
@@ -329,7 +329,7 @@ def info_acao_associacao_no_periodo(
             info['receitas_devolucao_no_periodo_capital'] += fechamento_periodo.total_receitas_devolucao_capital
             info['repasses_no_periodo_capital'] += fechamento_periodo.total_repasses_capital
             info['despesas_no_periodo_capital'] += fechamento_periodo.total_despesas_capital
-            info['saldo_atual_capital'] += fechamento_periodo.saldo_reprogramado_capital
+            
             info['receitas_nao_conciliadas_capital'] += fechamento_periodo.total_receitas_nao_conciliadas_capital
             info['despesas_nao_conciliadas_capital'] += fechamento_periodo.total_despesas_nao_conciliadas_capital
             info['despesas_conciliadas_capital'] += (fechamento_periodo.total_despesas_capital -
@@ -343,21 +343,32 @@ def info_acao_associacao_no_periodo(
             info['receitas_no_periodo_livre'] += fechamento_periodo.total_receitas_livre
             info['receitas_devolucao_no_periodo_livre'] += fechamento_periodo.total_receitas_devolucao_livre
             info['repasses_no_periodo_livre'] += fechamento_periodo.total_repasses_livre
-            info['saldo_atual_livre'] += fechamento_periodo.saldo_reprogramado_livre
+            
             info['receitas_nao_conciliadas_livre'] += fechamento_periodo.total_receitas_nao_conciliadas_livre
             info['saldo_bancario_livre'] += fechamento_periodo.saldo_reprogramado_livre
 
             if exclude_despesa and considera_exclude_despesa:
-                despesa = Despesa.objects.get(uuid=exclude_despesa)
-                rateios = despesa.rateios.filter(acao_associacao=fechamento_periodo.acao_associacao).filter(
-                    conta_associacao=fechamento_periodo.conta_associacao)
-                for rateio in rateios.all():
-                    if rateio.aplicacao_recurso == APLICACAO_CAPITAL:
-                        info['despesas_no_periodo_capital'] -= rateio.valor_rateio
-                        info['saldo_atual_capital'] += rateio.valor_rateio
-                    elif rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
-                        info['despesas_no_periodo_custeio'] -= rateio.valor_rateio
-                        info['saldo_atual_custeio'] += rateio.valor_rateio
+                info['saldo_atual_custeio'] += fechamento_periodo.saldo_anterior_custeio + fechamento_periodo.total_receitas_custeio
+                info['saldo_atual_capital'] += fechamento_periodo.saldo_anterior_capital + fechamento_periodo.total_receitas_capital
+                info['saldo_atual_livre'] += fechamento_periodo.saldo_anterior_livre + fechamento_periodo.total_receitas_livre
+            else:
+                info['saldo_atual_custeio'] += fechamento_periodo.saldo_reprogramado_custeio
+                info['saldo_atual_capital'] += fechamento_periodo.saldo_reprogramado_capital
+                info['saldo_atual_livre'] += fechamento_periodo.saldo_reprogramado_livre
+
+        if exclude_despesa and considera_exclude_despesa:
+            rateios = RateioDespesa.rateios_da_acao_associacao_no_periodo(
+                acao_associacao=acao_associacao,
+                periodo=periodo,
+                exclude_despesa=exclude_despesa,
+            )
+            for rateio in rateios:
+                if rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
+                    info['despesas_no_periodo_custeio'] += rateio.valor_rateio
+                    info['saldo_atual_custeio'] -= rateio.valor_rateio
+                elif rateio.aplicacao_recurso == APLICACAO_CAPITAL:
+                    info['despesas_no_periodo_capital'] += rateio.valor_rateio
+                    info['saldo_atual_capital'] -= rateio.valor_rateio
 
         return info
 
@@ -725,40 +736,43 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             'saldo_atual_livre': 0,
         }
 
-    def fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=False):
+    def fechamento_sumarizado_por_conta(fechamentos_periodo):
         """
-        `considera_exclude_despesa` só deve ser True quando o saldo é obtido
-        exclusivamente do fechamento, sem recálculo de receitas ou despesas.
-        Esse parâmetro é utilizado apenas no cenário de edição de despesa.
+        Executa apenas quando há fechamentos em aberto, ou seja, na edição de despesa
+        via acertos solicitados. Dos fechamentos, obtemos apenas os saldos disponiveis (receitas)
+        e realizamos o recalculo da despesa para obter o valor real da conta.
         """
         info = resultado_vazio()
         for fechamento_periodo in fechamentos_periodo:
             info['saldo_anterior_custeio'] += fechamento_periodo.saldo_anterior_custeio
             info['receitas_no_periodo_custeio'] += fechamento_periodo.total_receitas_custeio
             info['repasses_no_periodo_custeio'] += fechamento_periodo.total_repasses_custeio
-            info['despesas_no_periodo_custeio'] += fechamento_periodo.total_despesas_custeio
-            info['saldo_atual_custeio'] += fechamento_periodo.saldo_reprogramado_custeio
-
+           
             info['saldo_anterior_capital'] += fechamento_periodo.saldo_anterior_capital
             info['receitas_no_periodo_capital'] += fechamento_periodo.total_receitas_capital
             info['repasses_no_periodo_capital'] += fechamento_periodo.total_repasses_capital
-            info['despesas_no_periodo_capital'] += fechamento_periodo.total_despesas_capital
-            info['saldo_atual_capital'] += fechamento_periodo.saldo_reprogramado_capital
-
+           
             info['saldo_anterior_livre'] += fechamento_periodo.saldo_anterior_livre
             info['receitas_no_periodo_livre'] += fechamento_periodo.total_receitas_livre
             info['repasses_no_periodo_livre'] += fechamento_periodo.total_repasses_livre
-            info['saldo_atual_livre'] += fechamento_periodo.saldo_reprogramado_livre
+           
+            info['saldo_atual_custeio'] += fechamento_periodo.saldo_anterior_custeio + fechamento_periodo.total_receitas_custeio
+            info['saldo_atual_capital'] += fechamento_periodo.saldo_anterior_capital + fechamento_periodo.total_receitas_capital
+            info['saldo_atual_livre'] += fechamento_periodo.saldo_anterior_livre + fechamento_periodo.total_receitas_livre
 
-        if exclude_despesa and considera_exclude_despesa:
-            despesa = Despesa.objects.get(uuid=exclude_despesa)
-            for rateio in despesa.rateios.all():
-                if rateio.aplicacao_recurso == APLICACAO_CAPITAL:
-                    info['despesas_no_periodo_capital'] -= rateio.valor_rateio
-                    info['saldo_atual_capital'] += rateio.valor_rateio
-                elif rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
-                    info['despesas_no_periodo_custeio'] -= rateio.valor_rateio
-                    info['saldo_atual_custeio'] += rateio.valor_rateio
+        rateios = RateioDespesa.rateios_da_conta_associacao_no_periodo(
+            conta_associacao=conta_associacao,
+            periodo=periodo,
+            exclude_despesa=exclude_despesa,
+        )
+
+        for rateio in rateios:
+            if rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
+                info['despesas_no_periodo_custeio'] += rateio.valor_rateio
+                info['saldo_atual_custeio'] -= rateio.valor_rateio
+            elif rateio.aplicacao_recurso == APLICACAO_CAPITAL:
+                info['despesas_no_periodo_capital'] += rateio.valor_rateio
+                info['saldo_atual_capital'] -= rateio.valor_rateio
 
         return info
 
@@ -908,7 +922,7 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
                                                                             periodo=periodo)
     if fechamentos_periodo:
         logger.info(f'Encontrato fechamentos no período {periodo} e conta {conta_associacao}. Usando fechamento.')
-        return fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=True)
+        return fechamento_sumarizado_por_conta(fechamentos_periodo)
     else:
         logger.info(f'Não encontrato fechamentos no período {periodo} e conta {conta_associacao}. Calculando saldo.')
         return periodo_aberto_sumarizado_por_conta(periodo, conta_associacao)

--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -736,7 +736,7 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             'saldo_atual_livre': 0,
         }
 
-    def fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=True):
+    def fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=False):
         """
         `considera_exclude_despesa` só deve ser True quando o saldo é obtido
         exclusivamente do fechamento, sem recálculo de receitas ou despesas.

--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -736,10 +736,13 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             'saldo_atual_livre': 0,
         }
 
-    def fechamento_sumarizado_por_conta(fechamentos_periodo):
+    def fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=True):
         """
-        Executa apenas quando há fechamentos em aberto, ou seja, na edição de despesa
-        via acertos solicitados. Dos fechamentos, obtemos apenas os saldos disponiveis (receitas)
+        `considera_exclude_despesa` só deve ser True quando o saldo é obtido
+        exclusivamente do fechamento, sem recálculo de receitas ou despesas.
+        Esse parâmetro é utilizado apenas no cenário de edição de despesa.
+
+        UPDATE: Dos fechamentos, caso haja, obtemos apenas os saldos disponiveis (receitas)
         e realizamos o recalculo da despesa para obter o valor real da conta.
         """
         info = resultado_vazio()
@@ -755,24 +758,31 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             info['saldo_anterior_livre'] += fechamento_periodo.saldo_anterior_livre
             info['receitas_no_periodo_livre'] += fechamento_periodo.total_receitas_livre
             info['repasses_no_periodo_livre'] += fechamento_periodo.total_repasses_livre
-           
-            info['saldo_atual_custeio'] += fechamento_periodo.saldo_anterior_custeio + fechamento_periodo.total_receitas_custeio
-            info['saldo_atual_capital'] += fechamento_periodo.saldo_anterior_capital + fechamento_periodo.total_receitas_capital
-            info['saldo_atual_livre'] += fechamento_periodo.saldo_anterior_livre + fechamento_periodo.total_receitas_livre
 
-        rateios = RateioDespesa.rateios_da_conta_associacao_no_periodo(
-            conta_associacao=conta_associacao,
-            periodo=periodo,
-            exclude_despesa=exclude_despesa,
-        )
+            if exclude_despesa and considera_exclude_despesa:
+                info['saldo_atual_custeio'] += fechamento_periodo.saldo_anterior_custeio + fechamento_periodo.total_receitas_custeio
+                info['saldo_atual_capital'] += fechamento_periodo.saldo_anterior_capital + fechamento_periodo.total_receitas_capital
+                info['saldo_atual_livre'] += fechamento_periodo.saldo_anterior_livre + fechamento_periodo.total_receitas_livre
+                
+            else:
+                info['saldo_atual_custeio'] += fechamento_periodo.saldo_reprogramado_custeio
+                info['saldo_atual_capital'] += fechamento_periodo.saldo_reprogramado_capital
+                info['saldo_atual_livre'] += fechamento_periodo.saldo_reprogramado_livre
 
-        for rateio in rateios:
-            if rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
-                info['despesas_no_periodo_custeio'] += rateio.valor_rateio
-                info['saldo_atual_custeio'] -= rateio.valor_rateio
-            elif rateio.aplicacao_recurso == APLICACAO_CAPITAL:
-                info['despesas_no_periodo_capital'] += rateio.valor_rateio
-                info['saldo_atual_capital'] -= rateio.valor_rateio
+        if exclude_despesa and considera_exclude_despesa:
+            rateios = RateioDespesa.rateios_da_conta_associacao_no_periodo(
+                conta_associacao=conta_associacao,
+                periodo=periodo,
+                exclude_despesa=exclude_despesa,
+            )
+            
+            for rateio in rateios:
+                if rateio.aplicacao_recurso == APLICACAO_CUSTEIO:
+                    info['despesas_no_periodo_custeio'] += rateio.valor_rateio
+                    info['saldo_atual_custeio'] -= rateio.valor_rateio
+                elif rateio.aplicacao_recurso == APLICACAO_CAPITAL:
+                    info['despesas_no_periodo_capital'] += rateio.valor_rateio
+                    info['saldo_atual_capital'] -= rateio.valor_rateio
 
         return info
 
@@ -847,7 +857,7 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             logger.info(
                 f'Encontrados fechamentos de períodos anteriores ao período {periodo} para a conta {conta_associacao}')
             sumario_periodo_anterior = fechamento_sumarizado_por_conta(
-                fechamentos_periodo_anterior)
+                fechamentos_periodo_anterior, considera_exclude_despesa=False)
 
             info['saldo_anterior_capital'] = sumario_periodo_anterior['saldo_atual_capital']
             info['saldo_atual_capital'] = info['saldo_anterior_capital']
@@ -922,7 +932,7 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
                                                                             periodo=periodo)
     if fechamentos_periodo:
         logger.info(f'Encontrato fechamentos no período {periodo} e conta {conta_associacao}. Usando fechamento.')
-        return fechamento_sumarizado_por_conta(fechamentos_periodo)
+        return fechamento_sumarizado_por_conta(fechamentos_periodo, considera_exclude_despesa=True)
     else:
         logger.info(f'Não encontrato fechamentos no período {periodo} e conta {conta_associacao}. Calculando saldo.')
         return periodo_aberto_sumarizado_por_conta(periodo, conta_associacao)

--- a/sme_ptrf_apps/core/services/info_por_acao_services.py
+++ b/sme_ptrf_apps/core/services/info_por_acao_services.py
@@ -847,7 +847,7 @@ def info_conta_associacao_no_periodo(conta_associacao, periodo, exclude_despesa=
             logger.info(
                 f'Encontrados fechamentos de períodos anteriores ao período {periodo} para a conta {conta_associacao}')
             sumario_periodo_anterior = fechamento_sumarizado_por_conta(
-                fechamentos_periodo_anterior, considera_exclude_despesa=False)
+                fechamentos_periodo_anterior)
 
             info['saldo_anterior_capital'] = sumario_periodo_anterior['saldo_atual_capital']
             info['saldo_atual_capital'] = info['saldo_anterior_capital']

--- a/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_conta_e_acao_associacao_no_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_conta_e_acao_associacao_no_periodo.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from sme_ptrf_apps.core.services.info_por_acao_services import (
-    info_conta_associacao_no_periodo, 
+    info_conta_associacao_no_periodo,
     info_acao_associacao_no_periodo
 )
 
@@ -105,6 +105,7 @@ def dados_fechamento_conta(
     assert fechamento.saldo_anterior_custeio == Decimal("6000.00")
 
     return associacao, conta, acao_associacao, periodo
+
 
 
 def test_info_conta_associacao_no_periodo_recalcula_saldo_com_rateios_atuais(
@@ -225,3 +226,118 @@ def test_info_acao_associacao_no_periodo_recalcula_saldo_com_rateios_atuais(
 
     assert response["despesas_no_periodo_custeio"] == Decimal("1000.00")
     assert response["saldo_atual_custeio"] == Decimal("5000.00")
+
+
+def test_info_conta_associacao_no_periodo_recalcula_saldo_com_rateios_atuais_sem_exclude(
+    dados_fechamento_conta,
+    despesa_factory,
+    rateio_despesa_factory,
+):
+    (
+        associacao,
+        conta,
+        acao_associacao,
+        periodo
+    ) = dados_fechamento_conta
+
+    # Despesas já cadastradas anteriormente
+    despesa_antiga = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 1),
+        data_documento=date(2022, 1, 1),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa_antiga,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    despesa = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 2),
+        data_documento=date(2022, 1, 2),
+    )
+    rateio_despesa_factory.create(
+        despesa=despesa,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    response = info_conta_associacao_no_periodo(
+        conta_associacao=conta,
+        periodo=periodo,
+    )
+
+    assert response["despesas_no_periodo_custeio"] == Decimal("0")
+    assert response["saldo_atual_custeio"] == Decimal("6000.00")
+
+
+def test_info_acao_associacao_no_periodo_recalcula_saldo_com_rateios_atuais_sem_exclude(
+    dados_fechamento_conta,
+    despesa_factory,
+    rateio_despesa_factory,
+):
+    (
+        associacao,
+        conta,
+        acao_associacao,
+        periodo
+    ) = dados_fechamento_conta
+
+    # Despesas já cadastradas anteriormente
+    despesa_antiga = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 1),
+        data_documento=date(2022, 1, 1),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa_antiga,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    despesa = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 2),
+        data_documento=date(2022, 1, 2),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    response = info_acao_associacao_no_periodo(
+        acao_associacao=acao_associacao,
+        periodo=periodo,
+       
+    )
+    assert response["despesas_no_periodo_custeio"] == Decimal("0")
+    assert response["saldo_atual_custeio"] == Decimal("6000.00")

--- a/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_conta_e_acao_associacao_no_periodo.py
+++ b/sme_ptrf_apps/core/tests/tests_services/tests_info_por_acao_services/test_info_conta_e_acao_associacao_no_periodo.py
@@ -1,0 +1,227 @@
+
+import pytest
+from datetime import date
+from decimal import Decimal
+
+from sme_ptrf_apps.core.services.info_por_acao_services import (
+    info_conta_associacao_no_periodo, 
+    info_acao_associacao_no_periodo
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def dados_fechamento_conta(
+    associacao_factory,
+    conta_associacao_factory,
+    periodo_factory,
+    fechamento_periodo_factory,
+    prestacao_conta_factory,
+    acao_associacao_factory,
+    acao_factory,
+    tipo_conta_factory,
+):
+    associacao = associacao_factory.create()
+
+    acao = acao_factory.create(
+        nome="PTRF Básico",
+        aceita_capital=True,
+        aceita_custeio=True,
+        aceita_livre=True,
+    )
+    acao_associacao = acao_associacao_factory.create(
+        associacao=associacao,
+        acao=acao,
+    )
+
+    tipo_conta = tipo_conta_factory.create(nome="Cheque")
+
+    conta = conta_associacao_factory.create(
+        tipo_conta=tipo_conta,
+        associacao=associacao,
+    )
+
+    periodo_anterior = periodo_factory.create(
+        referencia="2021.3",
+        data_inicio_realizacao_despesas=date(2021, 10, 1),
+        data_fim_realizacao_despesas=date(2021, 12, 31),   
+    )
+
+    # O valor está em receitas porque ele vai gerar no pre_save os saldo_programados
+    fechamento_anterior = fechamento_periodo_factory.create(
+        periodo=periodo_anterior,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=None,
+        total_receitas_custeio=6000,
+        total_despesas_custeio=0,
+
+        total_receitas_capital=0,
+        total_receitas_livre=0,
+        total_despesas_capital=0,
+
+        status="FECHADO",
+    )
+
+    assert fechamento_anterior.saldo_reprogramado_custeio == Decimal("6000.00")
+
+    periodo = periodo_factory.create(
+        periodo_anterior=periodo_anterior,
+        referencia="2022.1",
+        data_inicio_realizacao_despesas=date(2022, 1, 1),
+        data_fim_realizacao_despesas=date(2022, 4, 30),
+    )
+
+    pc = prestacao_conta_factory.create(
+        periodo=periodo,
+        associacao=associacao,
+    )
+    '''
+        saldo_anterior_custeio = fechamento_anterior.saldo_reprogramado_custeio
+        saldo_anterior_capital = fechamento_anterior.saldo_reprogramado_capital
+        saldo_anterior_livre = fechamento_anterior.saldo_reprogramado_livre
+    '''
+    fechamento = fechamento_periodo_factory.create(
+        prestacao_conta=pc,
+        periodo=periodo,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        fechamento_anterior=fechamento_anterior,
+
+        total_receitas_custeio=0,
+        total_despesas_custeio=0,
+
+        total_receitas_capital=0,
+        total_despesas_capital=0,
+
+        total_receitas_livre=0,
+
+        status="FECHADO",
+    )
+
+    assert fechamento.saldo_anterior_custeio == Decimal("6000.00")
+
+    return associacao, conta, acao_associacao, periodo
+
+
+def test_info_conta_associacao_no_periodo_recalcula_saldo_com_rateios_atuais(
+    dados_fechamento_conta,
+    despesa_factory,
+    rateio_despesa_factory,
+):
+    (
+        associacao,
+        conta,
+        acao_associacao,
+        periodo
+    ) = dados_fechamento_conta
+
+    # Despesas já cadastradas anteriormente
+    despesa_antiga = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 1),
+        data_documento=date(2022, 1, 1),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa_antiga,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    # Despesa que se está editando
+    despesa = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 2),
+        data_documento=date(2022, 1, 2),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    response = info_conta_associacao_no_periodo(
+        conta_associacao=conta,
+        periodo=periodo,
+        exclude_despesa=str(despesa.uuid),
+    )
+
+    assert response["despesas_no_periodo_custeio"] == Decimal("1000.00")
+    assert response["saldo_atual_custeio"] == Decimal("5000.00")
+
+
+def test_info_acao_associacao_no_periodo_recalcula_saldo_com_rateios_atuais(
+    dados_fechamento_conta,
+    despesa_factory,
+    rateio_despesa_factory,
+):
+    (
+        associacao,
+        conta,
+        acao_associacao,
+        periodo
+    ) = dados_fechamento_conta
+
+    # Despesas já cadastradas anteriormente
+    despesa_antiga = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 1),
+        data_documento=date(2022, 1, 1),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa_antiga,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    # Despesa que se está editando
+    despesa = despesa_factory.create(
+        associacao=associacao,
+        data_transacao=date(2022, 1, 2),
+        data_documento=date(2022, 1, 2),
+    )
+
+    rateio_despesa_factory.create(
+        despesa=despesa,
+        associacao=associacao,
+        conta_associacao=conta,
+        acao_associacao=acao_associacao,
+        aplicacao_recurso="CUSTEIO",
+        valor_rateio=Decimal("1000.00"),
+        valor_original=Decimal("1000.00"),
+        status="COMPLETO",
+        conferido=True,
+    )
+
+    response = info_acao_associacao_no_periodo(
+        acao_associacao=acao_associacao,
+        periodo=periodo,
+        exclude_despesa=str(despesa.uuid),
+    )
+
+    assert response["despesas_no_periodo_custeio"] == Decimal("1000.00")
+    assert response["saldo_atual_custeio"] == Decimal("5000.00")


### PR DESCRIPTION
# O que este PR faz

- ajusta estratégia de cálculo de saldo em conta e ações do endpoint /verificar-saldos para obter valor real disponível, considerando apenas receitas do fechamento + recálculo das despesas.
- testes unitários.

Referência Azure: [AB#153925](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/153925)