### PR TITLE
feat(154079): Ajustes em nova estrutura de pipeline de validações de Despesas - Hom

### DIFF
--- a/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
+++ b/sme_ptrf_apps/despesas/api/serializers/despesa_serializer.py
@@ -1,6 +1,8 @@
 import logging
+from django.db import transaction
+
 from rest_framework import serializers
-from waffle import get_waffle_flag_model
+from sme_ptrf_apps.despesas.feature_flags import despesas_pipeline_ativa
 
 from .rateio_despesa_serializer import RateioDespesaSerializer, RateioDespesaTabelaGastosEscolaSerializer
 from .tipo_documento_serializer import TipoDocumentoSerializer, TipoDocumentoListSerializer
@@ -88,8 +90,7 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
     )
 
     def validate_rateios(self, value):
-        flags = get_waffle_flag_model()
-        existe_flag_pipeline = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
+        existe_flag_pipeline = despesas_pipeline_ativa(self.context.get("request"))
         if existe_flag_pipeline:
             # bypass validate_rateios(R01, REG-003, REG-004, R05, REG-006), executa pela pipeline
             return value
@@ -161,17 +162,27 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
     def validate(self, data):
         recurso = self.context.get("recurso")
 
-        flags = get_waffle_flag_model()
-        existe_flag_pipeline = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
-        if not existe_flag_pipeline:
-            if not self.instance:
+        existe_flag_pipeline = despesas_pipeline_ativa(self.context.get("request"))
 
-                if not recurso:
-                    raise serializers.ValidationError(
-                        "Recurso da despesa é obrigatório"
-                    )
+        # Retorno de dados validados e mutados da pipeline
+        if existe_flag_pipeline:
+            data = self.executa_pipeline(data)
+            # retornar imediatamente com flag ativa para evitar
+            # executar ValidacaoDespesaService.validar_periodo_e_contas(código legado) em paralelo
+            # com a pipeline (codigo novo)
+            return data
 
-        # ainda não coberto
+        if not self.instance and not recurso:
+            raise serializers.ValidationError(
+                "Recurso da despesa é obrigatório"
+            )
+
+        # ainda não coberto — só roda com a flag desligada
+        # Regras cobertas por este método e seus validators correspondentes na pipeline:
+        #   Período da PC devolvida               → REG-007 (PeriodoPcDevolvidaValidator)
+        #   Datas de conta dos rateios             → REG-008 (ContasRateiosValidator)
+        #   Datas de conta dos impostos            → REG-008 (ContasImpostosValidator)
+        #   Conta e ação do mesmo recurso          → REG-009 (ContaAcaoRecursoValidator)
         ValidacaoDespesaService.validar_periodo_e_contas(
             instance=self.instance,
             data_transacao=data.get("data_transacao"),
@@ -179,10 +190,6 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
             despesas_impostos=data.get("despesas_impostos", []),
             recurso=self.instance.recurso if self.instance else recurso
         )
-
-        # Retorno de dados validados e mutados da pipeline
-        if existe_flag_pipeline:
-            data = self.executa_pipeline(data)
 
         return data
 
@@ -196,20 +203,23 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
             service = PrioridadesPaaImpactadasDespesaRateioService(rateio, instance_despesa)
             service.limpar_valor_prioridades_impactadas()
 
+    @transaction.atomic
     def create(self, validated_data):
         from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
-        from waffle import get_waffle_flag_model
+        # REG-029 — vincular gasto incluído (só pipeline + uuid de acerto no context)
+        # Agora dentro do MESMO @transaction.atomic do método: se a vinculação de SolicitaçãoAcerto
+        # falhar, o savepoint de DespesaService.create() também é desfeito —
+        # a despesa nunca fica persistida sem o vínculo.
+        pipeline_ativa = despesas_pipeline_ativa(self.context.get("request"))
 
         validated_data["recurso"] = self.context["recurso"]
 
         despesa = DespesaService.create(
             validated_data,
-            limpar_prioridades_callback=self._limpar_prioridades_paa
+            limpar_prioridades_callback=self._limpar_prioridades_paa,
+            pipeline_ativa=pipeline_ativa
         )
 
-        # REG-029 — vincular gasto incluído (só pipeline + uuid de acerto no context)
-        flags = get_waffle_flag_model()
-        pipeline_ativa = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
         uuid_acerto = self.context.get("uuid_solicitacao_acerto")
         if pipeline_ativa and uuid_acerto:
             from sme_ptrf_apps.core.services.solicitacao_acerto_documento_service import (
@@ -229,6 +239,8 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
         from copy import deepcopy
         import time
 
+        pipeline_ativa = despesas_pipeline_ativa(self.context.get("request"))
+
         # [PIPELINE — Fluxo 4] REG-031: DespesaService.update já chama
         # _marcar_lancamento_como_atualizado (PC devolvida + solicitação pendente).
         # REG-033: herança de conciliação de impostos também fica no service.
@@ -247,7 +259,8 @@ class DespesaCreateSerializer(serializers.ModelSerializer):
                 return DespesaService.update(
                     instance,
                     deepcopy(payload_original),
-                    limpar_prioridades_callback=self._limpar_prioridades_paa
+                    limpar_prioridades_callback=self._limpar_prioridades_paa,
+                    pipeline_ativa=pipeline_ativa
                 )
             except DatabaseError as e:
                 if "timeout" in str(e).lower() or "closed" in str(e).lower():

--- a/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
+++ b/sme_ptrf_apps/despesas/api/views/despesas_viewset.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django_filters import rest_framework as filters
 from rest_framework import mixins, status
 from rest_framework.decorators import action
@@ -234,9 +235,8 @@ class DespesasViewSet(mixins.CreateModelMixin,
             context["recurso"] = self.request.recurso
 
         # Detecção de fluxo acerto (pipelines 3/4) só com a flag — legado inalterado.
-        from waffle import get_waffle_flag_model
-        flags = get_waffle_flag_model()
-        pipeline_ativa = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
+        from sme_ptrf_apps.despesas.feature_flags import despesas_pipeline_ativa
+        pipeline_ativa = despesas_pipeline_ativa(self.request)
         if not pipeline_ativa:
             return context
 
@@ -270,6 +270,8 @@ class DespesasViewSet(mixins.CreateModelMixin,
         from django.db.models.deletion import ProtectedError
         from ....core.models import DevolucaoAoTesouro, ContaAssociacao
         from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+        from sme_ptrf_apps.despesas.feature_flags import despesas_pipeline_ativa
+        pipeline_ativa = despesas_pipeline_ativa(self.request)
         despesa = self.get_object()
 
         if despesa.rateios.filter(conta_associacao__status=ContaAssociacao.STATUS_INATIVA).exists():
@@ -281,7 +283,7 @@ class DespesasViewSet(mixins.CreateModelMixin,
             return Response(erro, status=status.HTTP_400_BAD_REQUEST)
 
         # Acerto exclusão (flag): marca lançamento antes de apagar/inativar a despesa.
-        DespesaService._marcar_lancamento_como_excluido(despesa)
+        DespesaService._marcar_lancamento_como_excluido(despesa, pipeline_ativa)
 
         if not despesa.inativar_em_vez_de_excluir:
             # Em caso de inativação, a inativação dos impostos é feita pelo próprio método inativar_despesa.
@@ -289,6 +291,7 @@ class DespesasViewSet(mixins.CreateModelMixin,
                 try:
                     self.perform_destroy(despesa_imposto)
                 except Exception as err:
+                    transaction.set_rollback(True)  # rollback para _marcar_lancamento_como_excluido em caso de erro
                     erro = {
                         'erro': 'despesa_do_imposto_nao_deletada',
                         'mensagem': str(err)
@@ -307,6 +310,7 @@ class DespesasViewSet(mixins.CreateModelMixin,
                 self.perform_destroy(despesa)
                 return Response(status=status.HTTP_204_NO_CONTENT)
             except ProtectedError as exception:
+                transaction.set_rollback(True)  # rollback para _marcar_lancamento_como_excluido em caso de erro
                 erros = []
 
                 if exception.args:

--- a/sme_ptrf_apps/despesas/feature_flags.py
+++ b/sme_ptrf_apps/despesas/feature_flags.py
@@ -1,0 +1,13 @@
+from waffle import flag_is_active
+
+
+def despesas_pipeline_ativa(request) -> bool:
+    """
+        True quando a flag 'despesas-pipeline' vale para ESTE request —
+        respeita everyone, percentual, grupo, usuário e staff/superuser.
+        Substitui o filtro manual `Flag.objects.filter(everyone=True)`,
+        que ignora todo o resto do targeting do waffle.
+    """
+    if request is None:
+        return False
+    return flag_is_active(request, "despesas-pipeline")

--- a/sme_ptrf_apps/despesas/services/despesa_service.py
+++ b/sme_ptrf_apps/despesas/services/despesa_service.py
@@ -9,9 +9,6 @@ from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, AP
 from sme_ptrf_apps.despesas.models import Despesa, RateioDespesa
 from sme_ptrf_apps.despesas.api.serializers.rateio_despesa_serializer import RateioDespesaCreateSerializer
 
-from sme_ptrf_apps.core.models.solicitacao_acerto_lancamento import SolicitacaoAcertoLancamento
-from sme_ptrf_apps.core.models.tipo_acerto_lancamento import TipoAcertoLancamento
-from sme_ptrf_apps.core.models.analise_lancamento_prestacao_conta import AnaliseLancamentoPrestacaoConta
 from sme_ptrf_apps.core.services.analise_lancamento_prestacao_conta_service import (
     AnaliseLancamentoPrestacaoContaService,
 )
@@ -79,19 +76,26 @@ class DespesaService:
 
     @classmethod
     @transaction.atomic
-    def create(cls, validated_data, limpar_prioridades_callback=None):
+    def create(cls, validated_data, limpar_prioridades_callback=None, pipeline_ativa=False):
+        """
+            Este método deve ser exclusivo para execução no Serializer em Despesas
+            validated_data: dict com os dados validados do serializer
+            limpar_prioridades_callback: função que será chamada para limpar as prioridades de rateios
+            pipeline_ativa: bool indicando se a pipeline de despesas está ativa
+        """
         logger.info("Iniciando criação de despesa")
 
         rateios = validated_data.pop("rateios")
         despesas_impostos = validated_data.pop("despesas_impostos", None)
 
         # [PIPELINE] Substituição futura: _validar_datas → DatasEncerramentoValidator (REG-010)
-        cls._validar_datas(validated_data)
+        if not pipeline_ativa:
+            cls._validar_datas(validated_data)
 
         # [PIPELINE] Substituição futura: _processar_pagamento_antecipado →
         #   validate: PagamentoAntecipadoValidator (REG-011)
         #   apply:    PagamentoAntecipadoValidator.apply() (REG-011 apply) + sync ctx→data no serializer
-        motivos, outros = cls._processar_pagamento_antecipado(validated_data)
+        motivos, outros = cls._processar_pagamento_antecipado(validated_data, pipeline_ativa)
 
         despesa = Despesa.objects.create(**validated_data)
 
@@ -102,7 +106,7 @@ class DespesaService:
         cls._criar_rateios(despesa, rateios)
         cls._aplicar_motivos(despesa, motivos, outros)
 
-        cls._processar_impostos(despesa, despesas_impostos)
+        cls._processar_impostos(despesa, despesas_impostos, pipeline_ativa)
 
         cls._finalizar_despesa(despesa, rateios, limpar_prioridades_callback)
 
@@ -115,7 +119,14 @@ class DespesaService:
     # =====================================================
     @classmethod
     @transaction.atomic
-    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None):
+    def update(cls, instance: Despesa, validated_data, limpar_prioridades_callback=None, pipeline_ativa=False):
+        """
+            Este método deve ser exclusivo para execução no Serializer em Despesas
+            instance: Despesa a ser atualizada
+            validated_data: dict com os dados validados do serializer
+            limpar_prioridades_callback: função que será chamada para limpar as prioridades de rateios
+            pipeline_ativa: bool indicando se a pipeline de despesas está ativa
+        """
 
         logger.info(f"Iniciando atualização de despesa: #{instance.id}")
 
@@ -127,12 +138,14 @@ class DespesaService:
             despesas_impostos = validated_data.pop("despesas_impostos", [])
 
             # [PIPELINE] Substituição futura: _validar_datas_update →
-            #   DatasEncerramentoValidator (REG-010) + DespesaContextBuilder.build() para defaults
-            cls._validar_datas_update(instance, validated_data)
+            # DatasEncerramentoValidator (REG-010) + DespesaContextBuilder.build() para defaults
+            if not pipeline_ativa:
+                cls._validar_datas_update(instance, validated_data)
+
             # [PIPELINE] Substituição futura: _processar_pagamento_antecipado →
             #   validate: PagamentoAntecipadoValidator (REG-011)
             #   apply:    PagamentoAntecipadoValidator.apply() (REG-011 apply) + sync ctx→data no serializer
-            motivos, outros = cls._processar_pagamento_antecipado(validated_data)
+            motivos, outros = cls._processar_pagamento_antecipado(validated_data, pipeline_ativa)
 
             # Executa apenas quando há alterações de dados do fornecedor
             cls._cria_atualiza_fornecedor(instance, validated_data)
@@ -145,10 +158,10 @@ class DespesaService:
             #   validate: MudancaAplicacaoValidator (REG-013)
             #   apply:    MudancaAplicacaoValidator.apply() (REG-013 apply) — reseta campos em ctx.rateios
             #   service:  persiste apenas (sem validação/mutação)
-            cls._atualizar_rateios(instance, rateios)
+            cls._atualizar_rateios(instance, rateios, pipeline_ativa)
             cls._aplicar_motivos(instance, motivos, outros)
 
-            cls._processar_impostos_update(instance, despesas_impostos)
+            cls._processar_impostos_update(instance, despesas_impostos, pipeline_ativa)
 
             cls._finalizar_despesa(instance, rateios, limpar_prioridades_callback)
 
@@ -194,9 +207,14 @@ class DespesaService:
     # =====================================================
 
     @staticmethod
-    def _processar_pagamento_antecipado(validated_data):
+    def _processar_pagamento_antecipado(validated_data, pipeline_ativa=False):
         motivos = validated_data.pop("motivos_pagamento_antecipado", [])
         outros = validated_data.get("outros_motivos_pagamento_antecipado")
+
+        if pipeline_ativa:
+            # REG-011 — PagamentoAntecipadoValidator já validou e resetou;
+            # os valores já chegam pelo executa_pipeline() no serializer.
+            return motivos, outros
 
         dt = validated_data.get("data_transacao")
         dd = validated_data.get("data_documento")
@@ -232,7 +250,7 @@ class DespesaService:
         despesa.rateios.set(rateios_lista)
 
     @staticmethod
-    def _atualizar_rateios(despesa: Despesa, rateios):
+    def _atualizar_rateios(despesa: Despesa, rateios, pipeline_ativa=False):
         keep = []
 
         uuids = [
@@ -266,97 +284,101 @@ class DespesaService:
 
                 if rateio_para_atualizar:
 
-                    aplicacao_anterior = rateio_para_atualizar.aplicacao_recurso
-                    nova_aplicacao = rateio.get("aplicacao_recurso")
+                    # REG-013 — MudancaAplicacaoValidator (validate + apply) já cobriu isso
+                    # quando a pipeline está ativa: campos já chegam validados e resetados.
+                    if not pipeline_ativa:
+                        aplicacao_anterior = rateio_para_atualizar.aplicacao_recurso
+                        nova_aplicacao = rateio.get("aplicacao_recurso")
 
-                    saida_recurso_externo = rateio.get(
-                        "saida_de_recurso_externo",
-                        rateio_para_atualizar.saida_de_recurso_externo
-                    )
-
-                    despesa_que_nao_precisam_especificacao = despesa.eh_despesa_sem_comprovacao_fiscal or saida_recurso_externo   # noqa
-
-                    # CAPITAL -> CUSTEIO
-                    if aplicacao_anterior == APLICACAO_CAPITAL and nova_aplicacao == APLICACAO_CUSTEIO:
-
-                        if not despesa_que_nao_precisam_especificacao:
-                            tipo_custeio = rateio.get("tipo_custeio")
-                            especificacao = rateio.get("especificacao_material_servico")
-                            if not tipo_custeio or not especificacao:
-                                raise serializers.ValidationError({
-                                    "mensagem": (
-                                        "Ao alterar o tipo de aplicação de Capital para Custeio, "
-                                        "é obrigatório informar o Tipo de Custeio e a Especificação de "
-                                        "Material ou Serviço em cada rateio."
-                                    )
-                                })
-                            if especificacao.aplicacao_recurso != APLICACAO_CUSTEIO:
-                                raise serializers.ValidationError({
-                                    "mensagem": (
-                                        "Ao alterar o tipo de aplicação de Capital para Custeio, "
-                                        "é obrigatório informar uma Especificação de Material ou Serviço "
-                                        "de Custeio. A especificação atual é de Capital."
-                                    )
-                                })
-                            rateio.update({
-                                "numero_processo_incorporacao_capital": "",
-                                "quantidade_itens_capital": 0,
-                                "nao_exibir_em_rel_bens": False,
-                                "valor_item_capital": 0,
-                            })
-                        else:
-                            rateio.update({
-                                "numero_processo_incorporacao_capital": "",
-                                "quantidade_itens_capital": 0,
-                                "especificacao_material_servico": None,
-                                "nao_exibir_em_rel_bens": False,
-                                "valor_item_capital": 0,
-                            })
-
-                        logger.info(
-                            f"Resetando campos de CAPITAL → CUSTEIO "
-                            f"no rateio {rateio['uuid']}"
+                        saida_recurso_externo = rateio.get(
+                            "saida_de_recurso_externo",
+                            rateio_para_atualizar.saida_de_recurso_externo
                         )
 
-                    # CUSTEIO -> CAPITAL
-                    if aplicacao_anterior == APLICACAO_CUSTEIO and nova_aplicacao == APLICACAO_CAPITAL:
-                        if not despesa_que_nao_precisam_especificacao:
-                            especificacao = rateio.get("especificacao_material_servico")
-                            if especificacao is None:
-                                especificacao = rateio_para_atualizar.especificacao_material_servico
-                            if not especificacao:
-                                raise serializers.ValidationError({
-                                    "mensagem": (
-                                        "Ao alterar o tipo de aplicação de Custeio para Capital, "
-                                        "é obrigatório informar a Especificação de Material ou Serviço "
-                                        "de Capital em cada rateio."
-                                    )
+                        despesa_que_nao_precisam_especificacao = despesa.eh_despesa_sem_comprovacao_fiscal or saida_recurso_externo   # noqa
+
+                        # CAPITAL -> CUSTEIO
+                        if aplicacao_anterior == APLICACAO_CAPITAL and nova_aplicacao == APLICACAO_CUSTEIO:
+
+                            if not despesa_que_nao_precisam_especificacao:
+                                tipo_custeio = rateio.get("tipo_custeio")
+                                especificacao = rateio.get("especificacao_material_servico")
+                                if not tipo_custeio or not especificacao:
+                                    raise serializers.ValidationError({
+                                        "mensagem": (
+                                            "Ao alterar o tipo de aplicação de Capital para Custeio, "
+                                            "é obrigatório informar o Tipo de Custeio e a Especificação de "
+                                            "Material ou Serviço em cada rateio."
+                                        )
+                                    })
+                                if especificacao.aplicacao_recurso != APLICACAO_CUSTEIO:
+                                    raise serializers.ValidationError({
+                                        "mensagem": (
+                                            "Ao alterar o tipo de aplicação de Capital para Custeio, "
+                                            "é obrigatório informar uma Especificação de Material ou Serviço "
+                                            "de Custeio. A especificação atual é de Capital."
+                                        )
+                                    })
+                                rateio.update({
+                                    "numero_processo_incorporacao_capital": "",
+                                    "quantidade_itens_capital": 0,
+                                    "nao_exibir_em_rel_bens": False,
+                                    "valor_item_capital": 0,
                                 })
-                            if especificacao.aplicacao_recurso != APLICACAO_CAPITAL:
-                                raise serializers.ValidationError({
-                                    "mensagem": (
-                                        "Ao alterar o tipo de aplicação de Custeio para Capital, "
-                                        "é obrigatório informar uma Especificação de Material ou Serviço "
-                                        "de Capital. A especificação atual é de Custeio."
-                                    )
+                            else:
+                                rateio.update({
+                                    "numero_processo_incorporacao_capital": "",
+                                    "quantidade_itens_capital": 0,
+                                    "especificacao_material_servico": None,
+                                    "nao_exibir_em_rel_bens": False,
+                                    "valor_item_capital": 0,
                                 })
 
-                            rateio.update({
-                                "tipo_custeio": None,
-                            })
-                        else:
-                            rateio.update({
-                                "tipo_custeio": None,
-                                "especificacao_material_servico": None,
-                            })
+                            logger.info(
+                                f"Resetando campos de CAPITAL → CUSTEIO "
+                                f"no rateio {rateio['uuid']}"
+                            )
 
-                        logger.info(
-                            f"Resetando campos de CUSTEIO → CAPITAL "
-                            f"no rateio {rateio['uuid']}"
-                        )
+                        # CUSTEIO -> CAPITAL
+                        if aplicacao_anterior == APLICACAO_CUSTEIO and nova_aplicacao == APLICACAO_CAPITAL:
+                            if not despesa_que_nao_precisam_especificacao:
+                                especificacao = rateio.get("especificacao_material_servico")
+                                if especificacao is None:
+                                    especificacao = rateio_para_atualizar.especificacao_material_servico
+                                if not especificacao:
+                                    raise serializers.ValidationError({
+                                        "mensagem": (
+                                            "Ao alterar o tipo de aplicação de Custeio para Capital, "
+                                            "é obrigatório informar a Especificação de Material ou Serviço "
+                                            "de Capital em cada rateio."
+                                        )
+                                    })
+                                if especificacao.aplicacao_recurso != APLICACAO_CAPITAL:
+                                    raise serializers.ValidationError({
+                                        "mensagem": (
+                                            "Ao alterar o tipo de aplicação de Custeio para Capital, "
+                                            "é obrigatório informar uma Especificação de Material ou Serviço "
+                                            "de Capital. A especificação atual é de Custeio."
+                                        )
+                                    })
+
+                                rateio.update({
+                                    "tipo_custeio": None,
+                                })
+                            else:
+                                rateio.update({
+                                    "tipo_custeio": None,
+                                    "especificacao_material_servico": None,
+                                })
+
+                            logger.info(
+                                f"Resetando campos de CUSTEIO → CAPITAL "
+                                f"no rateio {rateio['uuid']}"
+                            )
 
                     # Foi substituido o método update() para que seja executado o save() do model
                     # Chamando o pre_save e o post_save do Rateio para recalcular o status do Rateio/Despesa
+                    # Mantem Persistência fora da condicional de pipeline, sempre toda. Pipeline só valida
                     for attr, value in rateio.items():
                         setattr(rateio_para_atualizar, attr, value)
 
@@ -394,7 +416,7 @@ class DespesaService:
     # =====================================================
 
     @classmethod
-    def _processar_impostos(cls, despesa: Despesa, despesas_impostos):
+    def _processar_impostos(cls, despesa: Despesa, despesas_impostos, pipeline_ativa=False):
         if not despesa.retem_imposto or not despesas_impostos:
             return
 
@@ -404,18 +426,27 @@ class DespesaService:
             rateios = imposto.pop("rateios", [])
 
             # [PIPELINE] Substituição futura: R16 coberto por ImpostosValidator (REG-012)
-            if not rateios:
+            if not pipeline_ativa and not rateios:
                 raise serializers.ValidationError({
                     "mensagem": "A despesa de imposto precisa ter rateio associado"
                 })
 
             imposto.pop("despesas_impostos", None)
             imposto.pop("motivos_pagamento_antecipado", None)
-            imposto["recurso"] = despesa.recurso
+
+            # [PIPELINE] - Duplicado em REG-064 .apply(). Sem conflito, independente de flag
+            if not pipeline_ativa:
+                imposto["recurso"] = despesa.recurso
 
             desp = Despesa.objects.create(**imposto)
             cls._criar_rateios(desp, rateios)
-            desp.verifica_data_documento_vazio()
+
+            # [PIPELINE] - Duplicado em REG-028 .apply(). Sem conflito, independente de flag
+            # Com uma diferença, na pipeline retorna a data mutada(sem presistencia)
+            # e no código legado, executa um .save() nesta chamada do método .verifica_data_documento_vazio()
+            if not pipeline_ativa:
+                desp.verifica_data_documento_vazio()
+
             desp.atualiza_status()
             lista.append(desp)
 
@@ -426,7 +457,7 @@ class DespesaService:
             despesa_imposto.atualiza_status()
 
     @classmethod
-    def _processar_impostos_update(cls, despesa, despesas_impostos):
+    def _processar_impostos_update(cls, despesa, despesas_impostos, pipeline_ativa=False):
         if despesa.retem_imposto and despesas_impostos:
             logger.info(
                 f"Atualizando despesas de impostos da despesa geradora {despesa.uuid}"
@@ -439,7 +470,7 @@ class DespesaService:
                 rateios = imposto.pop("rateios", [])
 
                 # [PIPELINE] Substituição futura: R16 coberto por ImpostosValidator (REG-012)
-                if not rateios:
+                if not pipeline_ativa and not rateios:
                     raise serializers.ValidationError({
                         "mensagem": "A despesa de imposto precisa ter rateio associado"
                     })
@@ -480,12 +511,16 @@ class DespesaService:
                     desp.save()
                     logger.info(f"Despesa imposto atualizada uuid={desp.uuid}")
                 else:
+                    # [PIPELINE] - Duplicado em REG-064 .apply(). Sem conflito, independente de flag
                     imposto["recurso"] = despesa.recurso
                     desp = Despesa.objects.create(**imposto)
                     logger.info(f"Despesa imposto criada uuid={desp.uuid}")
 
-                cls._atualizar_rateios(desp, rateios)
+                cls._atualizar_rateios(desp, rateios, pipeline_ativa)
 
+                # [PIPELINE] - Duplicado em REG-028 .apply(). Sem conflito, independente de flag
+                # Com uma diferença, na pipeline retorna a data mutada(sem presistencia)
+                # e no código legado, executa um .save() nesta chamada do método .verifica_data_documento_vazio()
                 desp.verifica_data_documento_vazio()
                 desp.atualiza_status()
 
@@ -535,48 +570,21 @@ class DespesaService:
         """
         Marca o lançamento como atualizado quando existir uma solicitação
         pendente de edição de lançamento em uma prestação de contas devolvida.
+
+        Este método realiza mutação no banco de dados:
+        - AnaliseLancamentoPrestacaoContaService.marcar_lancamento_como_atualizado()
+        Portanto, não deve ser incluído como um Validator.
+
+        :param despesa: intancia da Despesa
         """
-        from waffle import get_waffle_flag_model
-
-        flags = get_waffle_flag_model()
-        pipeline_ativa = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
-
-        if pipeline_ativa:
-            from sme_ptrf_apps.despesas.services.fluxo_acerto import (
-                obter_analise_lancamento_edicao_pendente,
-            )
-            lancamento_analise = obter_analise_lancamento_edicao_pendente(despesa)
-            if not lancamento_analise:
-                return
-        else:
-            prestacao_conta = despesa.prestacao_conta
-
-            if not prestacao_conta or prestacao_conta.status != PrestacaoConta.STATUS_DEVOLVIDA:
-                return
-
-            lancamento_analise = (
-                AnaliseLancamentoPrestacaoConta.objects.filter(
-                    despesa=despesa,
-                    lancamento_atualizado=False,
-                    tipo_lancamento=AnaliseLancamentoPrestacaoConta.TIPO_LANCAMENTO_GASTO,
-                    status_realizacao=AnaliseLancamentoPrestacaoConta.STATUS_REALIZACAO_PENDENTE,
-                )
-                .first()
-            )
-
-            if not lancamento_analise:
-                return
-
-            possui_solicitacao_pendente = (
-                lancamento_analise.solicitacoes_de_ajuste_da_analise.filter(
-                    tipo_acerto__categoria=TipoAcertoLancamento.CATEGORIA_EDICAO_LANCAMENTO,
-                    status_realizacao=SolicitacaoAcertoLancamento.STATUS_REALIZACAO_PENDENTE,
-                )
-                .exists()
-            )
-
-            if not possui_solicitacao_pendente:
-                return
+        # condicional anterior removida (no if utilizava o metodo obter_analise_lancamento_edicao_pendente, e no
+        # else utilizava o mesmo código [inline])
+        from sme_ptrf_apps.despesas.services.fluxo_acerto import (
+            obter_analise_lancamento_edicao_pendente,
+        )
+        lancamento_analise = obter_analise_lancamento_edicao_pendente(despesa)
+        if not lancamento_analise:
+            return
 
         AnaliseLancamentoPrestacaoContaService.marcar_lancamento_como_atualizado(
             lancamento_analise
@@ -587,16 +595,17 @@ class DespesaService:
         )
 
     @staticmethod
-    def _marcar_lancamento_como_excluido(despesa: Despesa):
+    def _marcar_lancamento_como_excluido(despesa: Despesa, pipeline_ativa=False):
         """
         Com flag despesas-pipeline: marca o lançamento como excluído quando
         existir solicitação pendente de exclusão em PC devolvida.
         Deve ser chamado antes do destroy/inativação da despesa.
-        """
-        from waffle import get_waffle_flag_model
 
-        flags = get_waffle_flag_model()
-        pipeline_ativa = flags.objects.filter(name='despesas-pipeline', everyone=True).exists()
+        legado chama marcar_lancamento_como_excluido() via HTTP no frontend via
+        POST /api/analises-lancamento-prestacao-conta/{uuid}/marcar-lancamento-excluido
+        fora do fluxo. Por isso, quando a flag estiver ativa, o método é chamado aqui no backend,
+        antes do destroy/inativação da despesa.
+        """
         if not pipeline_ativa:
             return
 

--- a/sme_ptrf_apps/despesas/tests/tests_api_tipos_custeio/test_tipo_custeio_viewset.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_tipos_custeio/test_tipo_custeio_viewset.py
@@ -1,7 +1,12 @@
 import pytest
 import json
+from unittest.mock import patch
 from rest_framework import status
 from sme_ptrf_apps.despesas.status_cadastro_completo import STATUS_COMPLETO
+from sme_ptrf_apps.despesas.services.tipo_custeio_vinculo_unidade_service import (
+    TipoCusteioVinculoUnidadeService,
+    UnidadeNaoEncontradaException,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -23,9 +28,8 @@ def test_api_tipos_custeio_vincular_com_sucesso(jwt_authenticated_client_sme, ti
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_api_tipos_custeio_vincular_com_erro(jwt_authenticated_client_sme, tipo_custeio_factory,  ):
-    tipo_custeio = tipo_custeio_factory()    
-    
+def test_api_tipos_custeio_vincular_com_erro(jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
 
     url = f'/api/tipos-custeio/{tipo_custeio.uuid}/vincular-unidades/'
 
@@ -39,6 +43,7 @@ def test_api_tipos_custeio_vincular_com_erro(jwt_authenticated_client_sme, tipo_
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {'mensagem': 'Erro ao vincular'}
+
 
 def test_api_tipos_custeio_desvincular_com_sucesso(jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
     tipo_custeio = tipo_custeio_factory()
@@ -57,13 +62,14 @@ def test_api_tipos_custeio_desvincular_com_sucesso(jwt_authenticated_client_sme,
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_api_tipos_custeio_desvincular_com_erro(jwt_authenticated_client_sme, tipo_custeio_factory, despesa_factory, rateio_despesa_factory):
+def test_api_tipos_custeio_desvincular_com_erro(
+        jwt_authenticated_client_sme, tipo_custeio_factory, despesa_factory, rateio_despesa_factory):
     tipo_custeio = tipo_custeio_factory()
     despesa = despesa_factory(status=STATUS_COMPLETO)
 
     rateio = rateio_despesa_factory(
         despesa=despesa,
-        tipo_custeio=tipo_custeio,       
+        tipo_custeio=tipo_custeio,
     )
 
     url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-unidades/'
@@ -77,4 +83,270 @@ def test_api_tipos_custeio_desvincular_com_erro(jwt_authenticated_client_sme, ti
     response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {'mensagem': "Não é possível desvincular pois a(s) unidade(s) possuem lançamentos deste tipo."}
+    assert response.json() == {
+        'mensagem': "Não é possível desvincular pois a(s) unidade(s) possuem lançamentos deste tipo."}
+
+
+def test_api_tipos_custeio_vincular_sem_unidades_retorna_400(jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/vincular-unidades/'
+    payload = {"unidade_uuids": []}
+
+    response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {'mensagem': 'Nenhuma unidade foi identificada para desvínculo.'}
+
+
+def test_api_tipos_custeio_vincular_unidade_nao_encontrada_retorna_404(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade = unidade_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/vincular-unidades/'
+    payload = {"unidade_uuids": [f"{unidade.uuid}"]}
+
+    with patch.object(
+            TipoCusteioVinculoUnidadeService, 'vincular_unidades',
+            side_effect=UnidadeNaoEncontradaException('Unidade não encontrada.')):
+        response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {'mensagem': 'Unidade não encontrada.'}
+
+
+def test_api_tipos_custeio_desvincular_sem_unidade_informada_retorna_400(
+        jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-unidades/'
+    payload = {"unidade_uuids": []}
+
+    response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {'erro': 'Nenhuma unidade informada.'}
+
+
+def test_api_tipos_custeio_desvincular_unidade_nao_encontrada_retorna_404(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade = unidade_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-unidades/'
+    payload = {"unidade_uuids": [f"{unidade.uuid}"]}
+
+    with patch.object(
+            TipoCusteioVinculoUnidadeService, 'desvincular_unidades',
+            side_effect=UnidadeNaoEncontradaException('Unidade não encontrada.')):
+        response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {'mensagem': 'Unidade não encontrada.'}
+
+
+def test_api_tipos_custeio_desvincular_com_uuid_invalido_retorna_erro_generico(
+        jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-unidades/'
+    payload = {"unidade_uuids": ["123"]}
+
+    response = jwt_authenticated_client_sme.post(url, data=json.dumps(payload), content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {'mensagem': 'Erro ao desvincular'}
+
+
+def test_api_tipos_custeio_destroy_protegido_por_despesas_vinculadas_retorna_400(
+        jwt_authenticated_client_d, tipo_custeio_factory, rateio_despesa_factory):
+    tipo_custeio = tipo_custeio_factory()
+    rateio_despesa_factory(tipo_custeio=tipo_custeio)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/'
+    response = jwt_authenticated_client_d.delete(url, content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        'erro': 'ProtectedError',
+        'mensagem': 'Esse tipo não pode ser excluído pois existem despesas cadastradas com esse tipo.'
+    }
+
+
+def test_api_tipos_custeio_vincular_todas_unidades_com_sucesso(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    tipo_custeio.unidades.add(unidade_factory())
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/vincular-todas-unidades/'
+    response = jwt_authenticated_client_sme.post(url, content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['sucesso'] is True
+    tipo_custeio.refresh_from_db()
+    assert tipo_custeio.unidades.count() == 0
+
+
+def test_api_tipos_custeio_vincular_todas_unidades_com_erro(jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/vincular-todas-unidades/'
+
+    with patch.object(TipoCusteioVinculoUnidadeService, 'vincular_todas_unidades', side_effect=Exception('boom')):
+        response = jwt_authenticated_client_sme.post(url, content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {'mensagem': 'Erro ao vincular todas as unidades.'}
+
+
+def test_api_tipos_custeio_desvincular_todas_unidades_com_sucesso(
+        jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-todas-unidades/'
+    response = jwt_authenticated_client_sme.post(url, content_type='application/json')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['sucesso'] is True
+
+
+def test_api_tipos_custeio_desvincular_todas_unidades_com_erro(jwt_authenticated_client_sme, tipo_custeio_factory):
+    tipo_custeio = tipo_custeio_factory()
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/desvincular-todas-unidades/'
+
+    with patch.object(
+            TipoCusteioVinculoUnidadeService, 'desvincular_todas_unidades', side_effect=Exception('boom')):
+        response = jwt_authenticated_client_sme.post(url, content_type='application/json')
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {'mensagem': 'Erro ao desvincular todas as unidades.'}
+
+
+def test_api_tipos_custeio_unidades_vinculadas_lista_as_unidades_do_tipo_custeio(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_vinculada = unidade_factory()
+    unidade_nao_vinculada = unidade_factory()
+    tipo_custeio.unidades.add(unidade_vinculada)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-vinculadas/'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    uuids_retornados = {item['uuid'] for item in result['results']}
+    assert uuids_retornados == {str(unidade_vinculada.uuid)}
+    assert str(unidade_nao_vinculada.uuid) not in uuids_retornados
+
+
+def test_api_tipos_custeio_unidades_vinculadas_filtra_por_dre(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory, dre_factory):
+    dre_alvo = dre_factory()
+    outra_dre = dre_factory()
+    tipo_custeio = tipo_custeio_factory()
+    unidade_da_dre_alvo = unidade_factory(dre=dre_alvo)
+    unidade_de_outra_dre = unidade_factory(dre=outra_dre)
+    tipo_custeio.unidades.add(unidade_da_dre_alvo, unidade_de_outra_dre)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-vinculadas/?dre={dre_alvo.uuid}'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert {item['uuid'] for item in result['results']} == {str(unidade_da_dre_alvo.uuid)}
+
+
+def test_api_tipos_custeio_unidades_vinculadas_filtra_por_tipo_unidade(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_emef = unidade_factory(tipo_unidade='EMEF')
+    unidade_ceu = unidade_factory(tipo_unidade='CEU')
+    tipo_custeio.unidades.add(unidade_emef, unidade_ceu)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-vinculadas/?tipo_unidade=EMEF'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert {item['uuid'] for item in result['results']} == {str(unidade_emef.uuid)}
+
+
+def test_api_tipos_custeio_unidades_vinculadas_filtra_por_nome_ou_codigo(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_buscada = unidade_factory(nome='Escola Municipal Buscada')
+    outra_unidade = unidade_factory(nome='Outra Escola')
+    tipo_custeio.unidades.add(unidade_buscada, outra_unidade)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-vinculadas/?nome_ou_codigo=Buscada'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert {item['uuid'] for item in result['results']} == {str(unidade_buscada.uuid)}
+
+
+def test_api_tipos_custeio_unidades_nao_vinculadas_lista_as_unidades_nao_vinculadas(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_vinculada = unidade_factory()
+    unidade_nao_vinculada = unidade_factory()
+    tipo_custeio.unidades.add(unidade_vinculada)
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-nao-vinculadas/'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    uuids_retornados = {item['uuid'] for item in result['results']}
+    assert str(unidade_nao_vinculada.uuid) in uuids_retornados
+    assert str(unidade_vinculada.uuid) not in uuids_retornados
+
+
+def test_api_tipos_custeio_unidades_nao_vinculadas_filtra_por_dre(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory, dre_factory):
+    tipo_custeio = tipo_custeio_factory()
+    dre_alvo = dre_factory()
+    unidade_da_dre_alvo = unidade_factory(dre=dre_alvo)
+    unidade_de_outra_dre = unidade_factory()
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-nao-vinculadas/?dre={dre_alvo.uuid}'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    uuids_retornados = {item['uuid'] for item in result['results']}
+    assert str(unidade_da_dre_alvo.uuid) in uuids_retornados
+    assert str(unidade_de_outra_dre.uuid) not in uuids_retornados
+
+
+def test_api_tipos_custeio_unidades_nao_vinculadas_filtra_por_tipo_unidade(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_emef = unidade_factory(tipo_unidade='EMEF')
+    unidade_ceu = unidade_factory(tipo_unidade='CEU')
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-nao-vinculadas/?tipo_unidade=EMEF'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    uuids_retornados = {item['uuid'] for item in result['results']}
+    assert str(unidade_emef.uuid) in uuids_retornados
+    assert str(unidade_ceu.uuid) not in uuids_retornados
+
+
+def test_api_tipos_custeio_unidades_nao_vinculadas_filtra_por_nome_ou_codigo(
+        jwt_authenticated_client_sme, tipo_custeio_factory, unidade_factory):
+    tipo_custeio = tipo_custeio_factory()
+    unidade_buscada = unidade_factory(nome='Escola Municipal Buscada')
+    outra_unidade = unidade_factory(nome='Outra Escola')
+
+    url = f'/api/tipos-custeio/{tipo_custeio.uuid}/unidades-nao-vinculadas/?nome_ou_codigo=Buscada'
+    response = jwt_authenticated_client_sme.get(url, content_type='application/json')
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    uuids_retornados = {item['uuid'] for item in result['results']}
+    assert str(unidade_buscada.uuid) in uuids_retornados
+    assert str(outra_unidade.uuid) not in uuids_retornados

--- a/sme_ptrf_apps/despesas/tests/tests_api_tipos_custeio/test_tipos_custeio_list.py
+++ b/sme_ptrf_apps/despesas/tests/tests_api_tipos_custeio/test_tipos_custeio_list.py
@@ -32,3 +32,32 @@ def test_api_tipos_custeio_list(jwt_authenticated_client_d, tipo_custeio_01, tip
 
     assert response.status_code == status.HTTP_200_OK
     assert result == resultado_esperado
+
+
+def test_api_tipos_custeio_list_filtra_por_nome(jwt_authenticated_client_d, tipo_custeio_01, tipo_custeio_02):
+    response = jwt_authenticated_client_d.get('/api/tipos-custeio/?nome=01', content_type='application/json')
+    result = json.loads(response.content)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [item['nome'] for item in result] == [tipo_custeio_01.nome]
+
+
+def test_api_tipos_custeio_list_filtra_por_unidade_vinculada(
+        jwt_authenticated_client_d, tipo_custeio_factory, unidade_factory):
+    unidade_alvo = unidade_factory()
+    outra_unidade = unidade_factory()
+
+    tipo_geral = tipo_custeio_factory(nome='Geral - sem restrição de unidade')
+    tipo_vinculado_ao_alvo = tipo_custeio_factory(nome='Vinculado à unidade alvo')
+    tipo_vinculado_ao_alvo.unidades.add(unidade_alvo)
+    tipo_de_outra_unidade = tipo_custeio_factory(nome='Vinculado a outra unidade')
+    tipo_de_outra_unidade.unidades.add(outra_unidade)
+
+    response = jwt_authenticated_client_d.get(
+        f'/api/tipos-custeio/?unidades__uuid={unidade_alvo.uuid}', content_type='application/json')
+    result = json.loads(response.content)
+
+    nomes_retornados = {item['nome'] for item in result}
+    assert response.status_code == status.HTTP_200_OK
+    assert nomes_retornados == {tipo_geral.nome, tipo_vinculado_ao_alvo.nome}
+    assert tipo_de_outra_unidade.nome not in nomes_retornados

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_carga_materiais_servicos_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_carga_materiais_servicos_service.py
@@ -1,0 +1,354 @@
+"""
+Testes para CargaMateriaisServicosService: parsing/validação de linhas do CSV,
+criação/atualização de EspecificacaoMaterialServico e cálculo do status do arquivo de carga.
+"""
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from sme_ptrf_apps.despesas.models import EspecificacaoMaterialServico
+from sme_ptrf_apps.despesas.services.carga_materiais_servicos_service import (
+    CargaMateriaisServicosException,
+    CargaMateriaisServicosService,
+)
+from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CUSTEIO
+
+from sme_ptrf_apps.core.choices.tipos_carga import CARGA_MATERIAIS_SERVICOS
+from sme_ptrf_apps.core.models.arquivo import (
+    DELIMITADOR_PONTO_VIRGULA,
+    DELIMITADOR_VIRGULA,
+    ERRO,
+    PROCESSADO_COM_ERRO,
+    SUCESSO,
+)
+
+pytestmark = pytest.mark.django_db
+
+CABECALHO_CAMPOS = list(CargaMateriaisServicosService.CABECALHOS.values())
+CABECALHO = ';'.join(CABECALHO_CAMPOS)
+
+
+def monta_linha(id_registro='', descricao='Papel A4', aplicacao='CUSTEIO', id_tipo_custeio='',
+                nome_tipo_custeio='', ativa='Sim', delimitador=';') -> str:
+    """Monta uma linha de CSV na ordem de colunas esperada pelo serviço de carga."""
+    campos = [str(id_registro), descricao, aplicacao, str(id_tipo_custeio), nome_tipo_custeio, ativa]
+    return delimitador.join(campos)
+
+
+def monta_csv(linhas: list, cabecalho: str = CABECALHO) -> bytes:
+    """Monta o conteúdo (bytes utf-8) de um arquivo CSV a partir de um cabeçalho e uma lista de linhas."""
+    conteudo = '\n'.join([cabecalho] + linhas)
+    return bytes(conteudo, encoding='utf-8')
+
+
+@pytest.fixture
+def service():
+    return CargaMateriaisServicosService()
+
+
+@pytest.fixture
+def tipo_custeio_material(tipo_custeio_factory):
+    return tipo_custeio_factory(nome='Material')
+
+
+@pytest.fixture
+def especificacao_existente(especificacao_material_servico_factory, tipo_custeio_material):
+    return especificacao_material_servico_factory(
+        descricao='Descrição antiga',
+        aplicacao_recurso=APLICACAO_CUSTEIO,
+        tipo_custeio=tipo_custeio_material,
+        ativa=False,
+    )
+
+
+class TestInicializaLogsEContadores:
+    def test_inicializa_log_reseta_estado(self, service):
+        service.logs = 'algo registrado antes'
+        service.importados = 5
+        service.erros = 2
+
+        service.inicializa_log()
+
+        assert service.logs == ''
+        assert service.importados == 0
+        assert service.erros == 0
+
+    def test_loga_erro_incrementa_contador_e_grava_mensagem(self, service):
+        service.inicializa_log()
+
+        service.loga_erro_carga_materiais_servicos('falha ao processar', linha=3)
+
+        assert service.erros == 1
+        assert 'Linha: 3 Erro: falha ao processar' in service.logs
+
+    def test_loga_sucesso_incrementa_contador_de_importados(self, service):
+        service.inicializa_log()
+
+        service.loga_sucesso_carga_materiais_servicos()
+
+        assert service.importados == 1
+
+
+class TestCarregaEValidaDadosTipoCusteio:
+    def test_linha_valida_custeio_retorna_dados_e_atualiza_linha_index(self, service, tipo_custeio_material):
+        linha = ['', 'Papel A4', APLICACAO_CUSTEIO, str(tipo_custeio_material.id), tipo_custeio_material.nome, 'Sim']
+
+        dados = service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=1)
+
+        assert dados == {
+            'id': None,
+            'descricao': 'Papel A4',
+            'aplicacao_recurso': APLICACAO_CUSTEIO,
+            'tipo_custeio_id': str(tipo_custeio_material.id),
+            'ativa': True,
+        }
+        assert service.linha_index == 1
+
+    def test_linha_valida_capital_nao_exige_tipo_custeio(self, service):
+        linha = ['5', 'Ar condicionado', APLICACAO_CAPITAL, '', '', 'Não']
+
+        dados = service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=2)
+
+        assert dados['id'] == 5
+        assert dados['tipo_custeio_id'] is None
+        assert dados['ativa'] is False
+
+    def test_tipo_custeio_inexistente_gera_excecao(self, service):
+        linha = ['', 'Papel A4', APLICACAO_CUSTEIO, '999999', 'Inexistente', 'Sim']
+
+        with pytest.raises(CargaMateriaisServicosException, match='id do tipo de custeio 999999 é inválido'):
+            service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=1)
+
+    def test_aplicacao_invalida_gera_excecao(self, service):
+        linha = ['', 'Papel A4', 'OUTRO', '', '', 'Sim']
+
+        with pytest.raises(CargaMateriaisServicosException, match='deveria ser no padrão string de CAPITAL ou CUSTEIO'):
+            service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=1)
+
+    def test_custeio_sem_id_tipo_custeio_gera_excecao(self, service):
+        linha = ['', 'Papel A4', APLICACAO_CUSTEIO, '', '', 'Sim']
+
+        with pytest.raises(CargaMateriaisServicosException, match='sem o campo ID preenchido'):
+            service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=1)
+
+    def test_id_tipo_custeio_nao_numerico_propaga_value_error(self, service):
+        """Documenta comportamento atual: o método só trata TipoCusteio.DoesNotExist, então um
+        ID não numérico propaga ValueError em vez de CargaMateriaisServicosException. A linha ainda
+        é reportada como erro porque processa_materiais_servicos captura Exception de forma ampla."""
+        linha = ['', 'Papel A4', APLICACAO_CUSTEIO, 'abc', 'Nome', 'Sim']
+
+        with pytest.raises(ValueError):
+            service.carrega_e_valida_dados_tipo_custeio(linha_conteudo=linha, linha_index=1)
+
+
+class TestCriaOuAtualizaEspecificacaoMaterialServico:
+    def test_cria_novo_registro_quando_id_nao_informado(self, service, tipo_custeio_material):
+        service.dados_materiais_servicos = {
+            'id': None,
+            'descricao': 'Novo material',
+            'aplicacao_recurso': APLICACAO_CUSTEIO,
+            'tipo_custeio_id': tipo_custeio_material.id,
+            'ativa': True,
+        }
+
+        service.cria_ou_atualiza_especificacao_material_servico()
+
+        especificacao = EspecificacaoMaterialServico.objects.get(descricao='Novo material')
+        assert especificacao.tipo_custeio_id == tipo_custeio_material.id
+        assert especificacao.ativa is True
+
+    def test_atualiza_registro_existente_quando_id_informado(self, service, especificacao_existente,
+                                                             tipo_custeio_material):
+        service.dados_materiais_servicos = {
+            'id': especificacao_existente.id,
+            'descricao': 'Descrição atualizada',
+            'aplicacao_recurso': APLICACAO_CUSTEIO,
+            'tipo_custeio_id': tipo_custeio_material.id,
+            'ativa': True,
+        }
+
+        service.cria_ou_atualiza_especificacao_material_servico()
+
+        especificacao_existente.refresh_from_db()
+        assert especificacao_existente.descricao == 'Descrição atualizada'
+        assert especificacao_existente.ativa is True
+        assert EspecificacaoMaterialServico.objects.count() == 1
+
+
+class TestAtualizaStatusArquivo:
+    def test_sucesso_quando_ha_importados_e_nenhum_erro(self, service, arquivo_factory):
+        arquivo = arquivo_factory(identificador='carga-status-sucesso')
+        service.importados = 2
+        service.erros = 0
+
+        service.atualiza_status_arquivo(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == SUCESSO
+        assert '2 linha(s) importada(s) com sucesso. 0 erro(s) reportado(s).' in arquivo.log
+
+    def test_processado_com_erro_quando_ha_importados_e_erros(self, service, arquivo_factory):
+        arquivo = arquivo_factory(identificador='carga-status-parcial')
+        service.importados = 1
+        service.erros = 1
+
+        service.atualiza_status_arquivo(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == PROCESSADO_COM_ERRO
+
+    def test_erro_quando_nenhuma_linha_importada(self, service, arquivo_factory):
+        arquivo = arquivo_factory(identificador='carga-status-erro')
+        service.importados = 0
+        service.erros = 3
+
+        service.atualiza_status_arquivo(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == ERRO
+
+
+class TestVerificaEstruturaCabecalho:
+    def test_cabecalho_correto_retorna_true(self):
+        assert CargaMateriaisServicosService.verifica_estrutura_cabecalho(CABECALHO_CAMPOS) is True
+
+    def test_cabecalho_incorreto_gera_excecao(self):
+        cabecalho_incorreto = ['Id'] + CABECALHO_CAMPOS[1:]
+
+        with pytest.raises(CargaMateriaisServicosException, match='Título da coluna 0 errado'):
+            CargaMateriaisServicosService.verifica_estrutura_cabecalho(cabecalho_incorreto)
+
+
+class TestProcessaMateriaisServicos:
+    def test_processa_com_sucesso_cria_e_atualiza_registros(self, service, arquivo_factory, tipo_custeio_material,
+                                                            especificacao_existente):
+        reader = [
+            CABECALHO_CAMPOS,
+            ['', 'Papel A4', APLICACAO_CUSTEIO, str(tipo_custeio_material.id), tipo_custeio_material.nome, 'Sim'],
+            [str(especificacao_existente.id), 'Descrição atualizada', APLICACAO_CUSTEIO,
+             str(tipo_custeio_material.id), tipo_custeio_material.nome, 'Sim'],
+        ]
+        arquivo = arquivo_factory(identificador='carga-processa-sucesso')
+
+        service.processa_materiais_servicos(reader=reader, arquivo=arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == SUCESSO
+        assert service.importados == 2
+        assert service.erros == 0
+        assert EspecificacaoMaterialServico.objects.filter(descricao='Papel A4').exists()
+        especificacao_existente.refresh_from_db()
+        assert especificacao_existente.descricao == 'Descrição atualizada'
+
+    def test_processa_linha_invalida_reporta_erro_e_nao_interrompe_as_demais(self, service, arquivo_factory,
+                                                                             tipo_custeio_material):
+        reader = [
+            CABECALHO_CAMPOS,
+            ['', 'Papel A4', 'OUTRO', '', '', 'Sim'],
+            ['', 'Caneta', APLICACAO_CUSTEIO, str(tipo_custeio_material.id), tipo_custeio_material.nome, 'Sim'],
+        ]
+        arquivo = arquivo_factory(identificador='carga-processa-linha-invalida')
+
+        service.processa_materiais_servicos(reader=reader, arquivo=arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == PROCESSADO_COM_ERRO
+        assert service.importados == 1
+        assert service.erros == 1
+        assert 'Linha: 1' in arquivo.log
+        assert EspecificacaoMaterialServico.objects.filter(descricao='Caneta').exists()
+        assert not EspecificacaoMaterialServico.objects.filter(descricao='Papel A4').exists()
+
+    def test_processa_cabecalho_incorreto_gera_status_erro_sem_processar_linhas(self, service, arquivo_factory):
+        reader = [
+            ['Id'] + CABECALHO_CAMPOS[1:],
+            ['', 'Papel A4', APLICACAO_CUSTEIO, '', '', 'Sim'],
+        ]
+        arquivo = arquivo_factory(identificador='carga-processa-cabecalho-incorreto')
+
+        service.processa_materiais_servicos(reader=reader, arquivo=arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == ERRO
+        assert service.importados == 0
+        assert 'Título da coluna 0 errado' in arquivo.log
+        assert EspecificacaoMaterialServico.objects.count() == 0
+
+
+class TestCarregaMateriaisServicos:
+    def test_delimitador_diferente_do_declarado_gera_erro_sem_processar(self, service, arquivo_factory,
+                                                                        tipo_custeio_material):
+        conteudo = SimpleUploadedFile(
+            'materiais_servicos.csv',
+            monta_csv([monta_linha(id_tipo_custeio=tipo_custeio_material.id,
+                                   nome_tipo_custeio=tipo_custeio_material.nome)]))
+        arquivo = arquivo_factory(
+            identificador='carga-delimitador-diferente',
+            conteudo=conteudo,
+            tipo_carga=CARGA_MATERIAIS_SERVICOS,
+            tipo_delimitador=DELIMITADOR_VIRGULA,
+        )
+
+        service.carrega_materiais_servicos(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == ERRO
+        assert 'Formato definido (DELIMITADOR_VIRGULA) é diferente do formato do arquivo csv ' \
+               '(DELIMITADOR_PONTO_VIRGULA)' in arquivo.log
+        assert EspecificacaoMaterialServico.objects.count() == 0
+
+    def test_delimitador_nao_suportado_gera_erro_generico(self, service, arquivo_factory):
+        conteudo = SimpleUploadedFile('materiais_servicos.csv', monta_csv([], cabecalho='|'.join(CABECALHO_CAMPOS)))
+        arquivo = arquivo_factory(
+            identificador='carga-delimitador-invalido',
+            conteudo=conteudo,
+            tipo_carga=CARGA_MATERIAIS_SERVICOS,
+            tipo_delimitador=DELIMITADOR_PONTO_VIRGULA,
+        )
+
+        service.carrega_materiais_servicos(arquivo)
+
+        arquivo.refresh_from_db()
+        assert 'Erro ao processar materiais e serviços' in arquivo.log
+        assert arquivo.status == ERRO
+
+    def test_carga_com_sucesso_cria_registros_e_seta_ultima_execucao(self, service, arquivo_factory,
+                                                                     tipo_custeio_material):
+        conteudo = SimpleUploadedFile(
+            'materiais_servicos.csv',
+            monta_csv([
+                monta_linha(descricao='Papel A4', aplicacao=APLICACAO_CUSTEIO,
+                            id_tipo_custeio=tipo_custeio_material.id, nome_tipo_custeio=tipo_custeio_material.nome),
+                monta_linha(descricao='Ar condicionado', aplicacao=APLICACAO_CAPITAL, ativa='Não'),
+            ]))
+        arquivo = arquivo_factory(
+            identificador='carga-sucesso',
+            conteudo=conteudo,
+            tipo_carga=CARGA_MATERIAIS_SERVICOS,
+            tipo_delimitador=DELIMITADOR_PONTO_VIRGULA,
+        )
+
+        service.carrega_materiais_servicos(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == SUCESSO
+        assert arquivo.ultima_execucao is not None
+        assert EspecificacaoMaterialServico.objects.filter(descricao='Papel A4', ativa=True).exists()
+        assert EspecificacaoMaterialServico.objects.filter(descricao='Ar condicionado', ativa=False).exists()
+
+    def test_carga_com_cabecalho_incorreto_gera_status_erro(self, service, arquivo_factory):
+        conteudo = SimpleUploadedFile(
+            'materiais_servicos.csv',
+            monta_csv([monta_linha()], cabecalho=';'.join(['Id'] + CABECALHO_CAMPOS[1:])))
+        arquivo = arquivo_factory(
+            identificador='carga-cabecalho-incorreto',
+            conteudo=conteudo,
+            tipo_carga=CARGA_MATERIAIS_SERVICOS,
+            tipo_delimitador=DELIMITADOR_PONTO_VIRGULA,
+        )
+
+        service.carrega_materiais_servicos(arquivo)
+
+        arquivo.refresh_from_db()
+        assert arquivo.status == ERRO
+        assert 'Título da coluna 0 errado' in arquivo.log
+        assert EspecificacaoMaterialServico.objects.count() == 0

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_despesa_service.py
@@ -967,10 +967,8 @@ def test_marca_lancamento_como_excluido_com_flag(
     analise_lancamento_prestacao_conta_factory,
     despesa_factory,
     associacao,
-    periodo_2020_2,
-    flag_factory,
+    periodo_2020_2
 ):
-    flag_factory.create(name="despesas-pipeline", everyone=True)
     despesa, analise_lancamento = criar_cenario_marcar_lancamento_como_excluido(
         prestacao_conta_factory,
         solicitacao_acerto_lancamento_factory,
@@ -984,7 +982,7 @@ def test_marca_lancamento_como_excluido_com_flag(
 
     assert not analise_lancamento.lancamento_excluido
 
-    DespesaService._marcar_lancamento_como_excluido(despesa)
+    DespesaService._marcar_lancamento_como_excluido(despesa, pipeline_ativa=True)
 
     analise_lancamento.refresh_from_db()
     assert analise_lancamento.lancamento_excluido
@@ -1015,4 +1013,3 @@ def test_nao_marca_lancamento_excluido_sem_flag(
 
     analise_lancamento.refresh_from_db()
     assert not analise_lancamento.lancamento_excluido
-

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_filtra_despesas_por_tags.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_filtra_despesas_por_tags.py
@@ -1,0 +1,170 @@
+"""Testes para filtra_despesas_por_tags — decide se uma Despesa/RateioDespesa deve ser
+excluída de uma listagem filtrada por tags de informação (ex.: Antecipado, Estornado)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from sme_ptrf_apps.despesas.services.filtra_despesas_por_tags import filtra_despesas_por_tags
+from ...models import Despesa
+
+pytestmark = pytest.mark.django_db
+
+
+def _item_neutro(**overrides) -> MagicMock:
+    """Duble de Despesa com todos os predicados de tag em False (nenhuma tag se aplica).
+
+    `conferido` inicia True para que TAG_NAO_CONCILIADA (que verifica `not conferido`)
+    também comece neutra. Use overrides para forçar um predicado específico como True
+    (ou `conferido=False`).
+    """
+    item = MagicMock()
+    item.teve_pagamento_antecipado.return_value = False
+    item.possui_estornos.return_value = False
+    item.possui_retencao_de_impostos.return_value = False
+    item.e_imposto_pago.return_value = False
+    item.e_imposto_nao_pago.return_value = False
+    item.tem_pagamento_com_recursos_proprios.return_value = False
+    item.tem_pagamentos_em_multiplas_contas.return_value = False
+    item.e_despesa_nao_reconhecida.return_value = False
+    item.e_despesa_sem_comprovacao_fiscal.return_value = False
+    item.conferido = True
+
+    for nome, valor in overrides.items():
+        if nome == "conferido":
+            item.conferido = valor
+        else:
+            getattr(item, nome).return_value = valor
+
+    return item
+
+
+class TestSemCorrespondencia:
+    def test_sem_filtro_retorna_true_mesmo_com_todos_os_predicados_verdadeiros(self):
+        item = _item_neutro(
+            teve_pagamento_antecipado=True,
+            possui_estornos=True,
+            possui_retencao_de_impostos=True,
+            e_imposto_pago=True,
+            e_imposto_nao_pago=True,
+            tem_pagamento_com_recursos_proprios=True,
+            tem_pagamentos_em_multiplas_contas=True,
+            e_despesa_nao_reconhecida=True,
+            e_despesa_sem_comprovacao_fiscal=True,
+            conferido=False,
+        )
+
+        assert filtra_despesas_por_tags(item, []) is True
+
+    def test_item_neutro_com_todas_as_tags_no_filtro_retorna_true(self):
+        """`conferido` não tem estado neutro (é sempre True ou False), então TAG_CONCILIADA e
+        TAG_NAO_CONCILIADA ficam de fora desta lista — são cobertas isoladamente abaixo."""
+        item = _item_neutro()
+        todas_as_tags = [
+            Despesa.TAG_ANTECIPADO["id"],
+            Despesa.TAG_ESTORNADO["id"],
+            Despesa.TAG_IMPOSTO["id"],
+            Despesa.TAG_IMPOSTO_PAGO["id"],
+            Despesa.TAG_IMPOSTO_A_SER_PAGO["id"],
+            Despesa.TAG_PARCIAL["id"],
+            Despesa.TAG_NAO_RECONHECIDA["id"],
+            Despesa.TAG_SEM_COMPROVACAO_FISCAL["id"],
+        ]
+
+        assert filtra_despesas_por_tags(item, todas_as_tags) is True
+
+    def test_predicado_verdadeiro_mas_tag_fora_do_filtro_nao_afeta_o_resultado(self):
+        item = _item_neutro(teve_pagamento_antecipado=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_ESTORNADO["id"]]) is True
+
+
+class TestCadaTagExcluiQuandoPredicadoVerdadeiro:
+    def test_tag_antecipado(self):
+        item = _item_neutro(teve_pagamento_antecipado=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_ANTECIPADO["id"]]) is False
+
+    def test_tag_estornado(self):
+        item = _item_neutro(possui_estornos=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_ESTORNADO["id"]]) is False
+
+    def test_tag_imposto(self):
+        item = _item_neutro(possui_retencao_de_impostos=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_IMPOSTO["id"]]) is False
+
+    def test_tag_imposto_pago(self):
+        item = _item_neutro(e_imposto_pago=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_IMPOSTO_PAGO["id"]]) is False
+
+    def test_tag_imposto_a_ser_pago(self):
+        item = _item_neutro(e_imposto_nao_pago=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_IMPOSTO_A_SER_PAGO["id"]]) is False
+
+    def test_tag_parcial_via_pagamento_com_recursos_proprios(self):
+        item = _item_neutro(tem_pagamento_com_recursos_proprios=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_PARCIAL["id"]]) is False
+
+    def test_tag_parcial_via_pagamentos_em_multiplas_contas(self):
+        item = _item_neutro(tem_pagamentos_em_multiplas_contas=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_PARCIAL["id"]]) is False
+
+    def test_tag_nao_reconhecida(self):
+        item = _item_neutro(e_despesa_nao_reconhecida=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_NAO_RECONHECIDA["id"]]) is False
+
+    def test_tag_sem_comprovacao_fiscal(self):
+        item = _item_neutro(e_despesa_sem_comprovacao_fiscal=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_SEM_COMPROVACAO_FISCAL["id"]]) is False
+
+    def test_tag_conciliada(self):
+        item = _item_neutro(conferido=True)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_CONCILIADA["id"]]) is False
+
+    def test_tag_nao_conciliada(self):
+        item = _item_neutro(conferido=False)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_NAO_CONCILIADA["id"]]) is False
+
+    def test_tag_no_filtro_mas_predicado_falso_retorna_true(self):
+        item = _item_neutro(teve_pagamento_antecipado=False)
+
+        assert filtra_despesas_por_tags(item, [Despesa.TAG_ANTECIPADO["id"]]) is True
+
+
+class TestCurtoCircuitoEComportamentoDeRateio:
+    def test_para_na_primeira_tag_que_corresponde_sem_avaliar_as_seguintes(self):
+        item = _item_neutro(teve_pagamento_antecipado=True)
+
+        resultado = filtra_despesas_por_tags(
+            item,
+            [Despesa.TAG_ANTECIPADO["id"], Despesa.TAG_ESTORNADO["id"]],
+        )
+
+        assert resultado is False
+        item.possui_estornos.assert_not_called()
+
+    def test_rateio_true_avalia_a_despesa_do_rateio_no_lugar_do_item(self):
+        despesa = _item_neutro(teve_pagamento_antecipado=True)
+        rateio = MagicMock(despesa=despesa)
+
+        resultado = filtra_despesas_por_tags(rateio, [Despesa.TAG_ANTECIPADO["id"]], rateio=True)
+
+        assert resultado is False
+        despesa.teve_pagamento_antecipado.assert_called_once()
+
+    def test_rateio_false_nao_acessa_o_atributo_despesa(self):
+        item = _item_neutro(teve_pagamento_antecipado=True)
+        item.despesa = None
+
+        resultado = filtra_despesas_por_tags(item, [Despesa.TAG_ANTECIPADO["id"]], rateio=False)
+
+        assert resultado is False

--- a/sme_ptrf_apps/despesas/tests/tests_services/test_fluxo_acerto.py
+++ b/sme_ptrf_apps/despesas/tests/tests_services/test_fluxo_acerto.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 from rest_framework.exceptions import ValidationError
+from waffle.testutils import override_flag
 
 from sme_ptrf_apps.core.models import (
     AnaliseLancamentoPrestacaoConta,
@@ -332,15 +333,14 @@ def test_viewset_context_nao_injeta_uuid_sem_flag(
     assert "uuid_solicitacao_acerto" not in context
 
 
+@override_flag('despesas-pipeline', active=True)
 def test_viewset_context_injeta_uuid_com_flag(
     solicitacao_acerto_documento_factory,
     recurso_factory,
-    flag_factory,
 ):
     """Com despesas-pipeline, uuid válido no body entra no context (fluxo 3)."""
     from sme_ptrf_apps.despesas.api.views.despesas_viewset import DespesasViewSet
 
-    flag_factory.create(name="despesas-pipeline", everyone=True)
     solicitacao = solicitacao_acerto_documento_factory()
     request = SimpleNamespace(
         data={"uuid_solicitacao_acerto": str(solicitacao.uuid)},

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_builder.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_builder.py
@@ -1,0 +1,232 @@
+"""Testes para DespesaContextBuilder — montagem do DespesaDtoContext a partir do
+validated_data do serializer, com fallback para a instância em updates."""
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from sme_ptrf_apps.despesas.validators.builder import DespesaContextBuilder
+
+pytestmark = pytest.mark.django_db
+
+
+def _instancia_despesa(**overrides) -> SimpleNamespace:
+    """Duble de uma instância de Despesa com todos os campos que o builder consulta via getattr."""
+    valores = dict(
+        valor_total=Decimal("200.00"),
+        valor_recursos_proprios=Decimal("20.00"),
+        data_transacao="2024-03-10",
+        data_documento="2024-03-09",
+        retem_imposto=True,
+        eh_despesa_reconhecida_pela_associacao=True,
+        numero_boletim_de_ocorrencia="BO-1",
+        eh_despesa_sem_comprovacao_fiscal=True,
+        tipo_documento="tipo-doc-instancia",
+        tipo_transacao="tipo-transacao-instancia",
+        numero_documento="999",
+        documento_transacao="doc-transacao-instancia",
+        cpf_cnpj_fornecedor="11.478.276/0001-04",
+        nome_fornecedor="Fornecedor da instância",
+        rateios=["rateio-instancia"],
+        despesas_impostos=["imposto-instancia"],
+        motivos_pagamento_antecipado=["motivo-instancia"],
+        outros_motivos_pagamento_antecipado="outro motivo da instância",
+        associacao="associacao-instancia",
+        valor_original=Decimal("150.00"),
+    )
+    valores.update(overrides)
+    return SimpleNamespace(**valores)
+
+
+class TestBuildCreate:
+    def test_build_create_sem_dados_aplica_defaults(self):
+        ctx = DespesaContextBuilder.build(validated_data={})
+
+        assert ctx.is_create is True
+        assert ctx.despesa_instance is None
+        assert ctx.valor_total == Decimal("0")
+        assert ctx.valor_recursos_proprios == Decimal("0")
+        assert ctx.valor_original is None
+        assert ctx.retem_imposto is False
+        assert ctx.eh_despesa_reconhecida_pela_associacao is True
+        assert ctx.numero_boletim_de_ocorrencia == ""
+        assert ctx.eh_despesa_sem_comprovacao_fiscal is False
+        assert ctx.tipo_documento is None
+        assert ctx.tipo_transacao is None
+        assert ctx.numero_documento == ""
+        assert ctx.documento_transacao == ""
+        assert ctx.cpf_cnpj_fornecedor == ""
+        assert ctx.nome_fornecedor == ""
+        assert ctx.rateios == []
+        assert ctx.rateios_raw == []
+        assert ctx.despesas_impostos == []
+        assert ctx.motivos_pagamento_antecipado == []
+        assert ctx.outros_motivos is None
+        assert ctx.associacao is None
+        assert ctx.recurso is None
+        assert ctx.uuid_solicitacao_acerto is None
+        assert ctx.is_acerto is False
+
+    def test_build_create_com_dados_completos_preenche_context(self):
+        recurso = object()
+        validated_data = {
+            "valor_total": 150.5,
+            "valor_recursos_proprios": 10,
+            "valor_original": "150.50",
+            "data_transacao": "2024-03-10",
+            "data_documento": "2024-03-09",
+            "retem_imposto": True,
+            "eh_despesa_reconhecida_pela_associacao": False,
+            "numero_boletim_de_ocorrencia": "BO-1",
+            "eh_despesa_sem_comprovacao_fiscal": True,
+            "tipo_documento": "tipo-doc",
+            "tipo_transacao": "tipo-transacao",
+            "numero_documento": "123456",
+            "documento_transacao": "doc-transacao",
+            "cpf_cnpj_fornecedor": "11.478.276/0001-04",
+            "nome_fornecedor": "Fornecedor SA",
+            "rateios": ["rateio-1"],
+            "despesas_impostos": ["imposto-1"],
+            "motivos_pagamento_antecipado": ["motivo-1"],
+            "outros_motivos_pagamento_antecipado": "outro motivo",
+            "associacao": "associacao-1",
+        }
+
+        ctx = DespesaContextBuilder.build(
+            validated_data=validated_data,
+            recurso=recurso,
+            initial_data={"rateios": ["uuid-1", "uuid-2"]},
+            uuid_solicitacao_acerto="uuid-solicitacao",
+        )
+
+        assert ctx.is_create is True
+        assert ctx.valor_total == Decimal("150.5")
+        assert ctx.valor_recursos_proprios == Decimal("10")
+        assert ctx.valor_original == Decimal("150.50")
+        assert ctx.retem_imposto is True
+        assert ctx.eh_despesa_reconhecida_pela_associacao is False
+        assert ctx.numero_boletim_de_ocorrencia == "BO-1"
+        assert ctx.eh_despesa_sem_comprovacao_fiscal is True
+        assert ctx.tipo_documento == "tipo-doc"
+        assert ctx.tipo_transacao == "tipo-transacao"
+        assert ctx.numero_documento == "123456"
+        assert ctx.documento_transacao == "doc-transacao"
+        assert ctx.cpf_cnpj_fornecedor == "11.478.276/0001-04"
+        assert ctx.nome_fornecedor == "Fornecedor SA"
+        assert ctx.rateios == ["rateio-1"]
+        assert ctx.rateios_raw == ["uuid-1", "uuid-2"]
+        assert ctx.despesas_impostos == ["imposto-1"]
+        assert ctx.motivos_pagamento_antecipado == ["motivo-1"]
+        assert ctx.outros_motivos == "outro motivo"
+        assert ctx.associacao == "associacao-1"
+        assert ctx.recurso is recurso
+        assert ctx.despesa_instance is None
+        assert ctx.uuid_solicitacao_acerto == "uuid-solicitacao"
+        assert ctx.is_acerto is True
+
+    def test_build_initial_data_none_resulta_em_rateios_raw_vazio(self):
+        ctx = DespesaContextBuilder.build(validated_data={}, initial_data=None)
+
+        assert ctx.rateios_raw == []
+
+
+class TestBuildUpdate:
+    def test_build_update_sem_validated_data_usa_a_instancia(self):
+        instancia = _instancia_despesa()
+
+        ctx = DespesaContextBuilder.build(validated_data={}, instance=instancia)
+
+        assert ctx.is_create is False
+        assert ctx.despesa_instance is instancia
+        assert ctx.valor_total == instancia.valor_total
+        assert ctx.valor_recursos_proprios == instancia.valor_recursos_proprios
+        assert ctx.valor_original == instancia.valor_original
+        assert ctx.retem_imposto is True
+        assert ctx.eh_despesa_reconhecida_pela_associacao is True
+        assert ctx.numero_boletim_de_ocorrencia == "BO-1"
+        assert ctx.eh_despesa_sem_comprovacao_fiscal is True
+        assert ctx.tipo_documento == "tipo-doc-instancia"
+        assert ctx.tipo_transacao == "tipo-transacao-instancia"
+        assert ctx.numero_documento == "999"
+        assert ctx.documento_transacao == "doc-transacao-instancia"
+        assert ctx.cpf_cnpj_fornecedor == "11.478.276/0001-04"
+        assert ctx.nome_fornecedor == "Fornecedor da instância"
+        assert ctx.rateios == ["rateio-instancia"]
+        assert ctx.despesas_impostos == ["imposto-instancia"]
+        assert ctx.motivos_pagamento_antecipado == ["motivo-instancia"]
+        assert ctx.outros_motivos == "outro motivo da instância"
+        assert ctx.associacao == "associacao-instancia"
+
+    def test_build_update_recurso_nao_vem_da_instancia(self):
+        """recurso é parâmetro externo (self.context no serializer), não é lido da instância."""
+        instancia = _instancia_despesa()
+
+        ctx = DespesaContextBuilder.build(validated_data={}, instance=instancia)
+
+        assert ctx.recurso is None
+
+    def test_build_validated_data_tem_precedencia_sobre_a_instancia(self):
+        instancia = _instancia_despesa(numero_documento="999")
+
+        ctx = DespesaContextBuilder.build(
+            validated_data={"numero_documento": "123456"},
+            instance=instancia,
+        )
+
+        assert ctx.numero_documento == "123456"
+
+    def test_build_chave_none_em_validated_data_nao_recai_para_a_instancia(self):
+        """Se a chave está presente em validated_data (mesmo com valor None), o builder não
+        consulta a instância.
+
+        Comportamento esperado: a edição de despesa é feita via PUT (validated_data sempre
+        completo), então um campo None em validated_data é uma limpeza intencional do valor,
+        não uma omissão que devesse herdar o dado da instância (PATCH)."""
+        instancia = _instancia_despesa(numero_documento="999")
+
+        ctx = DespesaContextBuilder.build(
+            validated_data={"numero_documento": None},
+            instance=instancia,
+        )
+
+        assert ctx.numero_documento == ""
+
+    def test_build_reconhecida_false_na_instancia_nao_e_sobrescrita_para_true(self):
+        instancia = _instancia_despesa(eh_despesa_reconhecida_pela_associacao=False)
+
+        ctx = DespesaContextBuilder.build(validated_data={}, instance=instancia)
+
+        assert ctx.eh_despesa_reconhecida_pela_associacao is False
+
+    def test_build_instancia_sem_valor_original_fica_none(self):
+        instancia = SimpleNamespace()
+
+        ctx = DespesaContextBuilder.build(validated_data={}, instance=instancia)
+
+        assert ctx.valor_original is None
+
+
+class TestBuildCamposComRegrasEspeciais:
+    def test_build_reconhecida_explicita_false_e_preservada(self):
+        ctx = DespesaContextBuilder.build(
+            validated_data={"eh_despesa_reconhecida_pela_associacao": False}
+        )
+
+        assert ctx.eh_despesa_reconhecida_pela_associacao is False
+
+    def test_build_retem_imposto_truthy_e_convertido_para_bool(self):
+        ctx = DespesaContextBuilder.build(validated_data={"retem_imposto": 1})
+
+        assert ctx.retem_imposto is True
+
+    def test_build_outros_motivos_mantem_string_vazia_explicita(self):
+        ctx = DespesaContextBuilder.build(
+            validated_data={"outros_motivos_pagamento_antecipado": ""}
+        )
+
+        assert ctx.outros_motivos == ""
+
+    def test_build_valor_original_ausente_fica_none(self):
+        ctx = DespesaContextBuilder.build(validated_data={"valor_total": 100})
+
+        assert ctx.valor_original is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_logger.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_logger.py
@@ -1,0 +1,223 @@
+"""Testes para ContextualLogger — LoggerAdapter que prefixa mensagens do pipeline de
+validação de despesas com o contexto (fluxo, is_create, is_acerto, despesa, associação, recurso)."""
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from sme_ptrf_apps.despesas.validators.logger import ContextualLogger, _DEFAULT_LOGGER
+from sme_ptrf_apps.despesas.tests.tests_validators.conftest import make_ctx
+
+pytestmark = pytest.mark.django_db
+
+
+class TestProcess:
+    def test_process_prefixa_mensagem_com_o_contexto_na_ordem_de_insercao(self):
+        log = ContextualLogger(logging.getLogger("teste"), {"flow": "Fluxo 1", "is_create": True})
+
+        mensagem, kwargs = log.process("Pipeline iniciado", {})
+
+        assert mensagem == "[flow=Fluxo 1 | is_create=True] Pipeline iniciado"
+        assert kwargs == {}
+
+    def test_process_com_contexto_vazio_nao_deixa_espaco_sobrando(self):
+        log = ContextualLogger(logging.getLogger("teste"), {})
+
+        mensagem, kwargs = log.process("mensagem sem contexto", {})
+
+        assert mensagem == "[] mensagem sem contexto"
+
+    def test_process_preserva_kwargs_recebidos(self):
+        log = ContextualLogger(logging.getLogger("teste"), {"flow": "Fluxo 1"})
+
+        _, kwargs = log.process("msg", {"exc_info": True})
+
+        assert kwargs == {"exc_info": True}
+
+
+class TestFromContextCamposMinimos:
+    def test_from_context_sem_dados_opcionais_traz_apenas_flow_is_create_is_acerto(self):
+        ctx = make_ctx(is_create=True)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1 — Criação")
+
+        assert log.extra["flow"] == "Fluxo 1 — Criação"
+        assert log.extra["is_create"] is True
+        assert log.extra["is_acerto"] is False
+        assert "despesa_id" not in log.extra
+        assert "despesa_uuid" not in log.extra
+        assert "recurso_id" not in log.extra
+        assert "solicitacao_acerto" not in log.extra
+        assert "associacao_id" not in log.extra
+        assert "associacao_uuid" not in log.extra
+
+    def test_from_context_usa_o_logger_padrao_quando_base_logger_nao_informado(self):
+        ctx = make_ctx()
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert log.logger is _DEFAULT_LOGGER
+
+    def test_from_context_usa_base_logger_informado(self):
+        ctx = make_ctx()
+        logger_customizado = logging.getLogger("sme_ptrf_apps.despesas.validators.teste")
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1", base_logger=logger_customizado)
+
+        assert log.logger is logger_customizado
+
+    def test_from_context_operation_id_concatena_os_campos_ja_presentes(self):
+        ctx = make_ctx(is_create=False)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 2 — Edição")
+
+        assert log.extra["operation_id"] == "flow=Fluxo 2 — Edição | is_create=False | is_acerto=False"
+
+
+class TestFromContextDespesaInstance:
+    def test_from_context_com_despesa_instance_adiciona_id_e_uuid(self):
+        despesa = SimpleNamespace(id=1, uuid="uuid-despesa", recurso=None)
+        ctx = make_ctx(is_create=False, despesa_instance=despesa)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 2")
+
+        assert log.extra["despesa_id"] == 1
+        assert log.extra["despesa_uuid"] == "uuid-despesa"
+
+
+class TestFromContextRecurso:
+    def test_from_context_usa_recurso_direto_do_contexto(self):
+        recurso = SimpleNamespace(id=42)
+        ctx = make_ctx(recurso=recurso)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert log.extra["recurso_id"] == 42
+
+    def test_from_context_sem_atributo_id_usa_str_do_recurso(self):
+        ctx = make_ctx(recurso="recurso-sem-id")
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert log.extra["recurso_id"] == "recurso-sem-id"
+
+    def test_from_context_sem_recurso_direto_usa_recurso_da_despesa_instance(self):
+        recurso_da_despesa = SimpleNamespace(id=7)
+        despesa = SimpleNamespace(id=1, uuid="uuid-despesa", recurso=recurso_da_despesa)
+        ctx = make_ctx(is_create=False, recurso=None, despesa_instance=despesa)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 2")
+
+        assert log.extra["recurso_id"] == 7
+
+    def test_from_context_sem_recurso_e_sem_despesa_instance_nao_adiciona_recurso_id(self):
+        ctx = make_ctx(recurso=None, despesa_instance=None)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert "recurso_id" not in log.extra
+
+
+class TestFromContextSolicitacaoAcerto:
+    def test_from_context_com_uuid_solicitacao_acerto_marca_solicitacao_acerto_e_is_acerto(self):
+        ctx = make_ctx(uuid_solicitacao_acerto="uuid-solicitacao")
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 3")
+
+        assert log.extra["solicitacao_acerto"] == "uuid-solicitacao"
+        assert log.extra["is_acerto"] is True
+
+    def test_from_context_sem_uuid_solicitacao_acerto_nao_adiciona_a_chave(self):
+        ctx = make_ctx(uuid_solicitacao_acerto=None)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert "solicitacao_acerto" not in log.extra
+
+
+class TestFromContextAssociacao:
+    def test_from_context_com_associacao_com_id_e_uuid(self):
+        associacao = SimpleNamespace(id=9, uuid="uuid-associacao")
+        ctx = make_ctx(associacao=associacao)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert log.extra["associacao_id"] == 9
+        assert log.extra["associacao_uuid"] == "uuid-associacao"
+
+    def test_from_context_com_associacao_sem_id_ou_uuid_usa_str_dela_mesma(self):
+        ctx = make_ctx(associacao="associacao-crua")
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert log.extra["associacao_id"] == "associacao-crua"
+        assert log.extra["associacao_uuid"] == "associacao-crua"
+
+    def test_from_context_sem_associacao_nao_adiciona_as_chaves(self):
+        ctx = make_ctx(associacao=None)
+
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        assert "associacao_id" not in log.extra
+        assert "associacao_uuid" not in log.extra
+
+
+class TestWithValidator:
+    def test_with_validator_adiciona_a_chave_validator_preservando_o_restante(self):
+        ctx = make_ctx(is_create=True)
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        log_validator = log.with_validator("RateiosObrigatoriosValidator")
+
+        assert log_validator.extra["validator"] == "RateiosObrigatoriosValidator"
+        assert log_validator.extra["flow"] == "Fluxo 1"
+        assert log_validator.extra["is_create"] is True
+
+    def test_with_validator_nao_muta_o_logger_original(self):
+        ctx = make_ctx()
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        log.with_validator("ValidatorX")
+
+        assert "validator" not in log.extra
+
+    def test_with_validator_reaproveita_o_mesmo_logger_interno(self):
+        ctx = make_ctx()
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        log_validator = log.with_validator("ValidatorX")
+
+        assert log_validator.logger is log.logger
+
+    def test_with_validator_retorna_uma_nova_instancia(self):
+        ctx = make_ctx()
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1")
+
+        log_validator = log.with_validator("ValidatorX")
+
+        assert log_validator is not log
+
+
+class TestIntegracaoComLogging:
+    def test_log_info_emite_mensagem_com_contexto_formatado(self, caplog):
+        ctx = make_ctx(is_create=True)
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1 — Criação")
+
+        with caplog.at_level(logging.INFO, logger="sme_ptrf_apps.despesas.validators"):
+            log.info("Pipeline iniciado")
+
+        assert len(caplog.records) == 1
+        mensagem = caplog.records[0].getMessage()
+        assert mensagem.startswith("[flow=Fluxo 1 — Criação | is_create=True | is_acerto=False")
+        assert mensagem.endswith("Pipeline iniciado")
+
+    def test_log_com_validator_inclui_o_validator_na_mensagem(self, caplog):
+        ctx = make_ctx(is_create=True)
+        log = ContextualLogger.from_context(ctx, flow_name="Fluxo 1").with_validator("MeuValidator")
+
+        with caplog.at_level(logging.DEBUG, logger="sme_ptrf_apps.despesas.validators"):
+            log.debug("Executando")
+
+        mensagem = caplog.records[0].getMessage()
+        assert "validator=MeuValidator" in mensagem
+        assert mensagem.endswith("Executando")

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r02_r06_rateios.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r02_r06_rateios.py
@@ -1,0 +1,140 @@
+"""Paridade REG-002 a REG-006: ValidacaoDespesaService.validar_rateios_serializer
+(legado, ainda importável) vs os validators correspondentes na pipeline.
+"""
+from decimal import Decimal
+
+import pytest
+from rest_framework import serializers
+
+from sme_ptrf_apps.despesas.services.validacao_despesa_service import ValidacaoDespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r02_rateios_obrigatorios import RateiosObrigatoriosValidator
+from sme_ptrf_apps.despesas.validators.r03_soma_valor_rateio import SomaValorRateioValidator
+from sme_ptrf_apps.despesas.validators.r04_soma_valor_original import SomaValorOriginalValidator
+from sme_ptrf_apps.despesas.validators.r05_quantidade_capital import QuantidadeCapitalValidator
+from sme_ptrf_apps.despesas.validators.r06_valor_original_capital import ValorOriginalCapitalValidator
+
+from .conftest import make_ctx
+
+CAPITAL = "CAPITAL"
+CUSTEIO = "CUSTEIO"
+
+_PIPELINE_VALIDATORS = [
+    RateiosObrigatoriosValidator(),
+    SomaValorRateioValidator(),
+    SomaValorOriginalValidator(),
+    QuantidadeCapitalValidator(),
+    ValorOriginalCapitalValidator(),
+]
+
+
+def _roda_legado(**kwargs):
+    try:
+        ValidacaoDespesaService.validar_rateios_serializer(**kwargs)
+    except serializers.ValidationError as exc:
+        return exc
+    return None
+
+
+def _roda_pipeline(**kwargs):
+    ctx = make_ctx(
+        valor_total=Decimal(str(kwargs.get("valor_total") or 0)),
+        valor_original=Decimal(str(kwargs.get("valor_original") or 0)),
+        valor_recursos_proprios=Decimal(str(kwargs.get("valor_recursos_proprios") or 0)),
+        retem_imposto=kwargs.get("retem_imposto", False),
+        rateios=kwargs.get("raw_rateios") or [],
+        despesas_impostos=kwargs.get("raw_despesas_impostos") or [],
+    )
+    try:
+        for validator in _PIPELINE_VALIDATORS:
+            ctx = validator.validate(ctx)
+    except DespesaValidationError as exc:
+        return exc
+    return None
+
+
+@pytest.mark.parametrize("kwargs", [
+    dict(valor_total=100, valor_original=100, raw_rateios=[]),
+    dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{"valor_rateio": 50, "valor_original": 100, "aplicacao_recurso": CUSTEIO}],
+    ),
+    dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{"valor_rateio": 100, "valor_original": 50, "aplicacao_recurso": CUSTEIO}],
+    ),
+    dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{
+            "valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CAPITAL,
+            "quantidade_itens_capital": 0, "valor_item_capital": 100,
+        }],
+    ),
+    dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{
+            "valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CAPITAL,
+            "quantidade_itens_capital": 2, "valor_item_capital": 30,
+        }],
+    ),
+])
+def test_paridade_casos_de_erro(kwargs):
+    """Cada variação de kwargs cobre um caso inválido diferente (sem rateio, soma de valor_rateio
+    divergente do total, soma de valor_original divergente, capital sem quantidade de itens,
+    capital com valor de item incompatível) — ambos os caminhos devem rejeitar.
+    """
+    erro_legado = _roda_legado(**kwargs)
+    erro_pipeline = _roda_pipeline(**kwargs)
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_custeio_valido():
+    """Rateio único em CUSTEIO com somas batendo deve ser aceito em ambos os caminhos."""
+    kwargs = dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{"valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CUSTEIO}],
+    )
+    assert _roda_legado(**kwargs) is None
+    assert _roda_pipeline(**kwargs) is None
+
+
+def test_paridade_capital_valido():
+    """Rateio único em CAPITAL com quantidade/valor de itens consistentes com o valor_rateio deve
+    ser aceito em ambos os caminhos.
+    """
+    kwargs = dict(
+        valor_total=100, valor_original=100,
+        raw_rateios=[{
+            "valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CAPITAL,
+            "quantidade_itens_capital": 2, "valor_item_capital": 50,
+        }],
+    )
+    assert _roda_legado(**kwargs) is None
+    assert _roda_pipeline(**kwargs) is None
+
+
+def test_paridade_com_imposto_retido_valido():
+    """Com retem_imposto=True, o valor do imposto deve compor a soma total junto do rateio; quando
+    a soma bate, ambos os caminhos aceitam.
+    """
+    kwargs = dict(
+        valor_total=150, valor_original=150, retem_imposto=True,
+        raw_rateios=[{"valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CUSTEIO}],
+        raw_despesas_impostos=[{"valor_total": 50, "valor_original": 50}],
+    )
+    assert _roda_legado(**kwargs) is None
+    assert _roda_pipeline(**kwargs) is None
+
+
+def test_paridade_com_imposto_retido_soma_invalida():
+    """Mesmo cenário anterior, mas com o valor do imposto divergente do necessário para fechar a
+    soma total — ambos os caminhos devem rejeitar.
+    """
+    kwargs = dict(
+        valor_total=150, valor_original=150, retem_imposto=True,
+        raw_rateios=[{"valor_rateio": 100, "valor_original": 100, "aplicacao_recurso": CUSTEIO}],
+        raw_despesas_impostos=[{"valor_total": 30, "valor_original": 30}],
+    )
+    assert _roda_legado(**kwargs) is not None
+    assert _roda_pipeline(**kwargs) is not None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r07_periodo_pc_devolvida.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r07_periodo_pc_devolvida.py
@@ -1,0 +1,89 @@
+"""Paridade REG-007: ValidacaoDespesaService.validar_periodo_e_contas (legado, ainda
+importável) vs PeriodoPcDevolvidaValidator, no fluxo de edição (despesa_instance presente).
+"""
+import datetime
+
+import pytest
+from rest_framework import serializers
+
+from sme_ptrf_apps.core.models import PrestacaoConta
+from sme_ptrf_apps.despesas.services.validacao_despesa_service import ValidacaoDespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r07_periodo_pc_devolvida import PeriodoPcDevolvidaValidator
+
+from .conftest import make_ctx
+
+
+def _roda_legado(despesa, nova_data_transacao):
+    try:
+        ValidacaoDespesaService.validar_periodo_e_contas(
+            instance=despesa,
+            data_transacao=nova_data_transacao,
+            rateios=[],
+            despesas_impostos=[],
+            recurso=despesa.recurso,
+        )
+    except serializers.ValidationError as exc:
+        return exc
+    return None
+
+
+def _roda_pipeline(despesa, nova_data_transacao):
+    ctx = make_ctx(despesa_instance=despesa, data_transacao=nova_data_transacao)
+    try:
+        PeriodoPcDevolvidaValidator().validate(ctx)
+    except DespesaValidationError as exc:
+        return exc
+    return None
+
+
+@pytest.mark.django_db
+def test_paridade_data_fora_do_periodo_da_devolucao(
+    despesa_factory, prestacao_conta_factory, associacao, periodo_2020_1, periodo_2020_2
+):
+    """Com PC devolvida no período 2020_2, mover a data_transacao para fora desse período (para o
+    período 2020_1) deve ser invalidado em ambos os caminhos.
+    """
+    despesa = despesa_factory(
+        associacao=associacao,
+        data_transacao=periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=3),
+    )
+    prestacao_conta_factory(status=PrestacaoConta.STATUS_DEVOLVIDA, periodo=periodo_2020_2, associacao=associacao)
+    nova_data = periodo_2020_1.data_inicio_realizacao_despesas + datetime.timedelta(days=3)
+
+    erro_legado = _roda_legado(despesa, nova_data)
+    erro_pipeline = _roda_pipeline(despesa, nova_data)
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_data_dentro_do_periodo_da_devolucao(despesa_factory, prestacao_conta_factory, associacao, periodo_2020_2):  # noqa: E501
+    """Manter a data_transacao dentro do mesmo período da PC devolvida deve ser aceito em ambos os caminhos."""
+    despesa = despesa_factory(
+        associacao=associacao,
+        data_transacao=periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=3),
+    )
+    prestacao_conta_factory(status=PrestacaoConta.STATUS_DEVOLVIDA, periodo=periodo_2020_2, associacao=associacao)
+    nova_data = periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=5)
+
+    erro_legado = _roda_legado(despesa, nova_data)
+    erro_pipeline = _roda_pipeline(despesa, nova_data)
+    assert erro_legado is None
+    assert erro_pipeline is None
+
+
+@pytest.mark.django_db
+def test_paridade_pc_nao_devolvida_nao_valida(despesa_factory, prestacao_conta_factory, associacao, periodo_2020_1, periodo_2020_2):  # noqa: E501
+    """Sem PC no status DEVOLVIDA a regra é ignorada, mesmo movendo a data para outro período."""
+    despesa = despesa_factory(
+        associacao=associacao,
+        data_transacao=periodo_2020_2.data_inicio_realizacao_despesas + datetime.timedelta(days=3),
+    )
+    prestacao_conta_factory(status=PrestacaoConta.STATUS_EM_ANALISE, periodo=periodo_2020_2, associacao=associacao)
+    nova_data = periodo_2020_1.data_inicio_realizacao_despesas + datetime.timedelta(days=3)
+
+    erro_legado = _roda_legado(despesa, nova_data)
+    erro_pipeline = _roda_pipeline(despesa, nova_data)
+    assert erro_legado is None
+    assert erro_pipeline is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r08_r09_contas.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r08_r09_contas.py
@@ -1,0 +1,155 @@
+"""Paridade REG-008/REG-009: ValidacaoDespesaService.validar_periodo_e_contas (legado, ainda
+importável) vs ContasRateiosValidator/ContasImpostosValidator/ContaAcaoRecursoValidator.
+"""
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from model_bakery import baker
+from rest_framework import serializers
+
+from sme_ptrf_apps.despesas.services.validacao_despesa_service import ValidacaoDespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r08_contas_impostos import ContasImpostosValidator
+from sme_ptrf_apps.despesas.validators.r08_contas_rateios import ContasRateiosValidator
+from sme_ptrf_apps.despesas.validators.r09_conta_acao_recurso import ContaAcaoRecursoValidator
+
+from .conftest import make_ctx
+
+_PIPELINE_VALIDATORS = [ContasRateiosValidator(), ContasImpostosValidator(), ContaAcaoRecursoValidator()]
+
+
+def _roda_legado(data_transacao, rateios, despesas_impostos, recurso):
+    try:
+        ValidacaoDespesaService.validar_periodo_e_contas(
+            instance=None,
+            data_transacao=data_transacao,
+            rateios=rateios,
+            despesas_impostos=despesas_impostos,
+            recurso=recurso,
+        )
+    except serializers.ValidationError as exc:
+        return exc
+    return None
+
+
+def _roda_pipeline(data_transacao, rateios, despesas_impostos):
+    ctx = make_ctx(data_transacao=data_transacao, rateios=rateios, despesas_impostos=despesas_impostos)
+    try:
+        for validator in _PIPELINE_VALIDATORS:
+            ctx = validator.validate(ctx)
+    except DespesaValidationError as exc:
+        return exc
+    return None
+
+
+@pytest.mark.django_db
+def test_paridade_conta_e_acao_recursos_diferentes(associacao):
+    """Rateio com conta e ação de recursos diferentes deve ser invalidado em ambos os caminhos (REG-009)."""
+    recurso_a = baker.make("Recurso")
+    recurso_b = baker.make("Recurso")
+    conta = baker.make("ContaAssociacao", associacao=associacao, tipo_conta__recurso=recurso_a)
+    acao = baker.make("AcaoAssociacao", associacao=associacao, acao__recurso=recurso_b)
+    rateios = [{"conta_associacao": conta, "acao_associacao": acao}]
+
+    erro_legado = _roda_legado(None, rateios, [], recurso_a)
+    erro_pipeline = _roda_pipeline(None, rateios, [])
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_conta_e_acao_mesmo_recurso(associacao):
+    """Rateio com conta e ação do mesmo recurso deve ser aceito em ambos os caminhos (REG-009)."""
+    recurso = baker.make("Recurso")
+    conta = baker.make("ContaAssociacao", associacao=associacao, tipo_conta__recurso=recurso)
+    acao = baker.make("AcaoAssociacao", associacao=associacao, acao__recurso=recurso)
+    rateios = [{"conta_associacao": conta, "acao_associacao": acao}]
+
+    erro_legado = _roda_legado(None, rateios, [], recurso)
+    erro_pipeline = _roda_pipeline(None, rateios, [])
+    assert erro_legado is None
+    assert erro_pipeline is None
+
+
+def test_paridade_conta_com_data_inicio_posterior_a_transacao():
+    """Conta do rateio com data_inicio posterior à data_transacao deve ser invalidada em ambos os
+    caminhos (REG-008).
+    """
+    conta = SimpleNamespace(data_inicio=datetime.date(2026, 6, 1), data_encerramento=None)
+    data_transacao = datetime.date(2026, 1, 1)
+    rateios = [{"conta_associacao": conta, "acao_associacao": None}]
+
+    erro_legado = _roda_legado(data_transacao, rateios, [], None)
+    erro_pipeline = _roda_pipeline(data_transacao, rateios, [])
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_conta_com_data_encerramento_anterior_a_transacao():
+    """Conta do rateio com data_encerramento anterior à data_transacao deve ser invalidada em ambos
+    os caminhos (REG-008).
+    """
+    conta = SimpleNamespace(
+        data_inicio=datetime.date(2020, 1, 1),
+        data_encerramento=datetime.date(2026, 1, 1),
+    )
+    data_transacao = datetime.date(2026, 6, 1)
+    rateios = [{"conta_associacao": conta, "acao_associacao": None}]
+
+    erro_legado = _roda_legado(data_transacao, rateios, [], None)
+    erro_pipeline = _roda_pipeline(data_transacao, rateios, [])
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_conta_do_imposto_fora_da_vigencia():
+    """Mesma checagem de vigência de conta, agora para a conta dentro de um imposto (despesas_impostos),
+    fora da vigência — deve ser invalidada em ambos os caminhos (REG-008).
+    """
+    conta = SimpleNamespace(data_inicio=datetime.date(2026, 6, 1), data_encerramento=None)
+    despesas_impostos = [{
+        "data_transacao": datetime.date(2026, 1, 1),
+        "rateios": [{"conta_associacao": conta}],
+    }]
+
+    erro_legado = _roda_legado(None, [], despesas_impostos, None)
+    erro_pipeline = _roda_pipeline(None, [], despesas_impostos)
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_conta_do_rateio_dentro_da_vigencia():
+    """Conta do rateio com data_transacao dentro do intervalo [data_inicio, data_encerramento] deve
+    ser aceita em ambos os caminhos (REG-008, caso de sucesso).
+    """
+    conta = SimpleNamespace(
+        data_inicio=datetime.date(2020, 1, 1),
+        data_encerramento=datetime.date(2027, 1, 1),
+    )
+    data_transacao = datetime.date(2026, 6, 1)
+    rateios = [{"conta_associacao": conta, "acao_associacao": None}]
+
+    erro_legado = _roda_legado(data_transacao, rateios, [], None)
+    erro_pipeline = _roda_pipeline(data_transacao, rateios, [])
+    assert erro_legado is None
+    assert erro_pipeline is None
+
+
+def test_paridade_conta_do_imposto_dentro_da_vigencia():
+    """Mesmo caso de sucesso anterior, agora para a conta dentro de um imposto (despesas_impostos)
+    (REG-008, caso de sucesso).
+    """
+    conta = SimpleNamespace(
+        data_inicio=datetime.date(2020, 1, 1),
+        data_encerramento=datetime.date(2027, 1, 1),
+    )
+    despesas_impostos = [{
+        "data_transacao": datetime.date(2026, 6, 1),
+        "rateios": [{"conta_associacao": conta}],
+    }]
+
+    erro_legado = _roda_legado(None, [], despesas_impostos, None)
+    erro_pipeline = _roda_pipeline(None, [], despesas_impostos)
+    assert erro_legado is None
+    assert erro_pipeline is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r10_datas_encerramento.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r10_datas_encerramento.py
@@ -1,0 +1,69 @@
+"""Paridade REG-010: DespesaService._validar_datas (legado) vs DatasEncerramentoValidator."""
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from rest_framework import serializers
+
+from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r10_datas_encerramento import DatasEncerramentoValidator
+
+from .conftest import make_ctx
+
+
+def _associacao(data_de_encerramento):
+    return SimpleNamespace(data_de_encerramento=data_de_encerramento)
+
+
+def _roda_legado(associacao, data_documento, data_transacao):
+    try:
+        DespesaService._validar_datas({
+            "associacao": associacao,
+            "data_documento": data_documento,
+            "data_transacao": data_transacao,
+        })
+    except serializers.ValidationError as exc:
+        return exc
+    return None
+
+
+def _roda_pipeline(associacao, data_documento, data_transacao):
+    ctx = make_ctx(associacao=associacao, data_documento=data_documento, data_transacao=data_transacao)
+    try:
+        DatasEncerramentoValidator().validate(ctx)
+    except DespesaValidationError as exc:
+        return exc
+    return None
+
+
+@pytest.mark.parametrize("campo_futuro", ["data_documento", "data_transacao"])
+def test_paridade_data_posterior_ao_encerramento(campo_futuro):
+    """data_documento ou data_transacao posterior à data_de_encerramento da associação deve ser
+    invalidada em ambos os caminhos.
+    """
+    encerramento = datetime.date(2026, 1, 31)
+    depois = datetime.date(2026, 2, 1)
+    associacao = _associacao(encerramento)
+    datas = {"data_documento": None, "data_transacao": None, campo_futuro: depois}
+
+    erro_legado = _roda_legado(associacao, datas["data_documento"], datas["data_transacao"])
+    erro_pipeline = _roda_pipeline(associacao, datas["data_documento"], datas["data_transacao"])
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_datas_dentro_do_prazo():
+    """Ambas as datas anteriores à data_de_encerramento devem ser aceitas em ambos os caminhos."""
+    associacao = _associacao(datetime.date(2026, 12, 31))
+    data = datetime.date(2026, 1, 15)
+    assert _roda_legado(associacao, data, data) is None
+    assert _roda_pipeline(associacao, data, data) is None
+
+
+def test_paridade_associacao_sem_data_de_encerramento():
+    """Associação sem data_de_encerramento definida ignora a regra, mesmo com datas futuras."""
+    associacao = _associacao(None)
+    data = datetime.date(2099, 1, 1)
+    assert _roda_legado(associacao, data, data) is None
+    assert _roda_pipeline(associacao, data, data) is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r11_pagamento_antecipado.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r11_pagamento_antecipado.py
@@ -1,0 +1,107 @@
+"""Paridade REG-011: DespesaService._processar_pagamento_antecipado (legado, pipeline_ativa=False)
+vs PagamentoAntecipadoValidator.
+"""
+import datetime
+
+from rest_framework import serializers
+
+from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r11_pagamento_antecipado import PagamentoAntecipadoValidator
+
+from .conftest import make_ctx
+
+
+def _roda_legado(motivos, outros, data_transacao, data_documento):
+    validated_data = {
+        "motivos_pagamento_antecipado": list(motivos),
+        "outros_motivos_pagamento_antecipado": outros,
+        "data_transacao": data_transacao,
+        "data_documento": data_documento,
+    }
+    try:
+        motivos_final, outros_final = DespesaService._processar_pagamento_antecipado(
+            validated_data, pipeline_ativa=False
+        )
+    except serializers.ValidationError as exc:
+        return exc, None, None
+    return None, motivos_final, outros_final
+
+
+def _roda_pipeline(motivos, outros, data_transacao, data_documento):
+    ctx = make_ctx(
+        motivos_pagamento_antecipado=list(motivos),
+        outros_motivos=outros,
+        data_transacao=data_transacao,
+        data_documento=data_documento,
+    )
+    validator = PagamentoAntecipadoValidator()
+    try:
+        validator.validate(ctx)
+    except DespesaValidationError as exc:
+        return exc, None, None
+    validator.apply(ctx)
+    return None, ctx.motivos_pagamento_antecipado, ctx.outros_motivos
+
+
+def test_paridade_antecipado_sem_motivo():
+    """Pagamento antecipado (data_transacao < data_documento) sem motivo informado deve ser
+    invalidado em ambos os caminhos.
+    """
+    dt = datetime.date(2026, 1, 5)
+    dd = datetime.date(2026, 1, 10)
+    erro_legado, _, _ = _roda_legado([], "", dt, dd)
+    erro_pipeline, _, _ = _roda_pipeline([], "", dt, dd)
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+def test_paridade_antecipado_com_motivo():
+    """Pagamento antecipado com motivo informado deve ser aceito e o motivo preservado em ambos
+    os caminhos.
+    """
+    dt = datetime.date(2026, 1, 5)
+    dd = datetime.date(2026, 1, 10)
+    erro_legado, motivos_legado, outros_legado = _roda_legado(["motivo-x"], "", dt, dd)
+    erro_pipeline, motivos_pipeline, outros_pipeline = _roda_pipeline(["motivo-x"], "", dt, dd)
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert motivos_legado == motivos_pipeline == ["motivo-x"]
+    assert outros_legado == outros_pipeline == ""
+
+
+def test_paridade_nao_antecipado_reseta_motivos():
+    """Quando não é pagamento antecipado (data_transacao >= data_documento), motivos e outros_motivos
+    devem ser resetados/ignorados em ambos os caminhos, mesmo que informados.
+    """
+    dt = datetime.date(2026, 1, 10)
+    dd = datetime.date(2026, 1, 5)
+    erro_legado, motivos_legado, outros_legado = _roda_legado(["motivo-x"], "texto qualquer", dt, dd)
+    erro_pipeline, motivos_pipeline, outros_pipeline = _roda_pipeline(["motivo-x"], "texto qualquer", dt, dd)
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert motivos_legado == motivos_pipeline == []
+    assert outros_legado == outros_pipeline == ""
+
+
+def test_paridade_datas_iguais_nao_e_antecipado():
+    """data_transacao igual a data_documento não caracteriza pagamento antecipado; motivos devem
+    ser descartados em ambos os caminhos.
+    """
+    data = datetime.date(2026, 1, 10)
+    erro_legado, motivos_legado, _ = _roda_legado(["motivo-x"], "", data, data)
+    erro_pipeline, motivos_pipeline, _ = _roda_pipeline(["motivo-x"], "", data, data)
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert motivos_legado == motivos_pipeline == []
+
+
+def test_paridade_sem_data_nao_valida():
+    """Sem data_transacao/data_documento definidas, a regra não é aplicada e os motivos informados
+    são mantidos como estão em ambos os caminhos.
+    """
+    erro_legado, motivos_legado, _ = _roda_legado(["motivo-x"], "", None, None)
+    erro_pipeline, motivos_pipeline, _ = _roda_pipeline(["motivo-x"], "", None, None)
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert motivos_legado == motivos_pipeline == ["motivo-x"]

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r12_impostos.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r12_impostos.py
@@ -1,0 +1,84 @@
+"""Paridade REG-012: checagem de rateio obrigatório em despesas_impostos, embutida em
+DespesaService._processar_impostos/_processar_impostos_update (legado, pipeline_ativa=False)
+vs ImpostosValidator.
+"""
+import copy
+
+import pytest
+from model_bakery import baker
+from rest_framework import serializers
+
+from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r12_impostos import ImpostosValidator
+
+from .conftest import make_ctx
+
+
+def _roda_pipeline(retem_imposto, despesas_impostos):
+    ctx = make_ctx(retem_imposto=retem_imposto, despesas_impostos=despesas_impostos)
+    try:
+        ImpostosValidator().validate(ctx)
+    except DespesaValidationError as exc:
+        return exc
+    return None
+
+
+@pytest.mark.django_db
+def test_paridade_create_sem_rateio_no_imposto(associacao):
+    """Imposto retido sem nenhum rateio deve ser invalidado tanto no create legado quanto na pipeline."""
+    despesa = baker.make("Despesa", associacao=associacao, retem_imposto=True)
+    despesas_impostos = [{"rateios": []}]
+
+    try:
+        DespesaService._processar_impostos(despesa, list(despesas_impostos), pipeline_ativa=False)
+        erro_legado = None
+    except serializers.ValidationError as exc:
+        erro_legado = exc
+
+    erro_pipeline = _roda_pipeline(True, despesas_impostos)
+
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_update_sem_rateio_no_imposto(associacao):
+    """Mesmo cenário de rateio ausente, agora no fluxo de update (_processar_impostos_update)."""
+    despesa = baker.make("Despesa", associacao=associacao, retem_imposto=True)
+    despesas_impostos = [{"rateios": []}]
+
+    try:
+        DespesaService._processar_impostos_update(despesa, list(despesas_impostos), pipeline_ativa=False)
+        erro_legado = None
+    except serializers.ValidationError as exc:
+        erro_legado = exc
+
+    erro_pipeline = _roda_pipeline(True, despesas_impostos)
+
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_sem_retencao_de_imposto_nao_valida(associacao):
+    """Sem retenção de imposto (retem_imposto=False) a regra é ignorada, mesmo com rateios vazios."""
+    despesa = baker.make("Despesa", associacao=associacao, retem_imposto=False)
+    despesas_impostos = [{"rateios": []}]
+
+    DespesaService._processar_impostos(despesa, list(despesas_impostos), pipeline_ativa=False)
+    erro_pipeline = _roda_pipeline(False, despesas_impostos)
+
+    assert erro_pipeline is None
+
+
+@pytest.mark.django_db
+def test_paridade_create_com_rateio_no_imposto(associacao):
+    """Caso de sucesso: imposto retido com rateio válido não deve gerar erro em nenhum caminho."""
+    despesa = baker.make("Despesa", associacao=associacao, retem_imposto=True)
+    despesas_impostos = [{"rateios": [{"valor_rateio": 100, "aplicacao_recurso": "CUSTEIO"}]}]
+
+    DespesaService._processar_impostos(despesa, copy.deepcopy(despesas_impostos), pipeline_ativa=False)
+    erro_pipeline = _roda_pipeline(True, copy.deepcopy(despesas_impostos))
+
+    assert erro_pipeline is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r13.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_paridade_pipeline_legado_r13.py
@@ -1,0 +1,155 @@
+"""Prova de conceito: compara o veredito e o estado final entre o caminho legado
+(DespesaService._atualizar_rateios, pipeline_ativa=False) e o caminho novo
+(MudancaAplicacaoValidator.validate()/apply()) para o mesmo cenário de entrada.
+"""
+import copy
+
+import pytest
+from model_bakery import baker
+
+from sme_ptrf_apps.despesas.models import RateioDespesa
+from sme_ptrf_apps.despesas.services.despesa_service import DespesaService
+from sme_ptrf_apps.despesas.validators.base import DespesaValidationError
+from sme_ptrf_apps.despesas.validators.r13_mudanca_aplicacao import MudancaAplicacaoValidator
+
+from .conftest import make_ctx
+
+CAPITAL = "CAPITAL"
+CUSTEIO = "CUSTEIO"
+
+
+def _cria_despesa_e_rateio(associacao, conta_associacao, acao_associacao, aplicacao_recurso, **extra_rateio):
+    despesa = baker.make("Despesa", associacao=associacao, eh_despesa_sem_comprovacao_fiscal=False)
+    rateio = baker.make(
+        "RateioDespesa",
+        aplicacao_recurso=aplicacao_recurso,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        despesa=despesa,
+        **extra_rateio,
+    )
+    return despesa, rateio
+
+
+def _roda_legado(despesa, payload):
+    try:
+        DespesaService._atualizar_rateios(despesa, [copy.deepcopy(payload)], pipeline_ativa=False)
+    except Exception as exc:
+        return exc, None
+    return None, RateioDespesa.objects.get(uuid=payload["uuid"])
+
+
+def _roda_pipeline(despesa, payload):
+    rateio = copy.deepcopy(payload)
+    ctx = make_ctx(
+        despesa_instance=despesa,
+        rateios=[rateio],
+        eh_despesa_sem_comprovacao_fiscal=despesa.eh_despesa_sem_comprovacao_fiscal,
+    )
+    validator = MudancaAplicacaoValidator()
+    try:
+        validator.validate(ctx)
+    except DespesaValidationError as exc:
+        return exc, None
+    validator.apply(ctx)
+    return None, rateio
+
+
+@pytest.mark.django_db
+def test_paridade_custeio_para_capital_sem_especificacao(associacao, conta_associacao, acao_associacao):
+    """Mudar de CUSTEIO para CAPITAL sem informar especificação de material/serviço deve ser invalidado
+    tanto no legado quanto na pipeline.
+    """
+    despesa_legado, rateio_legado = _cria_despesa_e_rateio(
+        associacao, conta_associacao, acao_associacao, CUSTEIO, especificacao_material_servico=None
+    )
+    despesa_pipeline, rateio_pipeline = _cria_despesa_e_rateio(
+        associacao, conta_associacao, acao_associacao, CUSTEIO, especificacao_material_servico=None
+    )
+    payload_base = {"aplicacao_recurso": CAPITAL, "especificacao_material_servico": None}
+
+    erro_legado, _ = _roda_legado(despesa_legado, {**payload_base, "uuid": str(rateio_legado.uuid)})
+    erro_pipeline, _ = _roda_pipeline(despesa_pipeline, {**payload_base, "uuid": str(rateio_pipeline.uuid)})
+
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_capital_para_custeio_valido(associacao, conta_associacao, acao_associacao):
+    """Mudar de CAPITAL para CUSTEIO com todos os dados obrigatórios deve passar em ambos os caminhos
+    e resetar os campos exclusivos de CAPITAL para os valores default.
+    """
+    tipo_custeio = baker.make("TipoCusteio")
+    especificacao_custeio = baker.make("EspecificacaoMaterialServico", aplicacao_recurso=CUSTEIO)
+
+    despesa_legado, rateio_legado = _cria_despesa_e_rateio(associacao, conta_associacao, acao_associacao, CAPITAL)
+    despesa_pipeline, rateio_pipeline = _cria_despesa_e_rateio(associacao, conta_associacao, acao_associacao, CAPITAL)
+    payload_base = {
+        "aplicacao_recurso": CUSTEIO,
+        "valor_rateio": 100,
+        "tipo_custeio": tipo_custeio,
+        "especificacao_material_servico": especificacao_custeio,
+        "numero_processo_incorporacao_capital": "ABC123",
+        "quantidade_itens_capital": 5,
+        "valor_item_capital": 50,
+        "nao_exibir_em_rel_bens": True,
+    }
+
+    erro_legado, rateio_final_legado = _roda_legado(despesa_legado, {**payload_base, "uuid": str(rateio_legado.uuid)})
+    erro_pipeline, rateio_final_pipeline = _roda_pipeline(
+        despesa_pipeline, {**payload_base, "uuid": str(rateio_pipeline.uuid)}
+    )
+
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert rateio_final_legado.numero_processo_incorporacao_capital == rateio_final_pipeline["numero_processo_incorporacao_capital"] == ""  # noqa: E501
+    assert rateio_final_legado.quantidade_itens_capital == rateio_final_pipeline["quantidade_itens_capital"] == 0
+    assert rateio_final_legado.valor_item_capital == rateio_final_pipeline["valor_item_capital"] == 0
+    assert rateio_final_legado.nao_exibir_em_rel_bens == rateio_final_pipeline["nao_exibir_em_rel_bens"] is False
+
+
+@pytest.mark.django_db
+def test_paridade_capital_para_custeio_sem_tipo_custeio(associacao, conta_associacao, acao_associacao):
+    """Mudar de CAPITAL para CUSTEIO sem informar tipo_custeio deve ser invalidado em ambos os caminhos."""
+    despesa_legado, rateio_legado = _cria_despesa_e_rateio(associacao, conta_associacao, acao_associacao, CAPITAL)
+    despesa_pipeline, rateio_pipeline = _cria_despesa_e_rateio(
+        associacao, conta_associacao, acao_associacao, CAPITAL
+    )
+    payload_base = {"aplicacao_recurso": CUSTEIO, "tipo_custeio": None, "especificacao_material_servico": None}
+
+    erro_legado, _ = _roda_legado(despesa_legado, {**payload_base, "uuid": str(rateio_legado.uuid)})
+    erro_pipeline, _ = _roda_pipeline(despesa_pipeline, {**payload_base, "uuid": str(rateio_pipeline.uuid)})
+
+    assert erro_legado is not None
+    assert erro_pipeline is not None
+
+
+@pytest.mark.django_db
+def test_paridade_custeio_para_capital_valido(associacao, conta_associacao, acao_associacao):
+    """Mudar de CUSTEIO para CAPITAL com especificação válida deve passar em ambos os caminhos e
+    resetar o campo tipo_custeio (exclusivo de CUSTEIO) para None/vazio.
+    """
+    especificacao_capital = baker.make("EspecificacaoMaterialServico", aplicacao_recurso=CAPITAL)
+
+    despesa_legado, rateio_legado = _cria_despesa_e_rateio(associacao, conta_associacao, acao_associacao, CUSTEIO)
+    despesa_pipeline, rateio_pipeline = _cria_despesa_e_rateio(
+        associacao, conta_associacao, acao_associacao, CUSTEIO
+    )
+    payload_base = {
+        "aplicacao_recurso": CAPITAL,
+        "valor_rateio": 100,
+        "especificacao_material_servico": especificacao_capital,
+        "quantidade_itens_capital": 2,
+        "valor_item_capital": 50,
+    }
+
+    erro_legado, rateio_final_legado = _roda_legado(despesa_legado, {**payload_base, "uuid": str(rateio_legado.uuid)})
+    erro_pipeline, rateio_final_pipeline = _roda_pipeline(
+        despesa_pipeline, {**payload_base, "uuid": str(rateio_pipeline.uuid)}
+    )
+
+    assert erro_legado is None
+    assert erro_pipeline is None
+    assert rateio_final_legado.tipo_custeio_id == rateio_final_pipeline.get("tipo_custeio") is None

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_pipeline.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_pipeline.py
@@ -1,0 +1,192 @@
+"""Testes para ValidatorPipeline — execução em duas fases (validate fail-fast, depois apply)
+de uma sequência de validators sobre um DespesaDtoContext."""
+import logging
+from dataclasses import replace
+
+import pytest
+
+from sme_ptrf_apps.despesas.validators.base import AbstractDespesaValidator, DespesaValidationError
+from sme_ptrf_apps.despesas.validators.pipeline import ValidatorPipeline
+from sme_ptrf_apps.despesas.tests.tests_validators.conftest import make_ctx
+
+pytestmark = pytest.mark.django_db
+
+
+class _ValidatorRegistraChamadas(AbstractDespesaValidator):
+    """Validator de teste que registra (nome, fase, ctx recebido) e opcionalmente muta o ctx."""
+
+    def __init__(self, nome, chamadas, muta_validate=None, muta_apply=None):
+        self.nome = nome
+        self.chamadas = chamadas
+        self.muta_validate = muta_validate
+        self.muta_apply = muta_apply
+
+    def validate(self, ctx):
+        self.chamadas.append((self.nome, "validate", ctx))
+        return self.muta_validate(ctx) if self.muta_validate else ctx
+
+    def apply(self, ctx):
+        self.chamadas.append((self.nome, "apply", ctx))
+        return self.muta_apply(ctx) if self.muta_apply else ctx
+
+
+class _ValidatorFalha(AbstractDespesaValidator):
+    """Validator de teste cujo validate() sempre levanta DespesaValidationError."""
+
+    def __init__(self, nome, chamadas, mensagem="erro de validação"):
+        self.nome = nome
+        self.chamadas = chamadas
+        self.mensagem = mensagem
+
+    def validate(self, ctx):
+        self.chamadas.append((self.nome, "validate", ctx))
+        raise DespesaValidationError(self.mensagem)
+
+
+class TestExecucaoSemErros:
+    def test_run_sem_validators_retorna_o_mesmo_ctx(self):
+        ctx = make_ctx()
+
+        resultado = ValidatorPipeline(validators=[]).run(ctx)
+
+        assert resultado is ctx
+
+    def test_run_flow_name_padrao_e_vazio(self):
+        resultado = ValidatorPipeline(validators=[]).run(make_ctx())
+
+        assert resultado is not None
+
+    def test_run_executa_toda_a_fase_1_antes_de_iniciar_a_fase_2(self):
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+        v2 = _ValidatorRegistraChamadas("V2", chamadas)
+
+        ValidatorPipeline(validators=[v1, v2], flow_name="Fluxo").run(make_ctx())
+
+        fases = [(nome, fase) for nome, fase, _ in chamadas]
+        assert fases == [
+            ("V1", "validate"),
+            ("V2", "validate"),
+            ("V1", "apply"),
+            ("V2", "apply"),
+        ]
+
+    def test_run_encadeia_o_ctx_retornado_por_validate_entre_validators(self):
+        chamadas = []
+
+        def muta(ctx):
+            return replace(ctx, numero_boletim_de_ocorrencia="alterado-por-v1")
+
+        v1 = _ValidatorRegistraChamadas("V1", chamadas, muta_validate=muta)
+        v2 = _ValidatorRegistraChamadas("V2", chamadas)
+        ctx_inicial = make_ctx(numero_boletim_de_ocorrencia="original")
+
+        ValidatorPipeline(validators=[v1, v2]).run(ctx_inicial)
+
+        _, _, ctx_recebido_por_v2 = chamadas[1]
+        assert ctx_recebido_por_v2.numero_boletim_de_ocorrencia == "alterado-por-v1"
+
+    def test_run_encadeia_o_ctx_retornado_por_apply_entre_validators(self):
+        chamadas = []
+
+        def muta(ctx):
+            return replace(ctx, numero_boletim_de_ocorrencia="alterado-no-apply-v1")
+
+        v1 = _ValidatorRegistraChamadas("V1", chamadas, muta_apply=muta)
+        v2 = _ValidatorRegistraChamadas("V2", chamadas)
+
+        ValidatorPipeline(validators=[v1, v2]).run(make_ctx(numero_boletim_de_ocorrencia="original"))
+
+        chamadas_apply_v2 = [c for c in chamadas if c[0] == "V2" and c[1] == "apply"]
+        assert chamadas_apply_v2[0][2].numero_boletim_de_ocorrencia == "alterado-no-apply-v1"
+
+    def test_run_retorna_o_ctx_resultante_do_ultimo_apply(self):
+        def muta_apply_v2(ctx):
+            return replace(ctx, numero_boletim_de_ocorrencia="final-v2")
+
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+        v2 = _ValidatorRegistraChamadas("V2", chamadas, muta_apply=muta_apply_v2)
+
+        resultado = ValidatorPipeline(validators=[v1, v2]).run(make_ctx())
+
+        assert resultado.numero_boletim_de_ocorrencia == "final-v2"
+
+    def test_run_so_aplica_apply_nos_validators_que_de_fato_executaram(self):
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+        v2 = _ValidatorRegistraChamadas("V2", chamadas)
+
+        ValidatorPipeline(validators=[v1, v2]).run(make_ctx())
+
+        nomes_com_apply = [nome for nome, fase, _ in chamadas if fase == "apply"]
+        assert nomes_com_apply == ["V1", "V2"]
+
+
+class TestFalhaNaFase1:
+    def test_run_interrompe_na_primeira_falha_e_propaga_a_excecao(self):
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+        v2 = _ValidatorFalha("V2", chamadas, mensagem="regra violada")
+        v3 = _ValidatorRegistraChamadas("V3", chamadas)
+
+        pipeline = ValidatorPipeline(validators=[v1, v2, v3])
+        ctx = make_ctx()
+
+        with pytest.raises(DespesaValidationError, match="regra violada"):
+            pipeline.run(ctx)
+
+        nomes_chamados = [nome for nome, _, _ in chamadas]
+        assert nomes_chamados == ["V1", "V2"]
+
+    def test_run_nao_chama_apply_de_nenhum_validator_quando_ha_falha(self):
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+        v2 = _ValidatorFalha("V2", chamadas)
+        pipeline = ValidatorPipeline(validators=[v1, v2])
+        ctx = make_ctx()
+
+        with pytest.raises(DespesaValidationError):
+            pipeline.run(ctx)
+
+        assert not any(fase == "apply" for _, fase, _ in chamadas)
+
+    def test_run_propaga_detail_dict_do_despesavalidationerror(self):
+        v1 = _ValidatorFalha("V1", chamadas=[], mensagem={"campo": "mensagem de erro"})
+        pipeline = ValidatorPipeline(validators=[v1])
+        ctx = make_ctx()
+
+        with pytest.raises(DespesaValidationError) as exc_info:
+            pipeline.run(ctx)
+
+        assert exc_info.value.detail == {"campo": "mensagem de erro"}
+
+
+class TestLogging:
+    def test_run_loga_inicio_execucao_de_validators_e_conclusao(self, caplog):
+        chamadas = []
+        v1 = _ValidatorRegistraChamadas("V1", chamadas)
+
+        with caplog.at_level(logging.DEBUG, logger="sme_ptrf_apps.despesas.validators"):
+            ValidatorPipeline(validators=[v1], flow_name="Fluxo X").run(make_ctx())
+
+        mensagens = [r.getMessage() for r in caplog.records]
+        assert any("Pipeline iniciado — 1 validators registrados" in m for m in mensagens)
+        assert any("flow=Fluxo X" in m for m in mensagens)
+        assert any("Fase 2: aplicando mutações de 1 validators" in m for m in mensagens)
+        assert any("Pipeline concluído com sucesso" in m for m in mensagens)
+        assert any("validator=_ValidatorRegistraChamadas" in m and "validate() concluído" in m for m in mensagens)
+        assert any("validator=_ValidatorRegistraChamadas" in m and "apply() concluído" in m for m in mensagens)
+
+    def test_run_loga_warning_na_falha_de_validacao_e_nao_loga_conclusao(self, caplog):
+        v1 = _ValidatorFalha("V1", chamadas=[], mensagem="falhou")
+        pipeline = ValidatorPipeline(validators=[v1])
+        ctx = make_ctx()
+
+        with caplog.at_level(logging.DEBUG, logger="sme_ptrf_apps.despesas.validators"):
+            with pytest.raises(DespesaValidationError):
+                pipeline.run(ctx)
+
+        mensagens = [r.getMessage() for r in caplog.records]
+        assert any("Falha na validação: falhou" in m for m in mensagens)
+        assert not any("Pipeline concluído com sucesso" in m for m in mensagens)

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_r13_mudanca_aplicacao.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_r13_mudanca_aplicacao.py
@@ -79,6 +79,7 @@ def test_valida_ok_capital_para_custeio_com_sem_exigencia(validator, associacao,
     ctx = make_ctx(
         rateios=[{"uuid": str(rateio_db.uuid), "aplicacao_recurso": CUSTEIO}],
         despesa_instance=despesa,
+        eh_despesa_sem_comprovacao_fiscal=True
     )
     result = validator.validate(ctx)
     assert result is ctx
@@ -226,3 +227,122 @@ def test_apply_custeio_para_capital_reseta_tipo_custeio(validator, associacao, c
     ctx = make_ctx(rateios=[rateio], despesa_instance=_despesa_normal())
     validator.apply(ctx)
     assert rateio["tipo_custeio"] is None
+
+
+@pytest.mark.django_db
+def test_valida_ok_imposto_sem_uuid(validator, associacao, conta_associacao, acao_associacao):
+    """Imposto novo (sem uuid, fluxo de criação) não tem estado anterior pra comparar — ignorado."""
+    imposto = {
+        "rateios": [{
+            "aplicacao_recurso": CUSTEIO,
+            "tipo_custeio": None,
+            "especificacao_material_servico": None,
+        }],
+    }
+    ctx = make_ctx(despesa_instance=None, despesas_impostos=[imposto])
+    result = validator.validate(ctx)
+    assert result is ctx
+
+
+@pytest.mark.django_db
+def test_valida_ok_imposto_uuid_nao_encontrado(validator):
+    """Imposto com uuid que não existe no banco é ignorado, sem erro."""
+    imposto = {"uuid": "00000000-0000-0000-0000-000000000000", "rateios": []}
+    ctx = make_ctx(despesa_instance=None, despesas_impostos=[imposto])
+    result = validator.validate(ctx)
+    assert result is ctx
+
+
+@pytest.mark.django_db
+def test_valida_erro_imposto_custeio_para_capital_sem_especificacao(
+    validator, associacao, conta_associacao, acao_associacao
+):
+    """Rateio de despesa de imposto também é validado — ctx.rateios (despesa principal) fica vazio."""
+    despesa_imposto_db = baker.make(
+        "Despesa",
+        associacao=associacao,
+        eh_despesa_sem_comprovacao_fiscal=False,
+    )
+    rateio_imposto_db = baker.make(
+        "RateioDespesa",
+        aplicacao_recurso=CUSTEIO,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+        especificacao_material_servico=None,
+    )
+    imposto = {
+        "uuid": str(despesa_imposto_db.uuid),
+        "rateios": [{
+            "uuid": str(rateio_imposto_db.uuid),
+            "aplicacao_recurso": CAPITAL,
+            "especificacao_material_servico": None,
+        }],
+    }
+    ctx = make_ctx(despesa_instance=None, rateios=[], despesas_impostos=[imposto])
+    with pytest.raises(DespesaValidationError) as exc_info:
+        validator.validate(ctx)
+    assert "mensagem" in exc_info.value.detail
+
+
+@pytest.mark.django_db
+def test_valida_ok_imposto_mudanca_valida(validator, associacao, conta_associacao, acao_associacao):
+    """Mudança de aplicação no rateio do imposto com especificação/tipo_custeio corretos não levanta erro."""
+    despesa_imposto_db = baker.make(
+        "Despesa",
+        associacao=associacao,
+        eh_despesa_sem_comprovacao_fiscal=False,
+    )
+    tipo_custeio = baker.make("TipoCusteio")
+    especificacao_custeio = baker.make("EspecificacaoMaterialServico", aplicacao_recurso=CUSTEIO)
+    rateio_imposto_db = baker.make(
+        "RateioDespesa",
+        aplicacao_recurso=CAPITAL,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+    )
+    imposto = {
+        "uuid": str(despesa_imposto_db.uuid),
+        "rateios": [{
+            "uuid": str(rateio_imposto_db.uuid),
+            "aplicacao_recurso": CUSTEIO,
+            "tipo_custeio": tipo_custeio,
+            "especificacao_material_servico": especificacao_custeio,
+        }],
+    }
+    ctx = make_ctx(despesa_instance=None, despesas_impostos=[imposto])
+    result = validator.validate(ctx)
+    assert result is ctx
+
+
+@pytest.mark.django_db
+def test_apply_imposto_reseta_campos(validator, associacao, conta_associacao, acao_associacao):
+    """apply() reseta campos incompatíveis dentro de despesas_impostos[i]['rateios'], não só em ctx.rateios."""
+    despesa_imposto_db = baker.make(
+        "Despesa",
+        associacao=associacao,
+        eh_despesa_sem_comprovacao_fiscal=False,
+    )
+    rateio_imposto_db = baker.make(
+        "RateioDespesa",
+        aplicacao_recurso=CAPITAL,
+        associacao=associacao,
+        conta_associacao=conta_associacao,
+        acao_associacao=acao_associacao,
+    )
+    rateio_imposto = {
+        "uuid": str(rateio_imposto_db.uuid),
+        "aplicacao_recurso": CUSTEIO,
+        "numero_processo_incorporacao_capital": "XYZ789",
+        "quantidade_itens_capital": 3,
+        "valor_item_capital": 10,
+        "nao_exibir_em_rel_bens": True,
+    }
+    imposto = {"uuid": str(despesa_imposto_db.uuid), "rateios": [rateio_imposto]}
+    ctx = make_ctx(despesa_instance=None, despesas_impostos=[imposto])
+    validator.apply(ctx)
+    assert rateio_imposto["numero_processo_incorporacao_capital"] == ""
+    assert rateio_imposto["quantidade_itens_capital"] == 0
+    assert rateio_imposto["valor_item_capital"] == 0
+    assert rateio_imposto["nao_exibir_em_rel_bens"] is False

--- a/sme_ptrf_apps/despesas/tests/tests_validators/test_r20_saldos.py
+++ b/sme_ptrf_apps/despesas/tests/tests_validators/test_r20_saldos.py
@@ -1,3 +1,6 @@
+from datetime import date
+from types import SimpleNamespace
+
 import pytest
 
 from sme_ptrf_apps.despesas.validators.r20_saldos import SaldosValidator
@@ -18,11 +21,78 @@ def test_valida_ok_sempre_passthrough(validator):
 
 
 def test_valida_ok_passthrough_com_associacao_e_data(validator):
-    from types import SimpleNamespace
-    from datetime import date
     ctx = make_ctx(
         associacao=SimpleNamespace(uuid="alguma-uuid"),
         data_transacao=date(2020, 3, 10),
     )
     result = validator.validate(ctx)
     assert result is ctx
+
+
+class TestGarantirUuids:
+    """A regra em si está desativada (validate() é passthrough), mas _garantir_uuids
+    é um utilitário público independente — testado isoladamente aqui."""
+
+    def test_lista_vazia_retorna_lista_vazia(self):
+        assert SaldosValidator._garantir_uuids([]) == []
+
+    def test_converte_instancias_de_model_para_uuid_string(self):
+        conta = SimpleNamespace(uuid="uuid-conta")
+        acao = SimpleNamespace(uuid="uuid-acao")
+        rateios = [{"conta_associacao": conta, "acao_associacao": acao, "valor_rateio": 100}]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert resultado == [
+            {"conta_associacao": "uuid-conta", "acao_associacao": "uuid-acao", "valor_rateio": 100}
+        ]
+
+    def test_mantem_valor_ja_string_inalterado(self):
+        rateios = [{"conta_associacao": "uuid-ja-string", "acao_associacao": "uuid-acao-string"}]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert resultado == [{"conta_associacao": "uuid-ja-string", "acao_associacao": "uuid-acao-string"}]
+
+    def test_ignora_campos_ausentes(self):
+        rateios = [{"valor_rateio": 50}]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert resultado == [{"valor_rateio": 50}]
+
+    def test_ignora_valor_none(self):
+        rateios = [{"conta_associacao": None, "acao_associacao": None}]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert resultado == [{"conta_associacao": None, "acao_associacao": None}]
+
+    def test_converte_apenas_o_campo_que_e_instancia_de_model(self):
+        conta = SimpleNamespace(uuid="uuid-conta")
+        rateios = [{"conta_associacao": conta, "acao_associacao": "uuid-acao-ja-string"}]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert resultado == [{"conta_associacao": "uuid-conta", "acao_associacao": "uuid-acao-ja-string"}]
+
+    def test_processa_multiplos_rateios_preservando_a_ordem(self):
+        conta_1 = SimpleNamespace(uuid="uuid-conta-1")
+        conta_2 = SimpleNamespace(uuid="uuid-conta-2")
+        rateios = [
+            {"conta_associacao": conta_1, "id": 1},
+            {"conta_associacao": conta_2, "id": 2},
+        ]
+
+        resultado = SaldosValidator._garantir_uuids(rateios)
+
+        assert [r["conta_associacao"] for r in resultado] == ["uuid-conta-1", "uuid-conta-2"]
+        assert [r["id"] for r in resultado] == [1, 2]
+
+    def test_nao_muta_o_dict_original(self):
+        conta = SimpleNamespace(uuid="uuid-conta")
+        rateio_original = {"conta_associacao": conta}
+
+        SaldosValidator._garantir_uuids([rateio_original])
+
+        assert rateio_original["conta_associacao"] is conta

--- a/sme_ptrf_apps/despesas/validators/r13_mudanca_aplicacao.py
+++ b/sme_ptrf_apps/despesas/validators/r13_mudanca_aplicacao.py
@@ -1,4 +1,4 @@
-from sme_ptrf_apps.despesas.models import RateioDespesa
+from sme_ptrf_apps.despesas.models import RateioDespesa, Despesa
 from sme_ptrf_apps.despesas.tipos_aplicacao_recurso import APLICACAO_CAPITAL, APLICACAO_CUSTEIO
 
 from .base import AbstractDespesaValidator, DespesaValidationError
@@ -12,6 +12,10 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
     Presente apenas em UPDATE_PIPELINE e UPDATE_ACERTO_PIPELINE (pipelines.py).
 
     Legado: despesa_service.py:234-355 (_atualizar_rateios)
+    O validate verificava somente ctx.rateios, e ignorava ctx.despesas_impostos
+
+    TODO: adotar estrutura de cache para rateios/impostos, considerando N requisição para cada item de rateios/impostos
+    viabilizar caches via DespesaDtoContext
     """
 
     def validate(self, ctx: DespesaDtoContext) -> DespesaDtoContext:
@@ -21,7 +25,8 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
         Levanta DespesaValidationError com detail={"mensagem": "..."} no primeiro rateio com violação.
         """
         if ctx.despesa_instance:
-            self._validar_mudancas_de_aplicacao(ctx.rateios, ctx.despesa_instance)
+            self._validar_mudancas_de_aplicacao(ctx.rateios, ctx.eh_despesa_sem_comprovacao_fiscal)
+        self._validar_mudancas_de_aplicacao_impostos(ctx.despesas_impostos)
         return ctx
 
     def apply(self, ctx: DespesaDtoContext) -> DespesaDtoContext:
@@ -30,10 +35,11 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
         Legado: despesa_service.py:300-313 (CAPITAL→CUSTEIO) e 343-350 (CUSTEIO→CAPITAL)
         """
         if ctx.despesa_instance:
-            self._resetar_campos_por_mudanca(ctx.rateios, ctx.despesa_instance)
+            self._resetar_campos_por_mudanca(ctx.rateios, ctx.eh_despesa_sem_comprovacao_fiscal)
+        self._resetar_campos_por_mudanca_impostos(ctx.despesas_impostos)
         return ctx
 
-    def _validar_mudancas_de_aplicacao(self, rateios: list, despesa) -> None:
+    def _validar_mudancas_de_aplicacao(self, rateios: list, eh_despesa_sem_comprovacao_fiscal: bool) -> None:
         for rateio in rateios:
             # despesa_service.py:257
             if "uuid" not in rateio:
@@ -47,7 +53,7 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
             # despesa_service.py:267-276
             aplicacao_anterior = rateio_atual.aplicacao_recurso
             nova_aplicacao = rateio.get("aplicacao_recurso")
-            sem_exigencia = self._sem_exigencia_especificacao(rateio, rateio_atual, despesa)
+            sem_exigencia = self._sem_exigencia_especificacao(rateio, rateio_atual, eh_despesa_sem_comprovacao_fiscal)
 
             # despesa_service.py:279-318
             if aplicacao_anterior == APLICACAO_CAPITAL and nova_aplicacao == APLICACAO_CUSTEIO:
@@ -57,7 +63,31 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
             elif aplicacao_anterior == APLICACAO_CUSTEIO and nova_aplicacao == APLICACAO_CAPITAL:
                 self._validar_custeio_para_capital(rateio, rateio_atual, sem_exigencia)
 
-    def _resetar_campos_por_mudanca(self, rateios: list, despesa) -> None:
+    def _validar_mudancas_de_aplicacao_impostos(self, despesas_impostos):
+        for imposto in despesas_impostos:
+            if not isinstance(imposto, dict) or not imposto.get("uuid"):
+                continue  # imposto novo (create) não tem "antes" pra comparar — nada a validar
+            imposto_instance = Despesa.objects.filter(uuid=imposto["uuid"]).first()
+            if not imposto_instance:
+                continue
+            eh_sem_comprovacao = imposto.get(
+                "eh_despesa_sem_comprovacao_fiscal", imposto_instance.eh_despesa_sem_comprovacao_fiscal
+            )
+            self._validar_mudancas_de_aplicacao(imposto.get("rateios", []), eh_sem_comprovacao)
+
+    def _resetar_campos_por_mudanca_impostos(self, despesas_impostos):
+        for imposto in despesas_impostos:
+            if not isinstance(imposto, dict) or not imposto.get("uuid"):
+                continue
+            imposto_instance = Despesa.objects.filter(uuid=imposto["uuid"]).first()
+            if not imposto_instance:
+                continue
+            eh_sem_comprovacao = imposto.get(
+                "eh_despesa_sem_comprovacao_fiscal", imposto_instance.eh_despesa_sem_comprovacao_fiscal
+            )
+            self._resetar_campos_por_mudanca(imposto.get("rateios", []), eh_sem_comprovacao)
+
+    def _resetar_campos_por_mudanca(self, rateios: list, eh_despesa_sem_comprovacao_fiscal: bool) -> None:
         for rateio in rateios:
             if "uuid" not in rateio:
                 continue
@@ -72,7 +102,7 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
             if aplicacao_anterior == nova_aplicacao:
                 continue
 
-            sem_exigencia = self._sem_exigencia_especificacao(rateio, rateio_atual, despesa)
+            sem_exigencia = self._sem_exigencia_especificacao(rateio, rateio_atual, eh_despesa_sem_comprovacao_fiscal)
 
             # despesa_service.py:300-313
             if aplicacao_anterior == APLICACAO_CAPITAL and nova_aplicacao == APLICACAO_CUSTEIO:
@@ -82,13 +112,16 @@ class MudancaAplicacaoValidator(AbstractDespesaValidator):
                 self._resetar_campos_custeio(rateio, sem_exigencia)
 
     @staticmethod
-    def _sem_exigencia_especificacao(rateio, rateio_atual, despesa) -> bool:
-        """despesa_service.py:271-276."""
+    def _sem_exigencia_especificacao(rateio, rateio_atual, eh_despesa_sem_comprovacao_fiscal: bool) -> bool:
+        """ despesa_service.py:271-276. eh_despesa_sem_comprovacao_fiscal já vem resolvido pelo chamador
+            (ctx.eh_despesa_sem_comprovacao_fiscal pra despesa principal, ou o valor submetido no próprio
+            imposto com fallback pro banco)
+        """
         saida_recurso_externo = rateio.get(
             "saida_de_recurso_externo",
             rateio_atual.saida_de_recurso_externo,
         )
-        return despesa.eh_despesa_sem_comprovacao_fiscal or saida_recurso_externo
+        return eh_despesa_sem_comprovacao_fiscal or saida_recurso_externo
 
     @staticmethod
     def _validar_capital_para_custeio(rateio: dict, sem_exigencia: bool) -> None:

--- a/sme_ptrf_apps/paa/tests/paa/test_retificacao_acao_inativada_apos_uso.py
+++ b/sme_ptrf_apps/paa/tests/paa/test_retificacao_acao_inativada_apos_uso.py
@@ -1,0 +1,171 @@
+"""
+Testes de integração: Ação PTRF utilizada em uma versão anterior do PAA e
+inativada (exibir_paa=False) antes de uma retificação.
+
+Regra de negócio (Ref. história 152458 / paas_acoes_conclusao):
+Quando o PAA é concluído (status GERADO), as Ações PTRF disponíveis naquele momento
+são "congeladas" em `Paa.acoes_conclusao` (ver `RegistrarAcoesPtrfConclusaoPaaService`).
+Se, depois disso, a Ação for inativada (campo `exibir_paa=False` em `core.Acao`), ela deixa
+de aparecer nas telas correntes do PAA (ex.: nova elaboração), mas deve continuar sendo
+listada durante uma retificação do PAA que já a utilizou, pois já foi usada em uma versão
+anterior (`AcoesPaaService.obter_ptrf`, condição `Q(acao__in=acoes_conclusao)`).
+
+Este teste simula o fluxo ponta a ponta:
+1. PAA em elaboração com uma Receita Prevista de R$1000,00 para a Ação "PTRF Básico";
+2. PAA é concluído (GERADO) e o histórico de ações da conclusão é registrado;
+3. A Ação "PTRF Básico" é inativada (exibir_paa=False);
+4. O PAA entra em retificação;
+5. A Ação e a receita de R$1000,00 devem continuar disponíveis/listadas.
+"""
+from decimal import Decimal
+
+import pytest
+
+from sme_ptrf_apps.paa.services.acoes_paa_service import (
+    AcoesPaaService,
+    AcoesReceitasPrevistasPaaService,
+)
+from sme_ptrf_apps.paa.services.paa_service import PaaService
+from sme_ptrf_apps.paa.services.registrar_acoes_conclusao_paa_service import (
+    RegistrarAcoesPtrfConclusaoPaaService,
+)
+
+
+@pytest.fixture
+def flag_paa_retificacao(flag_factory):
+    """Flag 'paa-retificacao' ativa para todos (necessária para o merge com acoes_conclusao)."""
+    return flag_factory.create(name='paa-retificacao', everyone=True)
+
+
+@pytest.fixture
+def acao_ptrf_basico(acao_factory):
+    """Ação PTRF Básico: recurso legado (padrão da factory) e exibir_paa=True."""
+    return acao_factory.create(nome='PTRF Básico', exibir_paa=True)
+
+
+@pytest.fixture
+def acao_associacao_ptrf_basico(acao_associacao_factory, paa, acao_ptrf_basico):
+    """Vínculo ativo da Ação 'PTRF Básico' com a Associação do PAA."""
+    return acao_associacao_factory.create(associacao=paa.associacao, acao=acao_ptrf_basico)
+
+
+@pytest.fixture
+def receita_1000_ptrf_basico(receita_prevista_paa_factory, paa, acao_associacao_ptrf_basico):
+    """Receita prevista de R$1000,00 (custeio) para a Ação 'PTRF Básico'."""
+    return receita_prevista_paa_factory.create(
+        paa=paa,
+        acao_associacao=acao_associacao_ptrf_basico,
+        previsao_valor_custeio=Decimal('1000.00'),
+        previsao_valor_capital=Decimal('0.00'),
+        previsao_valor_livre=Decimal('0.00'),
+    )
+
+
+@pytest.mark.django_db
+class TestAcaoInativadaAposUsoContinuaDisponivelNaRetificacao:
+
+    def _concluir_e_registrar_historico(self, paa):
+        """
+        Simula a conclusão da 1ª versão do PAA: status GERADO + registro das Ações
+        disponíveis naquele momento em `acoes_conclusao`.
+
+        Usa `RegistrarAcoesPtrfConclusaoPaaService` diretamente (em vez de
+        `PaaService.registra_historico_acoes`) para manter o teste isolado do
+        congelamento de saldo, que depende de um `Periodo` legado vigente na data
+        atual e não é relevante para a regra sendo testada aqui.
+        """
+        PaaService.concluir_paa(paa)
+        quantidade = RegistrarAcoesPtrfConclusaoPaaService.registrar(paa)
+        return quantidade
+
+    def test_acao_utilizada_e_depois_inativada_continua_listada_na_retificacao(
+        self, paa, acao_associacao_ptrf_basico, receita_1000_ptrf_basico, flag_paa_retificacao
+    ):
+        """Ação usada na 1ª versão do PAA e depois inativada continua no obter_ptrf durante retificação."""
+        self._concluir_e_registrar_historico(paa)
+
+        # A ação foi registrada como "já utilizada" na conclusão do PAA
+        assert acao_associacao_ptrf_basico.acao in paa.acoes_conclusao.all()
+
+        # A Ação "PTRF Básico" é inativada após a geração da 1ª versão do PAA
+        acao = acao_associacao_ptrf_basico.acao
+        acao.exibir_paa = False
+        acao.save()
+
+        # PAA entra em retificação
+        paa.set_paa_status_em_retificacao()
+        assert paa.status_em_retificacao is True
+
+        resultado = AcoesPaaService(paa).obter_ptrf()
+
+        assert acao_associacao_ptrf_basico in resultado, (
+            "A Ação 'PTRF Básico' deveria continuar listada na retificação, "
+            "pois já foi utilizada na primeira geração do PAA."
+        )
+
+        receitas = paa.receitaprevistapaa_set.filter(acao_associacao=acao_associacao_ptrf_basico)
+        assert receitas.count() == 1
+        assert receitas.first().previsao_valor_custeio == Decimal('1000.00')
+
+    def test_acao_utilizada_e_inativada_aparece_serializada_com_receita_de_1000_na_retificacao(
+        self, paa, acao_associacao_ptrf_basico, receita_1000_ptrf_basico, flag_paa_retificacao
+    ):
+        """A serialização usada pela tela do PAA também deve manter a Ação e sua receita de R$1000."""
+        self._concluir_e_registrar_historico(paa)
+
+        acao = acao_associacao_ptrf_basico.acao
+        acao.exibir_paa = False
+        acao.save()
+
+        paa.set_paa_status_em_retificacao()
+
+        serializado = AcoesReceitasPrevistasPaaService(paa).serialized_ptrf_com_receitas_previstas()
+
+        acao_serializada = next(
+            (item for item in serializado if item['acao']['uuid'] == str(acao.uuid)), None
+        )
+        assert acao_serializada is not None, "Ação 'PTRF Básico' deveria continuar listada na retificação"
+
+        receitas_previstas = acao_serializada['receitas_previstas_paa']
+        assert len(receitas_previstas) == 1
+        assert Decimal(receitas_previstas[0]['previsao_valor_custeio']) == Decimal('1000.00')
+
+    def test_sem_flag_paa_retificacao_acao_inativada_nao_e_mais_listada(
+        self, paa, acao_associacao_ptrf_basico, receita_1000_ptrf_basico
+    ):
+        """
+        Sem a flag 'paa-retificacao' ativa, o merge com `acoes_conclusao` não é aplicado
+        (comportamento legado): uma ação inativada deixa de ser listada mesmo tendo sido
+        utilizada antes. Mantido aqui para deixar explícito que a regra depende da flag.
+        """
+        self._concluir_e_registrar_historico(paa)
+
+        acao = acao_associacao_ptrf_basico.acao
+        acao.exibir_paa = False
+        acao.save()
+
+        paa.set_paa_status_em_retificacao()
+
+        resultado = AcoesPaaService(paa).obter_ptrf()
+
+        assert acao_associacao_ptrf_basico not in resultado
+
+    def test_acao_nunca_utilizada_e_inativada_nao_aparece_na_retificacao(
+        self, paa, acao_factory, acao_associacao_factory, flag_paa_retificacao
+    ):
+        """
+        Contraponto: uma Ação inativada que nunca foi utilizada em uma versão anterior do
+        PAA (não está em `acoes_conclusao`) não deve aparecer. Garante que o merge feito em
+        `obter_ptrf` não libera indiscriminadamente todas as ações inativas durante a
+        retificação, apenas as que já haviam sido usadas.
+        """
+        acao_nao_utilizada = acao_factory.create(nome='Ação Nunca Usada', exibir_paa=False)
+        acao_associacao_nao_utilizada = acao_associacao_factory.create(
+            associacao=paa.associacao, acao=acao_nao_utilizada
+        )
+
+        paa.set_paa_status_em_retificacao()
+
+        resultado = AcoesPaaService(paa).obter_ptrf()
+
+        assert acao_associacao_nao_utilizada not in resultado


### PR DESCRIPTION

Esse PR:

- função para centralizar checagem de flag 'despesas-pipeline' ativa. (despesas_pipeline_ativa(request))
- prioriza pipeline e retorna validated_data(em validate()), no DespesaCreateSerializer, quando flag de pipeline está ativa (evita executar legado)
- ignora execução de validate_rateios, no DespesaCreateSerializer, quando flag é ativa (considera regras de pipeline)
- Considere rollback em caso de erros no destroy da Viewset de despesa quando há marcação de lançamento como excluído
- Propaga 'pipeline_ativa' para o DespesaService.create(), DespesaService.update() e DespesaService._marcar_lancamento_como_excluido()
- Ajustes de testes unitários
- Adiciona testes de paridade entre as novas regras e o legado
- Testes adicionais

História [AB#154079](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/154079)
