### PR TITLE
fix(143636): adiciona novo campo eh_portaria_publicada ao serializer

### DIFF
--- a/sme_ptrf_apps/dre/api/serializers/ata_parecer_tecnico_serializer.py
+++ b/sme_ptrf_apps/dre/api/serializers/ata_parecer_tecnico_serializer.py
@@ -47,6 +47,8 @@ class AtaParecerTecnicoSerializer(serializers.ModelSerializer):
 
     portaria_publicada = serializers.SerializerMethodField()
 
+    eh_portaria_publicada = serializers.SerializerMethodField()
+
 
     def get_hora_reuniao(self, obj):
         return obj.hora_reuniao.strftime('%H:%M')
@@ -72,6 +74,9 @@ class AtaParecerTecnicoSerializer(serializers.ModelSerializer):
     def get_portaria_publicada(self, obj):
         return obj.portaria_publicada()
 
+    def get_eh_portaria_publicada(self, obj):
+        return obj.eh_portaria_publicada()
+
     class Meta:
         model = AtaParecerTecnico
         fields = (
@@ -92,7 +97,8 @@ class AtaParecerTecnicoSerializer(serializers.ModelSerializer):
             'versao',
             'motivo_retificacao',
             'eh_retificacao',
-            'portaria_publicada'
+            'portaria_publicada',
+            'eh_portaria_publicada'
         )
 
 

--- a/sme_ptrf_apps/dre/models/ata_parecer_tecnico.py
+++ b/sme_ptrf_apps/dre/models/ata_parecer_tecnico.py
@@ -145,6 +145,8 @@ class AtaParecerTecnico(ModeloBase):
 
         return f"de {data_portaria}"
 
+    def eh_portaria_publicada(self) -> bool:
+        return self.criado_em.date() >= self.DATA_CORTE_PORTARIA
 
 
 @receiver(pre_save, sender=AtaParecerTecnico)

--- a/sme_ptrf_apps/dre/tests/tests_api_ata_parecer_tecnico/test_retrieve_ata_parecer_tecnico.py
+++ b/sme_ptrf_apps/dre/tests/tests_api_ata_parecer_tecnico/test_retrieve_ata_parecer_tecnico.py
@@ -41,6 +41,7 @@ def test_api_retrieve_ata_parecer_tecnico(jwt_authenticated_client_dre, ata_pare
         'hora_reuniao': '00:00',
         'data_portaria': None,
         'portaria_publicada': '',
+        'eh_portaria_publicada': False,
         'numero_portaria': None,
         'versao': 'PREVIA'
     }

--- a/sme_ptrf_apps/dre/tests/tests_ata_parecer_tecnico/test_ata_parecer_tecnico_model.py
+++ b/sme_ptrf_apps/dre/tests/tests_ata_parecer_tecnico/test_ata_parecer_tecnico_model.py
@@ -82,3 +82,14 @@ def test_portaria_publicada_sem_data_portaria(ata_parecer_tecnico_t1):
     ata_parecer_tecnico_t1.data_portaria = None
 
     assert ata_parecer_tecnico_t1.portaria_publicada() == ""
+
+def test_eh_portaria_publicada_anterior_data_corte(ata_parecer_tecnico_t1):
+    ata_parecer_tecnico_t1.DATA_CORTE_PORTARIA = date(2026, 8, 19)
+    ata_parecer_tecnico_t1.criado_em = timezone.make_aware(datetime(2026, 8, 18))
+    assert ata_parecer_tecnico_t1.eh_portaria_publicada() == False
+
+
+def test_eh_portaria_publicada_data_corte_ou_posterior(ata_parecer_tecnico_t1):
+    ata_parecer_tecnico_t1.DATA_CORTE_PORTARIA = date(2026, 8, 19)
+    ata_parecer_tecnico_t1.criado_em = timezone.make_aware(datetime(2026, 8, 19))
+    assert ata_parecer_tecnico_t1.eh_portaria_publicada()


### PR DESCRIPTION
# O que este PR faz

- inclui campo eh_portaria_publicada (bool) ao serializer AtaParecerTecnicoSerializer para verificação do frontend ao editar ata.
- testes unitários